### PR TITLE
fix: 社区版本缺少qdbus不能启动插件的问题

### DIFF
--- a/deepin-system-monitor-plugin/dbus/dbusinterface.cpp
+++ b/deepin-system-monitor-plugin/dbus/dbusinterface.cpp
@@ -18,7 +18,7 @@ std::mutex DBusInterface::m_mutex;
 const QString SERVICE_NAME = "com.deepin.SystemMonitorPluginPopup";
 const QString SERVICE_PATH = "/com/deepin/SystemMonitorPluginPopup";
 
-const QString DBUS_COMMAND = "qdbus com.deepin.SystemMonitorPluginPopup /com/deepin/SystemMonitorPluginPopup com.deepin.SystemMonitorPluginPopup.slotShowOrHideSystemMonitorPluginPopupWidget";
+const QString DBUS_COMMAND = "gdbus call -e -d com.deepin.SystemMonitorPluginPopup -o /com/deepin/SystemMonitorPluginPopup -m  com.deepin.SystemMonitorPluginPopup.slotShowOrHideSystemMonitorPluginPopupWidget";
 
 DBusInterface::DBusInterface()
     : mp_Iface(nullptr)


### PR DESCRIPTION
社区版本缺少qdbus不能启动插件的问题

Log: 社区版本缺少qdbus不能启动插件的问题
Bug: https://pms.uniontech.com/bug-view-155451.html
/review
@wyu71 @myk1343 