### PR TITLE
feat: 适配任务栏图标激活状态

### DIFF
--- a/deepin-system-monitor-plugin-popup/dbus/systemmonitordbusadaptor.h
+++ b/deepin-system-monitor-plugin-popup/dbus/systemmonitordbusadaptor.h
@@ -24,6 +24,10 @@ public slots:
 
 signals:
     Q_SCRIPTABLE void sigSendShowOrHideSystemMonitorPluginPopupWidget();
+    //!
+    //! \brief sysMonPopVisibleChanged 系统监视器弹窗显示状态改变
+    //!
+    Q_SCRIPTABLE void sysMonPopVisibleChanged(bool);
 };
 
 #endif // SYSTEMMONITORDBUSADAPTOR_H

--- a/deepin-system-monitor-plugin-popup/gui/mainwindow.cpp
+++ b/deepin-system-monitor-plugin-popup/gui/mainwindow.cpp
@@ -28,6 +28,8 @@
 #include <QApplication>
 #include <QPalette>
 #include <QTimer>
+#include <QShowEvent>
+#include <QHideEvent>
 
 #define DOCK_TOP        0
 #define DOCK_RIGHT      1
@@ -336,6 +338,10 @@ void MainWindow::initConnect()
     connect(m_systemMonitorDbusAdaptor, &SystemMonitorDBusAdaptor::sigSendShowOrHideSystemMonitorPluginPopupWidget,
             this, &MainWindow::slotShowOrHideSystemMonitorPluginPopupWidget);
 
+    //系统监视器弹窗显示状态改变
+    connect(this, &MainWindow::sysMonPopVisibleChanged,
+            m_systemMonitorDbusAdaptor, &SystemMonitorDBusAdaptor::sysMonPopVisibleChanged);
+
     connect(DWindowManagerHelper::instance(), &DWindowManagerHelper::hasCompositeChanged, this, &MainWindow::CompositeChanged, Qt::QueuedConnection);
 
     connect(m_widthAni, &QVariantAnimation::valueChanged, this, [ = ](const QVariant & value) {
@@ -591,5 +597,17 @@ void MainWindow::mouseMoveEvent(QMouseEvent *event)
 void MainWindow::slotShowOrHideSystemMonitorPluginPopupWidget()
 {
     QTimer::singleShot(0, this, &MainWindow::Toggle);
+}
+
+void MainWindow::showEvent(QShowEvent *event)
+{
+    Q_EMIT sysMonPopVisibleChanged(true);
+    QWidget::showEvent(event);
+}
+
+void MainWindow::hideEvent(QHideEvent *event)
+{
+    Q_EMIT sysMonPopVisibleChanged(false);
+    QWidget::hideEvent(event);
 }
 

--- a/deepin-system-monitor-plugin-popup/gui/mainwindow.h
+++ b/deepin-system-monitor-plugin-popup/gui/mainwindow.h
@@ -50,12 +50,19 @@ class MainWindow : public DBlurEffectWidget
     Q_OBJECT
     Q_PROPERTY(int width READ getWidth WRITE setFixedWidth)
     Q_PROPERTY(int x WRITE setX)
+    Q_PROPERTY(bool sysMonPopVisible READ sysMonPopVisible NOTIFY sysMonPopVisibleChanged)
+
 public:
     explicit MainWindow(QWidget *parent = nullptr);
     ~MainWindow() override;
 
 Q_SIGNALS:
     void signal_geometry(int height);
+    /*!
+     * \brief sysMonPopVisibleChanged 系统监视器弹窗显示状态改变
+     * \param visible
+     */
+    void sysMonPopVisibleChanged(bool visible);
 
 public Q_SLOTS:
     /*!
@@ -98,6 +105,12 @@ private Q_SLOTS:
     void CompositeChanged();
 
     void registerMonitor();
+
+    /*!
+     * \brief sysMonPopVisible 系统监视器弹窗显示状态
+     * \return
+     */
+    bool sysMonPopVisible() const{ return isVisible();}
 
 private:
     /*!
@@ -143,6 +156,8 @@ protected:
 
     virtual bool eventFilter(QObject *object, QEvent *event) override;
 
+    virtual void showEvent(QShowEvent *event) override;
+    virtual void hideEvent(QHideEvent *event) override;
 private slots:
     void slotShowOrHideSystemMonitorPluginPopupWidget();
     //!

--- a/deepin-system-monitor-plugin/gui/monitor_plugin.h
+++ b/deepin-system-monitor-plugin/gui/monitor_plugin.h
@@ -188,6 +188,8 @@ public:
     //! the flags for the plugin
     //!
     Dock::PluginFlags flags() const  { return Dock::Type_Quick | Dock::Quick_Panel_Single | Dock::Attribute_Normal; }
+    //此接口只有在PluginsItemInterfaceV2下才可用
+    virtual void setMessageCallback(MessageCallbackFunc cb) override { m_messageCallback = cb; }
 #endif
 
 private slots:
@@ -206,6 +208,11 @@ private slots:
     //! \brief onClickQuickPanel mouse event active
     //!
     void onClickQuickPanel();
+
+    //!
+    //! \brief onSysMonPopVisibleChanged 系统监视器弹窗显示状态改变
+    //!
+    void onSysMonPopVisibleChanged(bool);
 #endif
 
 private:
@@ -255,6 +262,8 @@ private:
 private:
 #ifdef USE_API_QUICKPANEL20
     QuickPanelWidget *m_quickPanelWidget;
+    //此类型(MessageCallbackFunc)属于PluginsItemInterfaceV2
+    MessageCallbackFunc m_messageCallback;
 #endif
 
     bool m_pluginLoaded;


### PR DESCRIPTION
适配任务栏图标激活状态，系统监视器打开的时候任务栏图标显示为激活状态

Log: 适配任务栏图标激活状态，系统监视器打开的时候任务栏图标显示为激活状态

Task: https://pms.uniontech.com/task-view-331683.html