### PR TITLE
fix: 开机首次点击任务栏插件区的系统监视器任务栏卡住1min以上功能不可用

### DIFF
--- a/deepin-system-monitor-plugin/dbus/dbusinterface.cpp
+++ b/deepin-system-monitor-plugin/dbus/dbusinterface.cpp
@@ -40,15 +40,22 @@ DBusInterface::DBusInterface()
     : mp_Iface(nullptr)
 {
     // 初始化dbus
-    init();
+//    init();
 }
 
 void DBusInterface::showOrHideDeepinSystemMonitorPluginPopupWidget()
 {
     // 调用dbus接口弹出插件主界面
     // 如果无效的话就执行一次唤醒DBUS服务的命令
-    if (!mp_Iface->isValid()) {
-        QProcess::startDetached(DBUS_COMMAND);
+    if (mp_Iface == nullptr || !mp_Iface->isValid()) {
+        if (!QProcess::startDetached(DBUS_COMMAND)) {
+            if (mp_Iface == nullptr) {
+                init();
+                if (!mp_Iface->isValid()) {
+                    QDBusReply<void> reply = mp_Iface->call("slotShowOrHideSystemMonitorPluginPopupWidget");
+                }
+            }
+        }
     } else {
         QDBusReply<void> reply = mp_Iface->call("slotShowOrHideSystemMonitorPluginPopupWidget");
     }


### PR DESCRIPTION
开始时SystemMonitorPluginPopup未启动导致连接dbus柱塞，通过多进程方法防止dock柱塞

Log: 开机正常启动系统监视器
Bug: https://pms.uniontech.com/bug-view-149531.html
/review @lzwind @feeengli @myk1343 @hundundadi @jeffshuai