### PR TITLE
fix: 微信、QQ、腾讯会议、钉钉、腾讯视频系统监视器，查看进程，会发现图标对不上的问题

### DIFF
--- a/deepin-system-monitor-main/process/desktop_entry_cache.h
+++ b/deepin-system-monitor-main/process/desktop_entry_cache.h
@@ -53,7 +53,11 @@ inline const DesktopEntry DesktopEntryCache::entry(const QString &name) const
 inline const DesktopEntry DesktopEntryCache::entryWithSubName(const QString &subName) const
 {
     for (auto &key : m_cache.keys()) {
-        if (key.contains(subName))
+        if (key.toLower().compare(subName) == 0)
+            return m_cache[key];
+    }
+    for (auto &key : m_cache.keys()) {
+        if (key.toLower().contains(subName))
             return m_cache[key];
     }
     return {};

--- a/deepin-system-monitor-main/process/desktop_entry_cache_updater.cpp
+++ b/deepin-system-monitor-main/process/desktop_entry_cache_updater.cpp
@@ -49,7 +49,7 @@ DesktopEntry DesktopEntryCacheUpdater::createEntry(const QFileInfo &fileInfo)
         entry->exec = exec.split(' ');
         entry->name = QFileInfo(entry->exec[0]).baseName();
     } else {
-        entry->name = dde.name();
+        entry->name = dde.name().toLower();
     }
     // dde-file-manager plugins
     if (execStr.contains("dde-file-manager") && execStr.contains("plugin")) {
@@ -65,7 +65,7 @@ DesktopEntry DesktopEntryCacheUpdater::createEntry(const QFileInfo &fileInfo)
     }
 
     // startup wm class & name
-    auto wmclass = dde.stringValue("StartupWMClass");
+    auto wmclass = dde.stringValue("StartupWMClass").toLower();
     if (!wmclass.isEmpty()) {
         entry->startup_wm_class = wmclass;
         entry->name = wmclass;


### PR DESCRIPTION
微信、QQ、腾讯会议、钉钉、腾讯视频系统监视器，查看进程，会发现图标对不上的问题

Log: 微信、QQ、腾讯会议、钉钉、腾讯视频系统监视器，查看进程，会发现图标对不上的问题

Bug: https://pms.uniontech.com/bug-view-196499.html