### PR TITLE
fix:  重复开启并快速关闭系统监视器3-4次后应用无法正常启动

### DIFF
--- a/deepin-system-monitor-main/dbus/systemd1_manager_interface.h
+++ b/deepin-system-monitor-main/dbus/systemd1_manager_interface.h
@@ -72,7 +72,7 @@ public Q_SLOTS:  // METHODS
         ErrorContext ec {};
 
         // call dbus interface method: ListUnitFiles
-        QDBusMessage reply = callWithArgumentList(QDBus::Block, "ListUnitFiles", args);
+        QDBusMessage reply = callWithArgumentList(QDBus::BlockWithGui, "ListUnitFiles", args);
 
         // check dbus reply
         if (reply.type() == QDBusMessage::ErrorMessage) {
@@ -105,7 +105,7 @@ public Q_SLOTS:  // METHODS
         ErrorContext ec;
 
         // call dbus interface method: ListUnits
-        QDBusMessage reply = callWithArgumentList(QDBus::Block, "ListUnits", args);
+        QDBusMessage reply = callWithArgumentList(QDBus::BlockWithGui, "ListUnits", args);
         // check dbus reply
         if (reply.type() == QDBusMessage::ErrorMessage) {
             ec.setCode(ErrorContext::kErrorTypeDBus);


### PR DESCRIPTION
dbus在call时柱塞了GUI信号

Log: 正常关闭应用
Bug: https://pms.uniontech.com/bug-view-152357.html
@lzwind @pengfeixx @feeengli @hundundadi