### PR TITLE
fix: 系统监视器二级菜单中CPU缓存等信息显示为空

### DIFF
--- a/deepin-system-monitor-main/system/cpu_set.h
+++ b/deepin-system-monitor-main/system/cpu_set.h
@@ -90,6 +90,10 @@ public:
 private:
     void read_stats();
     /**
+     * @brief read_dmidecode 通过dmidecod读取CPU的cache信息
+     */
+    void read_dmi_cache_info();
+    /**
      * @brief read_lscpu 通过lscpu读取CPU信息
      */
     void read_lscpu();


### PR DESCRIPTION
通过dmidecode读取CPU缓存信息解决lscpu无法正确读取CPU缓存问题

Log: 正确显示CPU缓存信息
/review @pengfeixx 