### PR TITLE
fix: 系统监视器修改进程优先级后重新查看优先级始终显示为19

### DIFF
--- a/deepin-system-monitor-main/gui/process_table_view.cpp
+++ b/deepin-system-monitor-main/gui/process_table_view.cpp
@@ -216,8 +216,7 @@ void ProcessTableView::openExecDirWithFM()
                     QString output(whichProcess.readAllStandardOutput());
 
                     QDir flatpakRootDir(output.split("Location:")[1].split("\n")[0].simplified());
-                    if (flatpakRootDir.cd("files") && flatpakRootDir.cd("bin"))
-                    {
+                    if (flatpakRootDir.cd("files") && flatpakRootDir.cd("bin")) {
                         // Need split full path to get last filename.
                         const QString &path = QString(flatpakRootDir.absoluteFilePath(cmdline.split("/").last())).trimmed();
                         common::openFilePathItem(path);
@@ -882,7 +881,7 @@ void ProcessTableView::customizeProcessPriority()
     QString prio {"0"};
     if (m_selectedPID.isValid()) {
         pid_t pid = qvariant_cast<pid_t>(m_selectedPID);
-        slider->setValue(m_model->getProcessPriority(pid));
+        slider->setValue(m_model->getProcessPriorityValue(pid));
         prio = QString("%1").arg(slider->value());
         slider->setTipValue(prio);
     }

--- a/deepin-system-monitor-main/model/process_table_model.cpp
+++ b/deepin-system-monitor-main/model/process_table_model.cpp
@@ -345,6 +345,12 @@ ProcessPriority ProcessTableModel::getProcessPriority(pid_t pid) const
     return kInvalidPriority;
 }
 
+int ProcessTableModel::getProcessPriorityValue(pid_t pid) const
+{
+    int row = m_procIdList.indexOf(pid);
+    return row >= 0 ? ProcessDB::instance()->processSet()->getProcessById(pid).priority() : kNormalPriority;
+}
+
 // remove process entry from model with specified pid
 void ProcessTableModel::removeProcess(pid_t pid)
 {

--- a/deepin-system-monitor-main/model/process_table_model.h
+++ b/deepin-system-monitor-main/model/process_table_model.h
@@ -120,12 +120,20 @@ public:
      * @return Process state string
      */
     char getProcessState(pid_t pid) const;
+
     /**
      * @brief Get process priority enum type
      * @param pid Id of the process to get priority stub for
      * @return Process priority enum type
      */
     ProcessPriority getProcessPriority(pid_t pid) const;
+
+    /**
+     * @brief Get process priority enum type
+     * @param pid Id of the process to get priority stub for
+     * @return Process priority enum type
+     */
+    int getProcessPriorityValue(pid_t pid) const;
 
     /**
      * @brief Get process entry from list with specified pid


### PR DESCRIPTION
增加读取优先级值接口

Log: 正确显示优先级
Bug: https://pms.uniontech.com/bug-view-166309.html
/review @lzwind @myk1343 @feeengli @jeffshuai @pengfeixx @HeeMingYang @hundundadi