### PR TITLE
fix: 资源占用达到报警阈值时未弹出消息通知

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -53,6 +53,11 @@ Files: deepin-system-monitor-daemon/src/*.h deepin-system-monitor-daemon/src/*.c
 Copyright: UnionTech Software Technology Co., Ltd.
 License: GPL-3.0-or-later
 
+# deepin-system-monitor-server
+Files: deepin-system-monitor-server/src/*.h deepin-system-monitor-server/src/*.cpp
+Copyright: UnionTech Software Technology Co., Ltd.
+License: GPL-3.0-or-later
+
 # deepin-system-monitor-main
 Files: deepin-system-monitor-main/*.h deepin-system-monitor-main/*.cpp
 Copyright: UnionTech Software Technology Co., Ltd.

--- a/.tx/deepin.conf
+++ b/.tx/deepin.conf
@@ -1,0 +1,2 @@
+[transifex]
+branch = m20

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,8 @@ ADD_SUBDIRECTORY(deepin-system-monitor-plugin)
 ADD_SUBDIRECTORY(deepin-system-monitor-plugin-popup)
 #系统监视器安全等级保护守护应用
 ADD_SUBDIRECTORY(deepin-system-monitor-daemon)
+#系统监视器提示
+ADD_SUBDIRECTORY(deepin-system-monitor-server)
 #单元测试
 if(DOTEST)
     ADD_SUBDIRECTORY(tests)

--- a/deepin-system-monitor-daemon/src/systemmonitorservice.cpp
+++ b/deepin-system-monitor-daemon/src/systemmonitorservice.cpp
@@ -83,7 +83,7 @@ SystemMonitorService::SystemMonitorService(const char *name, QObject *parent)
         QDBusConnection::ExportAllSlots | QDBusConnection::ExportAllSignals |
         QDBusConnection::ExportAllProperties;
 
-    QDBusConnection::connectToBus(QDBusConnection::SystemBus, QString(name))
+    QDBusConnection::connectToBus(QDBusConnection::SessionBus, QString(name))
     .registerObject("/org/deepin/SystemMonitorDaemon", this, opts);
 }
 
@@ -229,11 +229,8 @@ void SystemMonitorService::setAlarmUsageOfMemory(int usage)
 void SystemMonitorService::showDeepinSystemMoniter()
 {
     PrintDBusCaller()
-    // 显示系统监视器
-    QProcess::startDetached("/usr/bin/deepin-system-monitor");
 
-    // QString cmd("qdbus com.deepin.SystemMonitorMain /com/deepin/SystemMonitorMain com.deepin.SystemMonitorMain.slotRaiseWindow");
-    QString cmd("gdbus call -e -d  com.deepin.SystemMonitorMain -o /com/deepin/SystemMonitorMain -m com.deepin.SystemMonitorMain.slotRaiseWindow");
+    QString cmd("gdbus call -e -d  com.deepin.SystemMonitorServer -o /com/deepin/SystemMonitorServer -m com.deepin.SystemMonitorServer.showDeepinSystemMoniter");
     QTimer::singleShot(100, this, [ = ]() { QProcess::startDetached(cmd); });
 }
 
@@ -270,7 +267,8 @@ bool SystemMonitorService::checkCpuAlarm()
 
     if (mCpuUsage >= mAlarmCpuUsage && diffTime >= timeGap) {
         mLastAlarmTimeStamp = curTimeStamp;
-        QProcess::startDetached("/usr/bin/deepin-system-monitor", QStringList() << "alarm" << "cpu" << QString::number(mCpuUsage));
+        QString cmd = QString("gdbus call -e -d  com.deepin.SystemMonitorServer -o /com/deepin/SystemMonitorServer -m com.deepin.SystemMonitorServer.showCpuAlarmNotify \"%1\" ").arg(QString::number(mCpuUsage));
+        QTimer::singleShot(100, this, [ = ]() { QProcess::startDetached(cmd); });
     }
 
     return false;
@@ -284,7 +282,8 @@ bool SystemMonitorService::checkMemoryAlarm()
 
     if (mMemoryUsage >= mAlarmMemoryUsage && diffTime > timeGap) {
         mLastAlarmTimeStamp = curTimeStamp;
-        QProcess::startDetached("/usr/bin/deepin-system-monitor", QStringList() << "alarm" << "memory" << QString::number(mMemoryUsage));
+        QString cmd = QString("gdbus call -e -d  com.deepin.SystemMonitorServer -o /com/deepin/SystemMonitorServer -m com.deepin.SystemMonitorServer.showMemoryAlarmNotify \"%1\" ").arg(QString::number(mMemoryUsage));
+        QTimer::singleShot(100, this, [ = ]() { QProcess::startDetached(cmd); });
     }
 
     return false;

--- a/deepin-system-monitor-server/CMakeLists.txt
+++ b/deepin-system-monitor-server/CMakeLists.txt
@@ -1,0 +1,52 @@
+cmake_minimum_required(VERSION 3.7)
+
+set(BIN_NAME deepin-system-monitor-server)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(CMAKE_AUTOMOC ON)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-strong -D_FORTITY_SOURCE=1 -z noexecstack -pie -fPIC -z lazy")
+
+# 设置包含头文件的时候不用包含路径 begin ****************************************************************************************
+MACRO(SUBDIRLIST result curdir)
+  FILE(GLOB children RELATIVE ${curdir} ${curdir}/*)
+  SET(dirlist "")
+  FOREACH(child ${children})
+    IF(IS_DIRECTORY ${curdir}/${child})
+      LIST(APPEND dirlist ${child})
+    ENDIF()
+  ENDFOREACH()
+  SET(${result} ${dirlist})
+ENDMACRO()
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
+SUBDIRLIST(dirs ${CMAKE_CURRENT_SOURCE_DIR}/src)
+foreach(dir ${dirs})
+    include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src/${dir})
+endforeach()
+# 设置包含头文件的时候不用包含路径 end ****************************************************************************************
+
+file(GLOB_RECURSE SRC_CPP ${CMAKE_CURRENT_LIST_DIR}/src/*.cpp)
+file(GLOB_RECURSE SRC_H ${CMAKE_CURRENT_LIST_DIR}/src/*.h)
+
+find_package(Qt5 COMPONENTS Core DBus REQUIRED)
+
+add_executable(${BIN_NAME}
+    ${SRC_CPP}
+    ${SRC_H}
+)
+
+target_include_directories(${BIN_NAME} PUBLIC
+  Qt5::Core
+  Qt5::DBus
+)
+
+target_link_libraries(${BIN_NAME} PRIVATE
+  Qt5::Core
+  Qt5::DBus
+)
+
+install(TARGETS ${BIN_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(FILES com.deepin.SystemMonitorServer.service DESTINATION ${CMAKE_INSTALL_DATADIR}/dbus-1/services)

--- a/deepin-system-monitor-server/com.deepin.SystemMonitorServer.service
+++ b/deepin-system-monitor-server/com.deepin.SystemMonitorServer.service
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=com.deepin.SystemMonitorServer
+Exec=/usr/bin/deepin-system-monitor-server

--- a/deepin-system-monitor-server/src/dbusserver.cpp
+++ b/deepin-system-monitor-server/src/dbusserver.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "dbusserver.h"
+
+#include <QDBusMessage>
+#include <QDBusConnection>
+#include <QProcess>
+#include <QDebug>
+#include <QTimer>
+#include <QCoreApplication>
+
+DBusServer::DBusServer(QObject *parent)
+    : QObject(parent)
+{
+    QDBusConnection dbus = QDBusConnection::sessionBus();
+    if (dbus.registerService("com.deepin.SystemMonitorServer")) {
+        QDBusConnection::RegisterOptions opts =
+            QDBusConnection::ExportAllSlots | QDBusConnection::ExportAllSignals |
+            QDBusConnection::ExportAllProperties;
+        dbus.registerObject("/com/deepin/SystemMonitorServer", this, opts);
+    }
+    m_timer.setSingleShot(true);
+    connect(&m_timer, &QTimer::timeout, this, [ = ]() { qApp->exit(0); });
+}
+
+void DBusServer::exitDBusServer(int msec)
+{
+    qApp->processEvents();
+    m_timer.start(msec);
+}
+
+void DBusServer::showCpuAlarmNotify(const QString &argument)
+{
+    QProcess::startDetached("/usr/bin/deepin-system-monitor", QStringList() << "alarm" << "cpu" << argument);
+    exitDBusServer(8000);
+}
+
+void DBusServer::showMemoryAlarmNotify(const QString &argument)
+{
+    QProcess::startDetached("/usr/bin/deepin-system-monitor", QStringList() << "alarm" << "memory" << argument);
+    exitDBusServer(8000);
+}
+
+void DBusServer::showDeepinSystemMoniter()
+{
+    // 显示系统监视器
+    QProcess::startDetached("/usr/bin/deepin-system-monitor");
+
+    // QString cmd("qdbus com.deepin.SystemMonitorMain /com/deepin/SystemMonitorMain com.deepin.SystemMonitorMain.slotRaiseWindow");
+    QString cmd("gdbus call -e -d  com.deepin.SystemMonitorMain -o /com/deepin/SystemMonitorMain -m com.deepin.SystemMonitorMain.slotRaiseWindow");
+    QTimer::singleShot(100, this, [ = ]() {
+        QProcess::startDetached(cmd);
+        qApp->processEvents();
+        exitDBusServer(8000);
+    });
+}

--- a/deepin-system-monitor-server/src/dbusserver.h
+++ b/deepin-system-monitor-server/src/dbusserver.h
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef DBUSALARMNOTIFY_H
+#define DBUSALARMNOTIFY_H
+
+#include <QObject>
+#include <QDBusContext>
+#include <QTimer>
+
+class DBusServer : public QObject, protected QDBusContext
+{
+    Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "com.deepin.SystemMonitorServer")
+public:
+    DBusServer(QObject *parent = nullptr);
+    ~DBusServer() {}
+    void exitDBusServer(int msec);
+
+public slots:
+    /**
+     * @brief showCpuAlarmNotify 显示CPU警告提示
+     * @param allArguments 警告提示信息
+     */
+    void showCpuAlarmNotify(const QString &argument);
+
+    /**
+     * @brief showMemoryAlarmNotify 显示Memory警告提示
+     * @param allArguments 警告提示信息
+     */
+    void showMemoryAlarmNotify(const QString &argument);
+
+    /**
+     * @brief showDeepinSystemMoniter 显示系统监视器主页面
+     */
+    void showDeepinSystemMoniter();
+
+private:
+    QTimer  m_timer;
+};
+
+#endif // DBUS_OBJECT_H

--- a/deepin-system-monitor-server/src/main.cpp
+++ b/deepin-system-monitor-server/src/main.cpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <QCoreApplication>
+#include <QTimer>
+
+#include "dbusserver.h"
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication a(argc, argv);
+
+    DBusServer dbusServer;
+    dbusServer.exitDBusServer(10000);
+
+    return a.exec();
+}


### PR DESCRIPTION
deepin-server-manager无法启动GUI应用

Log: 正确显示消息通知
Bug: https://pms.uniontech.com/bug-view-194991.html
/review @lzwind @myk1343 @feeengli @jeffshuai @pengfeixx @hundundadi