### PR TITLE
chore: Bump version to 6.0.18

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-system-monitor (6.0.18) unstable; urgency=medium
+
+  * feat: Block the system monitor plugin.(Task: 30767)
+
+ -- renbin <renbin@uniontech.com>  Wed, 10 Apr 2024 15:56:41 +0800
+
 deepin-system-monitor (6.0.17) unstable; urgency=medium
 
   * fix: delay in reading system information in the plug-in (#325)


### PR DESCRIPTION
Bump version to 6.0.18
PR:
* fix: 暂时屏蔽系统监视器插件 (#329)

Log: Bump version to 6.0.18