### PR TITLE
Dependencies中的libprocps4-dev改为libprocps-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Thanks a lot for [Lily Rivers](https://github.com/VioletDarkKitty/system-monito
 
 ## Dependencies
 
-* sudo apt install libpcap-dev libncurses5-dev libprocps4-dev libxtst-dev
+* sudo apt install libpcap-dev libncurses5-dev libprocps-dev libxtst-dev
 
 ## Installation
 


### PR DESCRIPTION
因为deepin-system-monitor基于libprocps6运行（而系统的核心组件也依赖于这个组件），而开发编译使用的开发库是libprocps-dev，这里的libprocps-dev版本可比libprocps4-dev高，一旦安装libprocps4-dev就会卸载libprocps-dev包，尽管编译能够通过，但是编译生成的执行文件无法运行，报段错误异常。而且一旦安装libprocps4-dev，就会同时安装libprocps4，这样就会导致系统存在libprocps4、libprocps6两个版本，会导致已经存在的监视器出现无法获取系统后台数量和程序数量问题。