### PR TITLE
chore: correct macro ending comment

### DIFF
--- a/deepin-system-monitor-main/common/common.cpp
+++ b/deepin-system-monitor-main/common/common.cpp
@@ -227,7 +227,7 @@ void WaylandSearchCentered()
     }
 #else
     WaylandCentered = false;
-#endif //WAYLAND_SESSION_SUPPORT
+#endif //USE_DEEPIN_WAYLAND
 
 }
 

--- a/deepin-system-monitor-main/gui/xwin_kill_preview_widget.cpp
+++ b/deepin-system-monitor-main/gui/xwin_kill_preview_widget.cpp
@@ -420,4 +420,4 @@ void XWinKillPreviewWidget::setupRegistry(Registry *registry)
     }
 
 }
-#endif //WAYLAND_SESSION_SUPPORT
+#endif //USE_DEEPIN_WAYLAND


### PR DESCRIPTION
The name in the comment should match the macro in #ifdef above.

Log: Correct macro ending comment