### PR TITLE
fix: fix fail to kill linglong app

### DIFF
--- a/deepin-system-monitor-main/gui/main_window.h
+++ b/deepin-system-monitor-main/gui/main_window.h
@@ -85,6 +85,11 @@ public Q_SLOTS:
      */
     void popupSettingsDialog();
 
+    /**
+     * @brief onKillProcess
+     */
+    void onKillProcess();
+
 protected:
     /**
      * @brief Initialize ui components

--- a/deepin-system-monitor-main/gui/process_page_widget.cpp
+++ b/deepin-system-monitor-main/gui/process_page_widget.cpp
@@ -270,8 +270,8 @@ void ProcessPageWidget::initConnections()
 {
     auto *mainWindow = gApp->mainWindow();
     // kill application signal triggered, show application kill preview widget
-    connect(mainWindow, &MainWindow::killProcessPerformed, this,
-            &ProcessPageWidget::showWindowKiller);
+    // connect(mainWindow, &MainWindow::killProcessPerformed, this,
+    //         &ProcessPageWidget::showWindowKiller);
     // switch display mode signal triggered, switch performance display mode
     connect(mainWindow, &MainWindow::displayModeChanged, this,
             &ProcessPageWidget::switchDisplayMode);


### PR DESCRIPTION
Previously, when killing an application, system-monitor needed to obtain the pid of the app. However, on a desktop environment using X11, system-monitor obtained an inaccurate pid of the linglong app, which resulted in failure to kill the app or accidental killing. Now consider using the window manager to kill the application, because the window manager contains detailed information about the application window.

Log: fix fail to kill linglong app
Bug: https://pms.uniontech.com/bug-view-283189.html