### PR TITLE
fix: the app add a blank proc while some apps closed.

### DIFF
--- a/deepin-system-monitor-main/process/process_set.cpp
+++ b/deepin-system-monitor-main/process/process_set.cpp
@@ -104,8 +104,9 @@ void ProcessSet::scanProcess()
                 m_prePid.removeAt(pid);  //remove disappear process pid
                 if(m_simpleSet.contains(pid))
                     m_simpleSet.remove(pid);
+                //for each pid,only one process reflected.So "removeOne()"func replied.
                 if(m_pidMyApps.contains(pid))
-                    m_pidMyApps.removeAt(pid);
+                    m_pidMyApps.removeOne(pid);
             }
         }
 


### PR DESCRIPTION
the app add a blank proc while some apps closed.

Log: the dsm cant delete the closed proc on ui
Bug: https://pms.uniontech.com/bug-view-226579.html