### PR TITLE
fix: 修复任务栏打开系统监视器popup会覆盖在任务栏上

### DIFF
--- a/deepin-system-monitor-plugin-popup/dbus/dbusdockinterface.h
+++ b/deepin-system-monitor-plugin-popup/dbus/dbusdockinterface.h
@@ -45,7 +45,7 @@ class DBusDockInterface: public QDBusAbstractInterface
    }
 public:
     static inline const char *staticInterfaceName()
-    { return common::systemInfo().DockService.toStdString().c_str(); }
+    { return (common::systemInfo().isOldVersion() ? "com.deepin.dde.Dock": "org.deepin.dde.Dock1"); }
 
 public:
     explicit DBusDockInterface( QObject *parent = nullptr);


### PR DESCRIPTION
 修复任务栏打开系统监视器popup会覆盖在任务栏上

Log:  修复任务栏打开系统监视器popup会覆盖在任务栏上

Bug: https://pms.uniontech.com/bug-view-240273.html