### PR TITLE
fix: quickpannel start app and disappeared self auto

### DIFF
--- a/deepin-system-monitor-plugin/gui/monitor_plugin.cpp
+++ b/deepin-system-monitor-plugin/gui/monitor_plugin.cpp
@@ -71,6 +71,7 @@ void MonitorPlugin::init(PluginProxyInterface *proxyInter)
     m_quickPanelWidget->setDescription(pluginDisplayName());
     QString plugIcon = DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::LightType? "dsm_pluginicon_dark" : "dsm_pluginicon_light";
     m_quickPanelWidget->setIcon(QIcon::fromTheme(plugIcon));
+    connect(m_quickPanelWidget,&QuickPanelWidget::clicked,this,&MonitorPlugin::onClickQuickPanel);
     qInfo() << __FUNCTION__ << __LINE__ << "[-MonitorPlugin-] QUICKPANEL20";
 #endif
 
@@ -193,6 +194,10 @@ void MonitorPlugin::invokedMenuItem(const QString &itemKey, const QString &menuI
         //QString cmd("qdbus com.deepin.SystemMonitorMain /com/deepin/SystemMonitorMain com.deepin.SystemMonitorMain.slotRaiseWindow");
         QString cmd("gdbus call -e -d  com.deepin.SystemMonitorMain -o /com/deepin/SystemMonitorMain -m com.deepin.SystemMonitorMain.slotRaiseWindow");
         QTimer::singleShot(200, this, [ = ]() { QProcess::startDetached(cmd); });
+#ifdef USE_API_QUICKPANEL20
+        qInfo() << __FUNCTION__ << __LINE__ << "[-MonitorPlugin-] right ClickQuickPanel";
+        m_proxyInter->requestSetAppletVisible(this, Dock::QUICK_ITEM_KEY, false);
+#endif
     }
 }
 
@@ -484,5 +489,12 @@ MonitorPlugin::~MonitorPlugin()
 QIcon MonitorPlugin::icon(Dock::IconType iconType, Dock::ThemeType) const
 {
     return( (iconType == Dock::IconType_DCC_Settings) ? QIcon(":/deepin-system-monitor.svg") : QIcon());
+}
+
+void MonitorPlugin::onClickQuickPanel()
+{
+    qInfo() << __FUNCTION__ << __LINE__ << "[-MonitorPlugin-] ClickQuickPanel";
+    m_proxyInter->requestSetAppletVisible(this, Dock::QUICK_ITEM_KEY, false);
+    DBusInterface::getInstance()->showOrHideDeepinSystemMonitorPluginPopupWidget();
 }
 #endif

--- a/deepin-system-monitor-plugin/gui/monitor_plugin.h
+++ b/deepin-system-monitor-plugin/gui/monitor_plugin.h
@@ -202,6 +202,13 @@ private slots:
     //!
     void udpateTipsInfo();
 
+#ifdef USE_API_QUICKPANEL20
+    //!
+    //! \brief onClickQuickPanel mouse event active
+    //!
+    void onClickQuickPanel();
+#endif
+
 private:
     //!
     //! \brief loadPlugin 加载插件

--- a/deepin-system-monitor-plugin/gui/quickpanelwidget.cpp
+++ b/deepin-system-monitor-plugin/gui/quickpanelwidget.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include "quickpanelwidget.h"
-#include "dbus/dbusinterface.h"
 
 #include <QVBoxLayout>
 
@@ -19,13 +18,12 @@ QuickPanelWidget::QuickPanelWidget(QWidget* parent)
 {
     initUI();
     connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged, this, &QuickPanelWidget::refreshBg);
-    connect(this,&QuickPanelWidget::clicked,this,&QuickPanelWidget::onClickQuickPanel);
 }
 
 QuickPanelWidget::~QuickPanelWidget()
 {
-}
 
+}
 
 void QuickPanelWidget::initUI()
 {
@@ -89,11 +87,10 @@ void QuickPanelWidget::paintEvent(QPaintEvent *event)
 
 void QuickPanelWidget::refreshBg()
 {
+    QString plugIcon = DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::LightType? "dsm_pluginicon_dark" : "dsm_pluginicon_light";
+    setIcon(QIcon::fromTheme(plugIcon));
+
     m_description->setForegroundRole(m_icon->activeState() && DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType ? QPalette::Highlight : QPalette::NoRole);
     update();
 }
 
-void QuickPanelWidget::onClickQuickPanel()
-{
-    DBusInterface::getInstance()->showOrHideDeepinSystemMonitorPluginPopupWidget();
-}

--- a/deepin-system-monitor-plugin/gui/quickpanelwidget.h
+++ b/deepin-system-monitor-plugin/gui/quickpanelwidget.h
@@ -40,7 +40,7 @@ private:
 
 private slots:
     void refreshBg();
-    void onClickQuickPanel();
+
 private:
     CommonIconButton *m_icon;
     DLabel *m_description;


### PR DESCRIPTION
快捷面板启动应用系统监示器后快捷面板自动隐藏
Log: quickpannel start app and disappeared self auto Bug: https://pms.uniontech.com/bug-view-228255.html Bug: https://pms.uniontech.com/bug-view-228257.html