### PR TITLE
fix: 文管在系统监视器中进程中图标显示错误

### DIFF
--- a/deepin-system-monitor-main/process/desktop_entry_cache_updater.cpp
+++ b/deepin-system-monitor-main/process/desktop_entry_cache_updater.cpp
@@ -55,6 +55,14 @@ DesktopEntry DesktopEntryCacheUpdater::createEntry(const QFileInfo &fileInfo)
     if (execStr.contains("dde-file-manager") && execStr.contains("plugin")) {
         entry->name = fileInfo.completeBaseName();
     }
+    if (icon.contains("dde-file-manager")) {
+        if (dde.stringValue("GenericName").trimmed() != "File Manager") {
+            return {};
+        }
+        entry->exec.clear();
+        entry->exec.append("dde-file-manager");
+        entry->name = "dde-file-manager";
+    }
 
     // startup wm class & name
     auto wmclass = dde.stringValue("StartupWMClass");


### PR DESCRIPTION
过滤部分文管的desktop

Log: 正常显示文管图标
Bug: https://pms.uniontech.com/bug-view-160309.html
/review @lzwind @myk1343 @feeengli @jeffshuai @pengfeixx @hundundadi