### PR TITLE
fix: 修复在dde-dock中右键菜单系统监视器图标无法激活系统监视器窗口到顶层

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-system-monitor (5.9.38) unstable; urgency=medium
+
+  * New version 5.9.38
+
+ -- shuaijie <shuaijie@uniontech.com>  Mon, 17 Jul 2023 18:29:06 +0800
+
 deepin-system-monitor (5.9.35) unstable; urgency=medium
 
   * New version 5.9.35

--- a/deepin-system-monitor-main/dbus/dbus_object.cpp
+++ b/deepin-system-monitor-main/dbus/dbus_object.cpp
@@ -56,7 +56,9 @@ void DBusObject::handleWindow()
 {
     internalMutex.lockForRead();
     MainWindow *mw = gApp->mainWindow();
-    mw->setWindowState((mw->windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
+    mw->setWindowState(mw->windowState() & ~Qt::WindowMinimized);
+    mw->raise();
+    mw->activateWindow();
     internalMutex.unlock();
 }
 


### PR DESCRIPTION
在dde-dock中右键菜单系统监视器图标无法激活系统监视器窗口到顶层

Log: 修复在dde-dock中右键菜单系统监视器图标无法激活系统监视器窗口到顶层

Bug: https://pms.uniontech.com/bug-view-191373.html