### PR TITLE
fix: 火狐浏览器进程的磁盘写入速率达到8EB/s

### DIFF
--- a/deepin-system-monitor-main/common/sample.h
+++ b/deepin-system-monitor-main/common/sample.h
@@ -223,7 +223,7 @@ public:
         auto cwdiff = (ccwb < pcwb) ? 0 : (ccwb - pcwb);
         // calculate read/write speed
         rdio = qreal(rdiff) / interval;
-        wrio = qreal(wdiff - cwdiff) / interval;
+        wrio = (wdiff < cwdiff) ? 0 : qreal(wdiff - cwdiff) / interval;
 
         return {rdio, wrio};
     }


### PR DESCRIPTION
修复火狐浏览器进程的磁盘写入速率达到8EB/s

Log: cancelled_write_bytes时磁盘写入速率达到8EB/s

Bug: https://pms.uniontech.com/bug-view-212249.html