### PR TITLE
chore: 适配含有内外边界的blurEffectWidget

### DIFF
--- a/deepin-system-monitor-plugin-popup/gui/mainwindow.cpp
+++ b/deepin-system-monitor-plugin-popup/gui/mainwindow.cpp
@@ -42,7 +42,11 @@ const QString KILL_DBUS_COMMAND = "killall deepin-system-monitor-plugin-popup";
 
 
 MainWindow::MainWindow(QWidget *parent)
+#ifdef DTKWIDGET_CLASS_DBlurEffectWithBorderWidget
+    : DBlurEffectWithBorderWidget(parent)
+#else
     : DBlurEffectWidget(parent)
+#endif
     , m_displayInter(new QDBusInterface(common::systemInfo().DISPLAY_SERVICE,
                                         common::systemInfo().DISPLAY_PATH,
                                         common::systemInfo().DISPLAY_INTERFACE,

--- a/deepin-system-monitor-plugin-popup/gui/mainwindow.h
+++ b/deepin-system-monitor-plugin-popup/gui/mainwindow.h
@@ -20,7 +20,11 @@
 
 // Qt
 #include <QListView>
+#ifdef DTKWIDGET_CLASS_DBlurEffectWithBorderWidget
+#include <DBlurEffectWithBorderWidget>
+#else
 #include <DBlurEffectWidget>
+#endif
 #include <DRegionMonitor>
 #include <DWidget>
 #include <DScrollArea>
@@ -37,7 +41,11 @@ QT_FORWARD_DECLARE_CLASS(QSequentialAnimationGroup)
  * \~chinese \class MainWindow
  * \~chinese \brief 主窗口类
  */
+#ifdef DTKWIDGET_CLASS_DBlurEffectWithBorderWidget
+class MainWindow : public DBlurEffectWithBorderWidget
+#else
 class MainWindow : public DBlurEffectWidget
+#endif
 {
     Q_OBJECT
     Q_PROPERTY(int width READ getWidth WRITE setFixedWidth)


### PR DESCRIPTION
由于在blurEffectWidget的paintEvent中绘制内边界,边界会属于窗口内,当内边界带透明度时,会透过窗口下的颜色,必须在 blurEffectWidget的painterEvent之后再绘制边界
此需求需要应用适配,将DBlurEffectWidget替换为DBlurEffectWithBorderWidget即可

Log: 适配含有内外边界的blurEffectWidget