### PR TITLE
fix: in the Community Edition, right clicking to modify the account i…

### DIFF
--- a/deepin-system-monitor-main/model/accounts_info_model.cpp
+++ b/deepin-system-monitor-main/model/accounts_info_model.cpp
@@ -230,6 +230,14 @@ bool AccountsInfoModel::LogoutByUserName(const QString &userName)
 
 void AccountsInfoModel::EditAccount()
 {
-    if (m_controlInter)
-        m_controlInter->call("ShowPage", "accounts", "Accounts Detail");
+    if (m_controlInter) {
+        bool version = common::systemInfo().isOldVersion();
+        if (version) {
+            //专业版v20接口：ShowPage(String module, String page)
+            m_controlInter->call("ShowPage", "accounts", "Accounts Detail");
+        } else if (!version) {
+            //社区版V23接口：ShowPage(String url)
+            m_controlInter->call("ShowPage", "accounts");
+        }
+    }
 }


### PR DESCRIPTION
…nformation has no reaction

Determine the system version and pass different parameters to the DBUS interface ShowPage according to the version.

Log: in the Community Edition, right clicking to modify the account information has no reaction
Bug: https://pms.uniontech.com/bug-view-252625.html