### PR TITLE
fix: tow code blocks cause memory leak.

### DIFF
--- a/deepin-system-monitor-main/model/accounts_info_model.cpp
+++ b/deepin-system-monitor-main/model/accounts_info_model.cpp
@@ -72,7 +72,10 @@ void AccountsInfoModel::onSessionRemoved(const QString &in0, const QDBusObjectPa
 void AccountsInfoModel::updateUserList(const QStringList &userPathList)
 {
     qInfo() << "AccountsInfoModel updateUserList line 61" << "updateUserList begins!" ;
+    // 释放构造对象
+    qDeleteAll(m_userMap.values());
     m_userMap.clear();
+
     for (QString userPath : userPathList) {
         QDBusInterface *userDBus = new QDBusInterface(common::systemInfo().AccountsService, userPath, common::systemInfo().UserInterface, QDBusConnection::systemBus(), this);
         User *newUser = new User;
@@ -90,9 +93,10 @@ void AccountsInfoModel::updateUserList(const QStringList &userPathList)
         }
         qInfo() << "AccountsInfoModel updateUserList line 78" << "get user info of :" << newUser->name();
         m_userMap.insert(newUser->name(), newUser);
+
+        delete userDBus;
     }
 }
-
 
 void AccountsInfoModel::updateUserOnlineStatus()
 {

--- a/deepin-system-monitor-main/process/process.cpp
+++ b/deepin-system-monitor-main/process/process.cpp
@@ -638,7 +638,10 @@ void Process::readSockInodes()
             if (!stat(fdp, &sbuf)) {
                 // get inode if it's a socket descriptor
                 if (S_ISSOCK(sbuf.st_mode)) {
-                    d->sockInodes << sbuf.st_ino;
+                    // not append repeat data, may memory leak.
+                    if (!d->sockInodes.contains(sbuf.st_ino)) {
+                        d->sockInodes << sbuf.st_ino;
+                    }
                 }
             } // ::if(stat)
         } // ::if(isdigit)

--- a/deepin-system-monitor-plugin-popup/process/process.cpp
+++ b/deepin-system-monitor-plugin-popup/process/process.cpp
@@ -536,7 +536,9 @@ void Process::readSockInodes()
             if (!stat(fdp, &sbuf)) {
                 // get inode if it's a socket descriptor
                 if (S_ISSOCK(sbuf.st_mode)) {
-                    d->sockInodes << sbuf.st_ino;
+                    if (!d->sockInodes.contains(sbuf.st_ino)) {
+                        d->sockInodes << sbuf.st_ino;
+                    }
                 }
             } // ::if(stat)
         } // ::if(isdigit)


### PR DESCRIPTION
1. QList loops to append repeated data;
2. Forgot to release temporary malloc data.

Log: fix two code block memory leaks.
Bug: https://pms.uniontech.com/bug-view-239575.html