### PR TITLE
fix: 修复1060末启动server

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/linuxdeepin/deepin-system-monitor
 
 Package: deepin-system-monitor
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libcap2-bin, libdwaylandclient5, libdwaylandserver5
+Depends: ${shlibs:Depends}, ${misc:Depends}, libcap2-bin, libdwaylandclient5, libdwaylandserver5,deepin-service-manager
 Recommends: uos-reporter, deepin-event-log
 Description: A system monitor tool.
  System Monitor is a system tool monitoring and managing hardware load, program running and system services. It's capable to real-time monitor CPU status, memory footprint, and upload/download speed, manage system and application processes, search and force end processes as well.


### PR DESCRIPTION
修复1060因deepin-service-manager不启动server

Log: 修复1060因deepin-service-manager不启动server