### PR TITLE
fix: 控制中心任务栏首次设置系统监视器展示，需要点击2次，系统监视器图标才会在任务栏中显示

### DIFF
--- a/deepin-system-monitor-plugin/CMakeLists.txt
+++ b/deepin-system-monitor-plugin/CMakeLists.txt
@@ -72,7 +72,7 @@ qt5_add_translation(APP_QM_FILES ${APP_TS_FILES})
 add_custom_target(PLUGIN_QMFILES ALL DEPENDS ${APP_QM_FILES})
 
 INSTALL(FILES com.deepin.dde.dock.module.system-monitor.gschema.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/glib-2.0/schemas)
-INSTALL(FILES com.deepin.system.monitor.plugin.gschema.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/glib-2.0/schemas)
+#INSTALL(FILES com.deepin.system.monitor.plugin.gschema.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/glib-2.0/schemas)
 INSTALL(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION lib/dde-dock/plugins)
 #安装翻译文件
 install(FILES ${APP_QM_FILES} DESTINATION ${CMAKE_INSTALL_DATADIR}/deepin-system-monitor-plugin/translations)

--- a/deepin-system-monitor-plugin/gui/monitor_plugin.h
+++ b/deepin-system-monitor-plugin/gui/monitor_plugin.h
@@ -215,18 +215,6 @@ private:
     //!
     void loadPlugin();
 
-#ifndef DDE_DOCK_NEW_VERSION
-    //!
-    //! \brief refreshPluginItemsVisible 刷新插件项显示隐藏
-    //!
-    void refreshPluginItemsVisible();
-#endif
-
-    //!
-    //! \brief initPluginState 初始化插件状态
-    //!
-    void initPluginState();
-
     //!
     //! \brief calcCpuRate 计算CPU占用率
     //! \param totalCPU 总CPU占用率
@@ -273,7 +261,6 @@ private:
     bool m_pluginLoaded;
     MonitorPluginButtonWidget *m_itemWidget = nullptr;
     QScopedPointer<SystemMonitorTipsWidget> m_dataTipsLabel;
-    QGSettings *m_settings;
 
     qlonglong m_down = 0;
     qlonglong m_upload = 0;
@@ -283,8 +270,6 @@ private:
     QTimer *m_refershTimer;
 
     QString startup;
-
-    bool m_isFirstInstall = false;//判断插件是否第一次安装
 
     QString m_cpuStr{"0.0"};       //转换后的cpu数据
     QString m_memStr{"0.0"};       //转换后的mem数据


### PR DESCRIPTION
通过pluginIsDisable()判断首次安装是否显示，无需应用自己编写配置文件并保存状态

Log: 控制中心任务栏首次设置系统监视器展示，需要点击2次，系统监视器图标才会在任务栏中显示

Bug: https://pms.uniontech.com/bug-view-213941.html