### PR TITLE
fix: 修复非GUI线程调用 update() 函数

### DIFF
--- a/deepin-system-monitor-main/gui/process_page_widget.h
+++ b/deepin-system-monitor-main/gui/process_page_widget.h
@@ -107,9 +107,9 @@ private Q_SLOTS:
     void changeIconTheme(DApplicationHelper::ColorType themeType);
 
     /**
-     * @brief 列表数据刷新
+     * @brief 列表数据刷新，更新应用和进程统计
      */
-    void onStatInfoUpdated();
+    void onAppAndProcCountUpdated(int appCount, int procCount);
 
     /**
      * @brief 详情页切换

--- a/deepin-system-monitor-main/system/system_monitor.cpp
+++ b/deepin-system-monitor-main/system/system_monitor.cpp
@@ -25,7 +25,6 @@ SystemMonitor::SystemMonitor(QObject *parent)
     , m_processDB(new ProcessDB(this))
 {
     m_sysInfo->readSysInfoStatic();
-
 }
 
 SystemMonitor::~SystemMonitor()
@@ -84,6 +83,7 @@ void SystemMonitor::timerEvent(QTimerEvent *event)
             m_processDB->update();
         } else {
             emit statInfoUpdated();
+            recountAppAndProcess();
         }
         if(cnt++ >250)
             cnt = 0;
@@ -97,6 +97,25 @@ void SystemMonitor::updateSystemMonitorInfo()
     m_processDB->update();
 
     emit statInfoUpdated();
+    recountAppAndProcess();
+}
+
+/**
+   @brief Count current apps and processes on SystemMonitor child thread.
+ */
+void SystemMonitor::recountAppAndProcess()
+{
+    ProcessSet *processSet = m_processDB->processSet();
+    // count all app
+    const QList<pid_t> &newpidlst = processSet->getPIDList();
+    int appCount = 0;
+    for (const auto &pid : newpidlst) {
+        auto process = processSet->getProcessById(pid);
+        if (process.appType() == kFilterApps)
+            appCount++;
+    }
+
+    emit appAndProcCountUpdate(appCount, newpidlst.size());
 }
 
 } // namespace system

--- a/deepin-system-monitor-main/system/system_monitor.h
+++ b/deepin-system-monitor-main/system/system_monitor.h
@@ -30,6 +30,7 @@ class SystemMonitor : public QObject
 
 signals:
     void statInfoUpdated();
+    void appAndProcCountUpdate(int appCount, int procCount);
 
 public:
     explicit SystemMonitor(QObject *parent = nullptr);
@@ -48,6 +49,7 @@ protected:
 
 private:
     void updateSystemMonitorInfo();
+    void recountAppAndProcess();
 
 private:
     SysInfo      *m_sysInfo;


### PR DESCRIPTION
非GUI线程间接调用了update()函数, update()内部的
处理函数会调用markDirty()更新脏控件列表，但是
dirtyWidget(QVector)在多线程访问时可能无法正确
更新数据，导致widget的inDirtyList标识为true，
但dirtyWidget后续未正确的复位标识。
在QWidgetBackingStore::doSync()中一直无法正确的
将绘制数据刷新。
移动onStatInfoUpdated()计算逻辑到子线程类中，
界面更新移动到GUI线程.

Log: 修复界面刷新显示问题
Bug: https://pms.uniontech.com/bug-view-247719.html
Change-Id: Ic033097bb7010363bc4ee1768340812231b9c4d1