### PR TITLE
fix: 修复在dde-dock中右键菜单系统监视器图标无法激活系统监视器窗口到顶层

### DIFF
--- a/deepin-system-monitor-main/dbus/dbus_object.cpp
+++ b/deepin-system-monitor-main/dbus/dbus_object.cpp
@@ -56,7 +56,9 @@ void DBusObject::handleWindow()
 {
     internalMutex.lockForRead();
     MainWindow *mw = gApp->mainWindow();
-    mw->setWindowState((mw->windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
+    mw->setWindowState(mw->windowState() & ~Qt::WindowMinimized);
+    mw->raise();
+    mw->activateWindow();
     internalMutex.unlock();
 }
 


### PR DESCRIPTION
在dde-dock中右键菜单系统监视器图标无法激活系统监视器窗口到顶层

Log: 修复在dde-dock中右键菜单系统监视器图标无法激活系统监视器窗口到顶层

Bug: https://pms.uniontech.com/bug-view-191373.html