### PR TITLE
fix: 修复系统监视器中强制结束防杀进程失败后，弹出多次提示窗口的问题

### DIFF
--- a/deepin-system-monitor-main/process/process_db.cpp
+++ b/deepin-system-monitor-main/process/process_db.cpp
@@ -290,6 +290,7 @@ void ProcessDB::sendSignalToProcess(pid_t pid, int signal)
                          errno,
                          QApplication::translate("Process.Signal", "Failed in sending signal to process"),
                          pid, SIGCONT, ec);
+                qWarning() << "Failed in sending signal to process! process id:" << pid;
                 Q_EMIT processControlResultReady(ec);
                 return;
             }


### PR DESCRIPTION
Description: 修复系统监视器中强制结束防杀进程失败后，弹出多次提示窗口的问题

Log: 修修复系统监视器中强制结束防杀进程失败后，弹出多次提示窗口的问题

Bug: https://pms.uniontech.com/bug-view-245061.html