### PR TITLE
feat: hw机型判断适配dconfig

### DIFF
--- a/deepin-system-monitor-main/assets/org.deepin.system-monitor.main.json
+++ b/deepin-system-monitor-main/assets/org.deepin.system-monitor.main.json
@@ -3,7 +3,7 @@
     "version": "1.0",
     "contents": {
 	"specialComType": {
-            "value": 0,
+            "value": -1,
             "serial": 0,
             "flags": ["global"],
             "name": "Special Computer Type",


### PR DESCRIPTION
Description: 修改默认配置值为-1,存在dconfig接口但是底层未修改配置文件时，将采用以前判断hw的方式

Log: hw机型判断适配dconfig

Task: https://pms.uniontech.com/task-view-276433.html