### PR TITLE
fix: 通过统信UOS助手启动文管在系统监视器中进程中图标显示错误

### DIFF
--- a/deepin-system-monitor-main/process/desktop_entry_cache_updater.cpp
+++ b/deepin-system-monitor-main/process/desktop_entry_cache_updater.cpp
@@ -51,6 +51,10 @@ DesktopEntry DesktopEntryCacheUpdater::createEntry(const QFileInfo &fileInfo)
     } else {
         entry->name = dde.name();
     }
+    // dde-file-manager plugins
+    if (execStr.contains("dde-file-manager") && execStr.contains("plugin")) {
+        entry->name = fileInfo.completeBaseName();
+    }
 
     // startup wm class & name
     auto wmclass = dde.stringValue("StartupWMClass");


### PR DESCRIPTION
识别UOS助手启动插件

Log: 正常显示文管图标
Bug: https://pms.uniontech.com/bug-view-160309.html
/review @lzwind @myk1343 @feeengli @jeffshuai @pengfeixx @HeeMingYang @hundundadi