### PR TITLE
chore: avoid use hard path header file

### DIFF
--- a/deepin-system-monitor-plugin/CMakeLists.txt
+++ b/deepin-system-monitor-plugin/CMakeLists.txt
@@ -28,6 +28,7 @@ find_package(DtkWidget REQUIRED)
 
 pkg_check_modules(DFrameworkDBus REQUIRED dframeworkdbus)
 pkg_check_modules(QGSettings REQUIRED gsettings-qt)
+pkg_check_modules(DdeDockInterface REQUIRED dde-dock) 
 
 add_definitions("${QT_DEFINITIONS} -DQT_PLUGIN")
 add_library(${PROJECT_NAME} SHARED ${SRCS} ${APP_RESOURCES})

--- a/deepin-system-monitor-plugin/gui/monitor_plugin.h
+++ b/deepin-system-monitor-plugin/gui/monitor_plugin.h
@@ -7,7 +7,7 @@
 #define MONITORPLUGIN_H
 
 //  smo-plugin
-#include "/usr/include/dde-dock/pluginsiteminterface.h"
+#include <pluginsiteminterface.h>
 #include "monitorpluginbuttonwidget.h"
 
 #include "dbus/dbusinterface.h"


### PR DESCRIPTION
Log: 使用 cmake 引入 dde-dock, 头文件避免使用绝对路径

之前的 DdeDockInterface_INCLUDE_DIRS 是空值，不生效，现在补充 pkg_check_modules