### PR TITLE
fix: avoid hardcoded exec path

### DIFF
--- a/deepin-system-monitor-main/common/common.cpp
+++ b/deepin-system-monitor-main/common/common.cpp
@@ -240,10 +240,10 @@ static void init_shell_list()
 static void init_script_list()
 {
     // fill scripting lang list (!!far from complete)
-    scriptList << "/usr/bin/python";
-    scriptList << "/usr/bin/perl";
-    scriptList << "/usr/bin/php";
-    scriptList << "/usr/bin/ruby";
+    scriptList << QStandardPaths::locateAll(QStandardPaths::ApplicationsLocation, "python");
+    scriptList << QStandardPaths::locateAll(QStandardPaths::ApplicationsLocation, "perl");
+    scriptList << QStandardPaths::locateAll(QStandardPaths::ApplicationsLocation, "php");
+    scriptList << QStandardPaths::locateAll(QStandardPaths::ApplicationsLocation, "ruby");
 }
 
 static void init_path_list()

--- a/deepin-system-monitor-main/process/priority_controller.cpp
+++ b/deepin-system-monitor-main/process/priority_controller.cpp
@@ -10,8 +10,8 @@
 #include <QProcess>
 #include <QFile>
 
-#define CMD_PKEXEC "/usr/bin/pkexec"
-#define CMD_RENICE "/usr/bin/renice"
+const QString CMD_PKEXEC = QStandardPaths::findExecutable("pkexec");
+const QString CMD_RENICE = QStandardPaths::findExecutable("renice");
 
 // constructor
 PriorityController::PriorityController(pid_t pid, int priority, QObject *parent)
@@ -57,20 +57,20 @@ void PriorityController::execute()
     QStringList params;
 
     // check pkexec existance
-    if (!QFile::exists({CMD_PKEXEC})) {
+    if (CMD_PKEXEC.isEmpty()) {
         Q_EMIT resultReady(ENOENT);
         exit(ENOENT);
     }
     // check renice existance
-    if (!QFile::exists({CMD_RENICE})) {
+    if (CMD_RENICE.isEmpty()) {
         Q_EMIT resultReady(ENOENT);
         exit(ENOENT);
     }
 
     // format: renice {priority} {pid}
-    params << QString(CMD_RENICE) << QString("%1").arg(m_priority) << QString("%1").arg(m_pid);
+    params << CMD_RENICE << QString("%1").arg(m_priority) << QString("%1").arg(m_pid);
 
     // -2: cant not be started; -1: crashed; other: exit code of pkexec
     // pkexec: 127: not auth/cant auth/error; 126: dialog dismiss
-    m_proc->start({CMD_PKEXEC}, params);
+    m_proc->start(CMD_PKEXEC, params);
 }

--- a/deepin-system-monitor-main/process/priority_controller.cpp
+++ b/deepin-system-monitor-main/process/priority_controller.cpp
@@ -9,6 +9,7 @@
 
 #include <QProcess>
 #include <QFile>
+#include <QStandardPaths>
 
 const QString CMD_PKEXEC = QStandardPaths::findExecutable("pkexec");
 const QString CMD_RENICE = QStandardPaths::findExecutable("renice");

--- a/deepin-system-monitor-main/process/process_controller.cpp
+++ b/deepin-system-monitor-main/process/process_controller.cpp
@@ -10,8 +10,8 @@
 #include <QFile>
 #include <QProcess>
 
-#define CMD_PKEXEC "/usr/bin/pkexec"
-#define CMD_KILL "/usr/bin/kill"
+const QString CMD_PKEXEC = QStandardPaths::findExecutable("pkexec");
+const QString CMD_KILL = QStandardPaths::findExecutable("kill");
 
 // constructor
 ProcessController::ProcessController(pid_t pid, int signal, QObject *parent)
@@ -49,21 +49,21 @@ void ProcessController::execute()
     QStringList params;
 
     // check pkexec existance
-    if (!QFile::exists({CMD_PKEXEC})) {
+    if (CMD_PKEXEC.isEmpty()) {
         Q_EMIT resultReady(ENOENT);
         exit(ENOENT);
     }
     // check kill existance
-    if (!QFile::exists({CMD_KILL})) {
+    if (CMD_KILL.isEmpty()) {
         Q_EMIT resultReady(ENOENT);
         exit(ENOENT);
     }
 
     // format: kill -{signal} {pid}
-    params << QString(CMD_KILL) << QString("-%1").arg(m_signal) << QString("%1").arg(m_pid);
+    params << CMD_KILL << QString("-%1").arg(m_signal) << QString("%1").arg(m_pid);
 
     // EINVAL, EPERM, ESRCH
     // -2: cant not be started; -1: crashed; other: exit code of pkexec
     // pkexec: 127: not auth/cant auth/error; 126: dialog dismiss
-    m_proc->start({CMD_PKEXEC}, params);
+    m_proc->start(CMD_PKEXEC, params);
 }

--- a/deepin-system-monitor-main/process/process_controller.cpp
+++ b/deepin-system-monitor-main/process/process_controller.cpp
@@ -9,6 +9,7 @@
 
 #include <QFile>
 #include <QProcess>
+#include <QStandardPaths>
 
 const QString CMD_PKEXEC = QStandardPaths::findExecutable("pkexec");
 const QString CMD_KILL = QStandardPaths::findExecutable("kill");

--- a/deepin-system-monitor-plugin/gui/monitor_plugin.cpp
+++ b/deepin-system-monitor-plugin/gui/monitor_plugin.cpp
@@ -149,7 +149,7 @@ void MonitorPlugin::invokedMenuItem(const QString &itemKey, const QString &menuI
     Q_UNUSED(checked);
     Q_UNUSED(itemKey);
     if (menuId == "openSystemMointor") {
-        QProcess::startDetached("/usr/bin/deepin-system-monitor");
+        QProcess::startDetached("deepin-system-monitor");
 
         //QString cmd("qdbus com.deepin.SystemMonitorMain /com/deepin/SystemMonitorMain com.deepin.SystemMonitorMain.slotRaiseWindow");
         QString cmd("gdbus call -e -d  com.deepin.SystemMonitorMain -o /com/deepin/SystemMonitorMain -m com.deepin.SystemMonitorMain.slotRaiseWindow");


### PR DESCRIPTION
Replace absolute paths to executable files with executable file names across 4 files

Related: linuxdeepin/developer-center#3374

The commit message should be fixed now, please review the PR and merge if there are no outstanding issues.