### PR TITLE
chore: Bump version to 6.0.17

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+deepin-system-monitor (6.0.17) unstable; urgency=medium
+
+  * fix: delay in reading system information in the plug-in (#325)
+  * chore: Adapt blurEffectWidget with inner and outer borders
+  * feat: Adapt taskbar icon activation status (#327) (Task: 331683)
+
+ -- renbin <renbin@uniontech.com>  Wed, 27 Mar 2024 15:23:42 +0800
+
 deepin-system-monitor (6.0.16) unstable; urgency=medium
 
   * New version 6.0.16.


### PR DESCRIPTION
Bump version to 6.0.17
PR:
* https://github.com/linuxdeepin/deepin-system-monitor/pull/325
* https://github.com/linuxdeepin/deepin-system-monitor/pull/326
* https://github.com/linuxdeepin/deepin-system-monitor/pull/327

Log: Bump version to 6.0.17