### PR TITLE
fix: build failure in Arch due to incompatible include path

### DIFF
--- a/deepin-system-monitor-main/gui/xwin_kill_preview_widget.h
+++ b/deepin-system-monitor-main/gui/xwin_kill_preview_widget.h
@@ -23,10 +23,10 @@
 #include "../config.h"
 #include <QWidget>
 //不再使用CMakeList开关宏的方式，改用全局变量运行时控制
-#include <KF5/KWayland/Client/clientmanagement.h>
-#include <KF5/KWayland/Client/registry.h>
-#include <KF5/KWayland/Client/connection_thread.h>
-#include <KF5/KWayland/Client/event_queue.h>
+#include <KWayland/Client/clientmanagement.h>
+#include <KWayland/Client/registry.h>
+#include <KWayland/Client/connection_thread.h>
+#include <KWayland/Client/event_queue.h>
 #include <QObject>
 #include <QGuiApplication>
 #include <QDebug>


### PR DESCRIPTION
`INTERFACE_INCLUDE_DIRECTORIES` directs to `/usr/include/KF5/KWayland` and the actual file lies under `/usr/include/KF5/KWayland/KWayland/Client/`, thus removing the extra `KF5/` layer should be correct and improves compatibility.

Ref:
```
set_target_properties(KF5::WaylandClient PROPERTIES
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include/KF5/KWayland;${_IMPORT_PREFIX}/include/KF5"
  INTERFACE_LINK_LIBRARIES "Qt5::Gui"
)
```

Log: Fix build failure in Arch due to incompatible include path