### PR TITLE
Define _GNU_SOURCE for a declaration of vasprintf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,25 @@ else()
     SET(IS_LOONGARCH_TYPE 0)
 endif()
 
+# For vasprintf in deepin-system-monitor-main/3rdparty/include/xalloc.h.
+# Also needed by the tests subdirectory.
+add_definitions("-D_GNU_SOURCE")
+
+# HAVE_CLOSE_RANGE is used by
+# deepin-system-monitor-main/3rdparty/include/fileutils.h to define
+# close_range if needed.
+try_compile(CLOSE_RANGE_RESULT "${CMAKE_CURRENT_BINARY_DIR}/try_compile"
+  "${PROJECT_SOURCE_DIR}/cmake/check-close_range.c")
+if(CLOSE_RANGE_RESULT)
+  add_definitions("-DHAVE_CLOSE_RANGE")
+endif()
+
+# Likewise, HAVE_DECL_CPU_ALLOC is used in
+# deepin-system-monitor-main/3rdparty/include/cpuset.h.  Support for
+# the <sched.h> macros was added in glibc 2.7, so define it
+# unconditionally.
+add_definitions("-DHAVE_DECL_CPU_ALLOC")
+
 #系统监视器主应用
 ADD_SUBDIRECTORY(deepin-system-monitor-main)
 #系统监视器插件

--- a/cmake/check-close_range.c
+++ b/cmake/check-close_range.c
@@ -1,0 +1,14 @@
+/* Check whether <unistd.h> declares close_range, for HAVE_CLOSE_RANGE. */
+
+/* Supplied by the build environment later. */
+#define _GNU_SOURCE
+
+#include <unistd.h>
+
+void *volatile p;
+
+int
+main(void)
+{
+  p = (void *) close_range;
+}


### PR DESCRIPTION
This is necessary to build with compilers which do not support implicit function declarations (a language feature that was removed from C99).

Defining _GNU_SOURCE during the build exposes that the imported util-linux sources are not built with some HAVE_* macros defined, for things that the glibc headers provide with _GNU_SOURCE.  These HAVE_* macros need to be defined as well.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
