### PR TITLE
fix: 修复 deepin-system-monitor漏洞

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -3,7 +3,7 @@ set -e
 
 if [ "$1" = configure ]; then
 	if command -v setcap > /dev/null; then
-		if setcap cap_net_raw,cap_dac_read_search,cap_sys_ptrace+ep /usr/bin/deepin-system-monitor;then
+		if setcap cap_net_raw,cap_dac_read_search+ep /usr/bin/deepin-system-monitor;then
 			chmod u-s /usr/bin/deepin-system-monitor
 		else
 			echo "Setcap failed, falling back to setuid" >&2


### PR DESCRIPTION
QT通过platformpluginpath插件对具有cap_sys_ptrace的程序提权为root

Log:  修复对具有cap_sys_ptrace的程序提权为root漏洞

Bug: https://pms.uniontech.com/bug-view-239329.html