### PR TITLE
Store memory usage in long instead of int

### DIFF
--- a/src/process_item.cpp
+++ b/src/process_item.cpp
@@ -6,7 +6,7 @@
 
 using namespace Utils;
 
-ProcessItem::ProcessItem(QPixmap processIcon, QString processName, QString dName, double processCpu, int processMemory, int processPid, QString processUser, char processState)
+ProcessItem::ProcessItem(QPixmap processIcon, QString processName, QString dName, double processCpu, long processMemory, int processPid, QString processUser, char processState)
 {
     iconPixmap = processIcon;
     name = processName;
@@ -204,7 +204,7 @@ double ProcessItem::getCPU() const
     return cpu;
 }
 
-int ProcessItem::getMemory() const
+long ProcessItem::getMemory() const
 {
     return memory;
 }
@@ -263,8 +263,8 @@ bool ProcessItem::sortByCPU(const ListItem *item1, const ListItem *item2, bool d
 
     // Sort item with memory if cpu is same.
     if (cpu1 == cpu2) {
-        int memory1 = static_cast<const ProcessItem*>(item1)->getMemory();
-        int memory2 = (static_cast<const ProcessItem*>(item2))->getMemory();
+        long memory1 = static_cast<const ProcessItem*>(item1)->getMemory();
+        long memory2 = (static_cast<const ProcessItem*>(item2))->getMemory();
 
         sortOrder = memory1 > memory2;
     }
@@ -279,8 +279,8 @@ bool ProcessItem::sortByCPU(const ListItem *item1, const ListItem *item2, bool d
 bool ProcessItem::sortByMemory(const ListItem *item1, const ListItem *item2, bool descendingSort)
 {
     // Init.
-    int memory1 = (static_cast<const ProcessItem*>(item1))->getMemory();
-    int memory2 = (static_cast<const ProcessItem*>(item2))->getMemory();
+    long memory1 = (static_cast<const ProcessItem*>(item1))->getMemory();
+    long memory2 = (static_cast<const ProcessItem*>(item2))->getMemory();
     bool sortOrder;
 
     // Sort item with cpu if memory is same.

--- a/src/process_item.h
+++ b/src/process_item.h
@@ -12,7 +12,7 @@ class ProcessItem : public ListItem
     Q_OBJECT
     
 public:
-    ProcessItem(QPixmap processIcon, QString processName, QString dName, double processCpu, int processMemory, int processPid, QString processUser, char processState);
+    ProcessItem(QPixmap processIcon, QString processName, QString dName, double processCpu, long processMemory, int processPid, QString processUser, char processState);
     
     bool sameAs(ListItem *item);
     void drawBackground(QRect rect, QPainter *painter, int index, bool isSelect);
@@ -36,7 +36,7 @@ public:
     QString getName() const;
     QString getDisplayName() const;
     double getCPU() const;
-    int getMemory() const;
+    long getMemory() const;
     int getPid() const;
     QString getUser() const;
     NetworkStatus getNetworkStatus() const;
@@ -45,7 +45,7 @@ public:
 private:
     double cpu;
     int iconSize;
-    int memory;
+    long memory;
     int pid;
     
     int padding;

--- a/src/status_monitor.cpp
+++ b/src/status_monitor.cpp
@@ -154,7 +154,7 @@ void StatusMonitor::updateStatus()
                     displayName = getDisplayNameFromName(name);
                 }
             }
-            int memory = ((&i.second)->resident - (&i.second)->share) * sysconf(_SC_PAGESIZE);
+            long memory = ((&i.second)->resident - (&i.second)->share) * sysconf(_SC_PAGESIZE);
             QPixmap icon = getProcessIconFromName(name, processIconCache);
             ProcessItem *item = new ProcessItem(icon, name, displayName, cpu / cpuNumber, memory, pid, user, (&i.second)->state);
             items << item;


### PR DESCRIPTION
This prevents single high-memory-usage application to be list as a
negative number.