### PR TITLE
fix: assertion error caused by beginRemoveRows

### DIFF
--- a/deepin-system-monitor-main/model/process_table_model.cpp
+++ b/deepin-system-monitor-main/model/process_table_model.cpp
@@ -87,8 +87,10 @@ void ProcessTableModel::updateProcessListWithUserSpecified()
     ProcessSet *processSet = ProcessDB::instance()->processSet();
     const QList<pid_t> &newpidlst = processSet->getPIDList();
 
-    beginRemoveRows({}, 0, m_procIdList.size());
-    endRemoveRows();
+    if (rowCount() > 0) {
+        beginRemoveRows({}, 0, rowCount() - 1);
+        endRemoveRows();
+    }
     m_procIdList.clear();
     m_processList.clear();
     int raw;


### PR DESCRIPTION
系统监视器在v23 bate2系统中启动时会报错:
ASSERT: "last < rowCount(parent)" in file itemmodels/qabstractitemmodel.cpp 是因为ProcessTableModel在调用beginRemoveRows时未检查当前总的row数量

Log: