### PR TITLE
fix: 修复传输文件时，系统监视器不显示传输速度

### DIFF
--- a/deepin-system-monitor-main/system/block_device_info_db.cpp
+++ b/deepin-system-monitor-main/system/block_device_info_db.cpp
@@ -135,7 +135,8 @@ void BlockDeviceInfoDB::readDiskInfo()
 
     //获取虚拟磁盘
     for (int i = 0; i < list.size(); ++i) {
-        if (list[i].fileName() != "." && list[i].fileName() != ".." && !list[i].fileName().contains("ram") && !list[i].fileName().contains("loop")) {
+        QString t_link = list.at(i).readLink();
+        if (list[i].fileName() != "." && list[i].fileName() != ".." && !list[i].fileName().contains("ram") && !list[i].fileName().contains("loop") && t_link.contains("virtual")) {
             int index = -1;
             //  查找当前的device是否存在
             for (int si = 0; si < m_deviceList.size(); ++si) {


### PR DESCRIPTION
修复传输文件时，系统监视器不显示传输速度

Log: 修复传输文件时，系统监视器不显示传输速度

Bug: https://pms.uniontech.com/bug-view-200077.html