### PR TITLE
fix: 修复非GUI线程调用 update() 函数 

### DIFF
--- a/deepin-system-monitor-main/gui/base/base_table_view.cpp
+++ b/deepin-system-monitor-main/gui/base/base_table_view.cpp
@@ -23,7 +23,6 @@
 #include <QScrollerProperties>
 #include <QScrollBar>
 #include <QFocusEvent>
-#include <QTimer>
 
 #define HEADER_MIN_SECTION_SIZE 120
 
@@ -88,7 +87,6 @@ BaseTableView::BaseTableView(DWidget *parent)
     QScroller::grabGesture(viewport(), QScroller::TouchGesture);
     //set horizontalScrollbar always visible
     setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
-    m_currtDataTime = QDateTime::currentDateTime();
 }
 
 // set view model

--- a/deepin-system-monitor-main/gui/base/base_table_view.cpp
+++ b/deepin-system-monitor-main/gui/base/base_table_view.cpp
@@ -27,9 +27,6 @@
 
 #define HEADER_MIN_SECTION_SIZE 120
 
-// Force repaint update interval 1000ms/60
-constexpr int s_RepaintInterval = 600000;
-
 // default constructor
 BaseTableView::BaseTableView(DWidget *parent)
     : DTreeView(parent)
@@ -283,11 +280,7 @@ void BaseTableView::currentChanged(const QModelIndex &current, const QModelIndex
         previousRect.setX(0);
         previousRect.setWidth(viewport()->width());
         previousRect.adjust(-1, -1, 1, 1);
-        if (delayRepaint()) {
-            QTimer::singleShot(0, this, [this] {repaint();});
-        } else {
-            viewport()->update(previousRect);
-        }
+        viewport()->update(previousRect);
     }
     // update current item's paint region
     if (current.isValid()) {
@@ -295,11 +288,7 @@ void BaseTableView::currentChanged(const QModelIndex &current, const QModelIndex
         currentRect.setX(0);
         currentRect.setWidth(viewport()->width());
         currentRect.adjust(-1, -1, 1, 1);
-        if (delayRepaint()) {
-            QTimer::singleShot(0, this, [this] {repaint();});
-        } else {
-            viewport()->update(currentRect);
-        }
+        viewport()->update(currentRect);
     }
 }
 
@@ -314,11 +303,7 @@ bool BaseTableView::viewportEvent(QEvent *event)
             rect.setX(0);
             rect.setWidth(viewport()->width());
             m_hover = QModelIndex();
-            if (delayRepaint()) {
-                QTimer::singleShot(0, this, [this] {repaint();});
-            } else {
-                viewport()->update(rect);
-            }
+            viewport()->update(rect);
         }
         break;
     }
@@ -333,22 +318,14 @@ bool BaseTableView::viewportEvent(QEvent *event)
                 auto rect = visualRect(oldHover);
                 rect.setX(0);
                 rect.setWidth(viewport()->width());
-                if (delayRepaint()) {
-                    QTimer::singleShot(0, this, [this] {repaint();});
-                } else {
-                    viewport()->update(rect);
-                }
+                viewport()->update(rect);
             }
         }
         if (m_hover.isValid()) {
             auto rect = visualRect(m_hover);
             rect.setX(0);
             rect.setWidth(viewport()->width());
-            if (delayRepaint()) {
-                QTimer::singleShot(0, this, [this] {repaint();});
-            } else {
-                viewport()->update(rect);
-            }
+            viewport()->update(rect);
         }
         break;
     }
@@ -375,11 +352,7 @@ bool BaseTableView::viewportEvent(QEvent *event)
         }
         // only left mouse button events (click & double click) need refresh
         m_pressed = (mev->button() == Qt::LeftButton && (mev->type() == QEvent::MouseButtonPress || mev->type() == QEvent::MouseButtonDblClick)) ? newIndex : QModelIndex();
-        if (delayRepaint()) {
-            QTimer::singleShot(0, this, [this] {repaint();});
-        } else {
-            viewport()->update(region);
-        }
+        viewport()->update(region);
         break;
     }
     case QEvent::TouchEnd: {
@@ -419,9 +392,6 @@ void BaseTableView::scrollTo(const QModelIndex &index, QAbstractItemView::Scroll
                                   indexRowSizeHint(index) * index.row() - verticalScrollBar()->value(),
                                   viewport()->width(),
                                   indexRowSizeHint(index)});
-        if (delayRepaint()) {
-            QTimer::singleShot(0, this, [this] {repaint();});
-        }
         // nothing to do
     } else {
         // current item above viewport rect
@@ -444,14 +414,3 @@ void BaseTableView::scrollTo(const QModelIndex &index, QAbstractItemView::Scroll
         verticalScrollBar()->setValue(verticalValue);
     }
 }
-
-bool BaseTableView::delayRepaint()
-{
-    qint64 currentMS = m_currtDataTime.msecsTo(QDateTime::currentDateTime());
-    if (currentMS >= s_RepaintInterval) {
-        m_currtDataTime = QDateTime::currentDateTime();
-        return true;
-    }
-    return false;
-}
-

--- a/deepin-system-monitor-main/gui/base/base_table_view.h
+++ b/deepin-system-monitor-main/gui/base/base_table_view.h
@@ -7,8 +7,6 @@
 #define BASE_TABLE_VIEW_H
 
 #include <DTreeView>
-#include <QBasicTimer>
-#include <QDateTime>
 
 DWIDGET_USE_NAMESPACE
 
@@ -74,13 +72,6 @@ protected:
      */
     void scrollTo(const QModelIndex &index, ScrollHint hint = EnsureVisible) override;
 
-
-private:
-    /**
-       @brief Delay force repaint widget
-     */
-    bool delayRepaint();
-
 private:
     // Common styled item delegate for this table view
     BaseItemDelegate *m_itemDelegate {nullptr};
@@ -93,8 +84,6 @@ private:
     QModelIndex m_pressed;
 
     int m_focusReason = Qt::TabFocusReason;
-
-    QDateTime    m_currtDataTime;
 };
 
 #endif  // BASE_TABLE_VIEW_H

--- a/deepin-system-monitor-main/gui/process_page_widget.cpp
+++ b/deepin-system-monitor-main/gui/process_page_widget.cpp
@@ -288,7 +288,8 @@ void ProcessPageWidget::initConnections()
 
     // update process summary text when process summary info updated background
     auto *monitor = ThreadManager::instance()->thread<SystemMonitorThread>(BaseThread::kSystemMonitorThread)->systemMonitorInstance();
-    connect(monitor, &SystemMonitor::statInfoUpdated, this, &ProcessPageWidget::onStatInfoUpdated, Qt::DirectConnection);
+    // Note: do not update on non-GUI thread.
+    connect(monitor, &SystemMonitor::appAndProcCountUpdate, this, &ProcessPageWidget::onAppAndProcCountUpdated);
 
     auto *dAppHelper = DApplicationHelper::instance();
     // change text color dynamically on theme type change, if not do this way, text color wont synchronize with theme type
@@ -408,27 +409,10 @@ void ProcessPageWidget::createWindowKiller()
             &ProcessPageWidget::popupKillConfirmDialog);
 }
 
-void ProcessPageWidget::onStatInfoUpdated()
+void ProcessPageWidget::onAppAndProcCountUpdated(int appCount, int procCount)
 {
-    QApplication::processEvents();
     const QString &buf = DApplication::translate("Process.Summary", kProcSummaryTemplateText);
-
-    ProcessSet *processSet = ProcessDB::instance()->processSet();
-    //记录所有进程数量
-    const QList<pid_t> &newpidlst = processSet->getPIDList();
-    m_iallProcNum = newpidlst.size();
-    int appCount = 0;
-    for (const auto &pid : newpidlst) {
-        auto process = processSet->getProcessById(pid);
-        if (process.appType() == kFilterApps)
-            appCount++;
-    }
-    m_procViewModeSummary->setText(buf.arg(appCount).arg(m_iallProcNum));
-    m_model = CPUInfoModel::instance();
-
-//    CPUPerformance = (m_model->cpuSet()->maxFreq() > CPU_FREQUENCY_STANDARD) ? High : Low;
-    //qInfo() << m_model->cpuSet()->maxFreq()  << (m_model->cpuSet()->maxFreq() > CPU_FREQUENCY_STANDARD) << CPUPerformance;
-
+    m_procViewModeSummary->setText(buf.arg(appCount).arg(procCount));
 }
 
 // change icon theme when theme changed

--- a/deepin-system-monitor-main/gui/process_page_widget.h
+++ b/deepin-system-monitor-main/gui/process_page_widget.h
@@ -107,9 +107,9 @@ private Q_SLOTS:
     void changeIconTheme(DApplicationHelper::ColorType themeType);
 
     /**
-     * @brief 列表数据刷新
+     * @brief 列表数据刷新，更新应用和进程统计
      */
-    void onStatInfoUpdated();
+    void onAppAndProcCountUpdated(int appCount, int procCount);
 
     /**
      * @brief 详情页切换

--- a/deepin-system-monitor-main/system/system_monitor.h
+++ b/deepin-system-monitor-main/system/system_monitor.h
@@ -30,6 +30,7 @@ class SystemMonitor : public QObject
 
 signals:
     void statInfoUpdated();
+    void appAndProcCountUpdate(int appCount, int procCount);
 
 public:
     explicit SystemMonitor(QObject *parent = nullptr);
@@ -48,6 +49,7 @@ protected:
 
 private:
     void updateSystemMonitorInfo();
+    void recountAppAndProcess();
 
 private:
     SysInfo      *m_sysInfo;


### PR DESCRIPTION
非GUI线程间接调用了update()函数, update()内部的
处理函数会调用markDirty()更新脏控件列表，但是
dirtyWidget(QVector)在多线程访问时可能无法正确
更新数据，导致widget的inDirtyList标识为true，
但dirtyWidget后续未正确的复位标识。
在QWidgetBackingStore::doSync()中一直无法正确的
将绘制数据刷新。
调整onStatInfoUpdated()中的setText()函数到GUI线程。

Log: 修复界面刷新显示问题
Bug: https://pms.uniontech.com/bug-view-247719.html

同时回退之前的临时修改