### PR TITLE
fix: 系统服务刷新后系统服务按钮出现focus状态

### DIFF
--- a/deepin-system-monitor-main/gui/system_service_table_view.cpp
+++ b/deepin-system-monitor-main/gui/system_service_table_view.cpp
@@ -723,7 +723,7 @@ void SystemServiceTableView::initConnections()
     connect(mgr, &ServiceManager::beginUpdateList, this, [ = ]() {
         m_loading = true;
 
-        setEnabled(false);
+        header()->setEnabled(false);
 
         m_noMatchingResultLabel->hide();
         m_spinner->start();
@@ -731,7 +731,7 @@ void SystemServiceTableView::initConnections()
     });
     // hide tip label & spinner & reset loading state after service list updated
     connect(m_model, &SystemServiceTableModel::modelReset, this, [ = ]() {
-        setEnabled(true);
+        header()->setEnabled(true);
 
         m_noMatchingResultLabel->hide();
         m_spinner->hide();


### PR DESCRIPTION
只设置系统服务表头不可用

Log: 正常显示系统服务按钮
Bug: https://pms.uniontech.com/bug-view-157227.html
/review @lzwind @myk1343 @feeengli @jeffshuai @pengfeixx @HeeMingYang @hundundadi