### PR TITLE
fix: missing symbol of MonitorPlugin::pluginStateSwitched()

### DIFF
--- a/deepin-system-monitor-plugin/gui/monitor_plugin.cpp
+++ b/deepin-system-monitor-plugin/gui/monitor_plugin.cpp
@@ -70,6 +70,11 @@ QWidget *MonitorPlugin::itemWidget(const QString &itemKey)
     return nullptr;
 }
 
+void MonitorPlugin::pluginStateSwitched()
+{
+
+}
+
 QWidget *MonitorPlugin::itemTipsWidget(const QString &itemKey)
 {
     m_dataTipsLabel->setObjectName(itemKey);


### PR DESCRIPTION
解决缺少符号，导致dock无法加载插件的问题。解决方式为添加了一个空的实现。