### PR TITLE
chore: add DConfig wrapper classes for system monitor components (#384)

### DIFF
--- a/deepin-system-monitor-daemon/configs/json/org_deepin_system-monitor_daemon.hpp
+++ b/deepin-system-monitor-daemon/configs/json/org_deepin_system-monitor_daemon.hpp
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: 2024 - 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef ORG_DEEPIN_SYSTEM-MONITOR_DAEMON_H
+#define ORG_DEEPIN_SYSTEM-MONITOR_DAEMON_H
+
+#include <QThread>
+#include <QVariant>
+#include <QDebug>
+#include <QAtomicPointer>
+#include <QAtomicInteger>
+#include <DConfig>
+
+class org_deepin_system-monitor_daemon : public QObject {
+    Q_OBJECT
+
+    Q_PROPERTY(QString log_rules READ log_rules WRITE setLog_rules NOTIFY log_rulesChanged)
+public:
+    explicit org_deepin_system-monitor_daemon(QThread *thread, const QString &appId, const QString &name, const QString &subpath, QObject *parent = nullptr)
+        : QObject(parent) {
+
+        if (!thread->isRunning()) {
+            qWarning() << QStringLiteral("Warning: The provided thread is not running.");
+        }
+        Q_ASSERT(QThread::currentThread() != thread);
+        auto worker = new QObject();
+        worker->moveToThread(thread);
+        QMetaObject::invokeMethod(worker, [=]() {
+            auto config = DTK_CORE_NAMESPACE::DConfig::create(appId, name, subpath, nullptr);
+            if (!config) {
+                qWarning() << QStringLiteral("Failed to create DConfig instance.");
+                worker->deleteLater();
+                return;
+            }
+            config->moveToThread(QThread::currentThread());
+            initialize(config);
+            worker->deleteLater();
+        });
+    }
+    explicit org_deepin_system-monitor_daemon(QThread *thread, DTK_CORE_NAMESPACE::DConfigBackend *backend, const QString &appId, const QString &name, const QString &subpath, QObject *parent = nullptr)
+        : QObject(parent) {
+
+        if (!thread->isRunning()) {
+            qWarning() << QStringLiteral("Warning: The provided thread is not running.");
+        }
+        Q_ASSERT(QThread::currentThread() != thread);
+        auto worker = new QObject();
+        worker->moveToThread(thread);
+        QMetaObject::invokeMethod(worker, [=]() {
+            auto config = DTK_CORE_NAMESPACE::DConfig::create(backend, appId, name, subpath, nullptr);
+            if (!config) {
+                qWarning() << QStringLiteral("Failed to create DConfig instance.");
+                worker->deleteLater();
+                return;
+            }
+            config->moveToThread(QThread::currentThread());
+            initialize(config);
+            worker->deleteLater();
+        });
+    }
+    explicit org_deepin_system-monitor_daemon(QThread *thread, const QString &name, const QString &subpath, QObject *parent = nullptr)
+        : QObject(parent) {
+
+        if (!thread->isRunning()) {
+            qWarning() << QStringLiteral("Warning: The provided thread is not running.");
+        }
+        Q_ASSERT(QThread::currentThread() != thread);
+        auto worker = new QObject();
+        worker->moveToThread(thread);
+        QMetaObject::invokeMethod(worker, [=]() {
+            auto config = DTK_CORE_NAMESPACE::DConfig::create(name, subpath, nullptr);
+            if (!config) {
+                qWarning() << QStringLiteral("Failed to create DConfig instance.");
+                worker->deleteLater();
+                return;
+            }
+            config->moveToThread(QThread::currentThread());
+            initialize(config);
+            worker->deleteLater();
+        });
+    }
+    explicit org_deepin_system-monitor_daemon(QThread *thread, DTK_CORE_NAMESPACE::DConfigBackend *backend, const QString &name, const QString &subpath, QObject *parent = nullptr)
+        : QObject(parent) {
+
+        if (!thread->isRunning()) {
+            qWarning() << QStringLiteral("Warning: The provided thread is not running.");
+        }
+        Q_ASSERT(QThread::currentThread() != thread);
+        auto worker = new QObject();
+        worker->moveToThread(thread);
+        QMetaObject::invokeMethod(worker, [=]() {
+            auto config = DTK_CORE_NAMESPACE::DConfig::create(backend, name, subpath, nullptr);
+            if (!config) {
+                qWarning() << QStringLiteral("Failed to create DConfig instance.");
+                worker->deleteLater();
+                return;
+            }
+            config->moveToThread(QThread::currentThread());
+            initialize(config);
+            worker->deleteLater();
+        });
+    }
+    ~org_deepin_system-monitor_daemon() {
+        if (m_config.loadRelaxed()) {
+            m_config.loadRelaxed()->deleteLater();
+        }
+    }
+
+    QString log_rules() const {
+        return p_log_rules;
+    }
+    void setLog_rules(const QString &value) {
+        auto oldValue = p_log_rules;
+        p_log_rules = value;
+        markPropertySet(0);
+        if (auto config = m_config.loadRelaxed()) {
+            QMetaObject::invokeMethod(config, [this, value]() {
+                m_config.loadRelaxed()->setValue(QStringLiteral("log_rules"), value);
+            });
+        }
+        if (p_log_rules != oldValue) {
+            Q_EMIT log_rulesChanged();
+        }
+    }
+Q_SIGNALS:
+    void log_rulesChanged();
+private:
+    void initialize(DTK_CORE_NAMESPACE::DConfig *config) {
+        Q_ASSERT(!m_config.loadRelaxed());
+        m_config.storeRelaxed(config);
+        if (testPropertySet(0)) {
+            config->setValue(QStringLiteral("log_rules"), QVariant::fromValue(p_log_rules));
+        } else {
+            updateValue(QStringLiteral("log_rules"), QVariant::fromValue(p_log_rules));
+        }
+
+        connect(config, &DTK_CORE_NAMESPACE::DConfig::valueChanged, this, [this](const QString &key) {
+            updateValue(key);
+        }, Qt::DirectConnection);
+    }
+    void updateValue(const QString &key, const QVariant &fallback = QVariant()) {
+        Q_ASSERT(QThread::currentThread() == m_config.loadRelaxed()->thread());
+        const QVariant &value = m_config.loadRelaxed()->value(key, fallback);
+        if (key == QStringLiteral("log_rules")) {
+            auto newValue = qvariant_cast<QString>(value);
+            QMetaObject::invokeMethod(this, [this, newValue]() {
+                if (p_log_rules != newValue) {
+                    p_log_rules = newValue;
+                    Q_EMIT log_rulesChanged();
+                }
+            });
+            return;
+        }
+    }
+    inline void markPropertySet(const int index) {
+        if (index < 32) {
+            m_propertySetStatus0.fetchAndOrOrdered(1 << (index - 0));
+            return;
+        }
+        Q_UNREACHABLE();
+    }
+    inline bool testPropertySet(const int index) const {
+        if (index < 32) {
+            return (m_propertySetStatus0.loadRelaxed() & (1 << (index - 0)));
+        }
+        Q_UNREACHABLE();
+    }
+    QAtomicPointer<DTK_CORE_NAMESPACE::DConfig> m_config = nullptr;
+    QString p_log_rules { QStringLiteral("*.debug=false;*.info=false;*.warning=true") };
+    QAtomicInteger<quint32> m_propertySetStatus0 = 0;
+};
+
+#endif // ORG_DEEPIN_SYSTEM-MONITOR_DAEMON_H

--- a/deepin-system-monitor-main/configs/json/org_deepin_system-monitor.hpp
+++ b/deepin-system-monitor-main/configs/json/org_deepin_system-monitor.hpp
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: 2024 - 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef ORG_DEEPIN_SYSTEM-MONITOR_H
+#define ORG_DEEPIN_SYSTEM-MONITOR_H
+
+#include <QThread>
+#include <QVariant>
+#include <QDebug>
+#include <QAtomicPointer>
+#include <QAtomicInteger>
+#include <DConfig>
+
+class org_deepin_system-monitor : public QObject {
+    Q_OBJECT
+
+    Q_PROPERTY(QString log_rules READ log_rules WRITE setLog_rules NOTIFY log_rulesChanged)
+public:
+    explicit org_deepin_system-monitor(QThread *thread, const QString &appId, const QString &name, const QString &subpath, QObject *parent = nullptr)
+        : QObject(parent) {
+
+        if (!thread->isRunning()) {
+            qWarning() << QStringLiteral("Warning: The provided thread is not running.");
+        }
+        Q_ASSERT(QThread::currentThread() != thread);
+        auto worker = new QObject();
+        worker->moveToThread(thread);
+        QMetaObject::invokeMethod(worker, [=]() {
+            auto config = DTK_CORE_NAMESPACE::DConfig::create(appId, name, subpath, nullptr);
+            if (!config) {
+                qWarning() << QStringLiteral("Failed to create DConfig instance.");
+                worker->deleteLater();
+                return;
+            }
+            config->moveToThread(QThread::currentThread());
+            initialize(config);
+            worker->deleteLater();
+        });
+    }
+    explicit org_deepin_system-monitor(QThread *thread, DTK_CORE_NAMESPACE::DConfigBackend *backend, const QString &appId, const QString &name, const QString &subpath, QObject *parent = nullptr)
+        : QObject(parent) {
+
+        if (!thread->isRunning()) {
+            qWarning() << QStringLiteral("Warning: The provided thread is not running.");
+        }
+        Q_ASSERT(QThread::currentThread() != thread);
+        auto worker = new QObject();
+        worker->moveToThread(thread);
+        QMetaObject::invokeMethod(worker, [=]() {
+            auto config = DTK_CORE_NAMESPACE::DConfig::create(backend, appId, name, subpath, nullptr);
+            if (!config) {
+                qWarning() << QStringLiteral("Failed to create DConfig instance.");
+                worker->deleteLater();
+                return;
+            }
+            config->moveToThread(QThread::currentThread());
+            initialize(config);
+            worker->deleteLater();
+        });
+    }
+    explicit org_deepin_system-monitor(QThread *thread, const QString &name, const QString &subpath, QObject *parent = nullptr)
+        : QObject(parent) {
+
+        if (!thread->isRunning()) {
+            qWarning() << QStringLiteral("Warning: The provided thread is not running.");
+        }
+        Q_ASSERT(QThread::currentThread() != thread);
+        auto worker = new QObject();
+        worker->moveToThread(thread);
+        QMetaObject::invokeMethod(worker, [=]() {
+            auto config = DTK_CORE_NAMESPACE::DConfig::create(name, subpath, nullptr);
+            if (!config) {
+                qWarning() << QStringLiteral("Failed to create DConfig instance.");
+                worker->deleteLater();
+                return;
+            }
+            config->moveToThread(QThread::currentThread());
+            initialize(config);
+            worker->deleteLater();
+        });
+    }
+    explicit org_deepin_system-monitor(QThread *thread, DTK_CORE_NAMESPACE::DConfigBackend *backend, const QString &name, const QString &subpath, QObject *parent = nullptr)
+        : QObject(parent) {
+
+        if (!thread->isRunning()) {
+            qWarning() << QStringLiteral("Warning: The provided thread is not running.");
+        }
+        Q_ASSERT(QThread::currentThread() != thread);
+        auto worker = new QObject();
+        worker->moveToThread(thread);
+        QMetaObject::invokeMethod(worker, [=]() {
+            auto config = DTK_CORE_NAMESPACE::DConfig::create(backend, name, subpath, nullptr);
+            if (!config) {
+                qWarning() << QStringLiteral("Failed to create DConfig instance.");
+                worker->deleteLater();
+                return;
+            }
+            config->moveToThread(QThread::currentThread());
+            initialize(config);
+            worker->deleteLater();
+        });
+    }
+    ~org_deepin_system-monitor() {
+        if (m_config.loadRelaxed()) {
+            m_config.loadRelaxed()->deleteLater();
+        }
+    }
+
+    QString log_rules() const {
+        return p_log_rules;
+    }
+    void setLog_rules(const QString &value) {
+        auto oldValue = p_log_rules;
+        p_log_rules = value;
+        markPropertySet(0);
+        if (auto config = m_config.loadRelaxed()) {
+            QMetaObject::invokeMethod(config, [this, value]() {
+                m_config.loadRelaxed()->setValue(QStringLiteral("log_rules"), value);
+            });
+        }
+        if (p_log_rules != oldValue) {
+            Q_EMIT log_rulesChanged();
+        }
+    }
+Q_SIGNALS:
+    void log_rulesChanged();
+private:
+    void initialize(DTK_CORE_NAMESPACE::DConfig *config) {
+        Q_ASSERT(!m_config.loadRelaxed());
+        m_config.storeRelaxed(config);
+        if (testPropertySet(0)) {
+            config->setValue(QStringLiteral("log_rules"), QVariant::fromValue(p_log_rules));
+        } else {
+            updateValue(QStringLiteral("log_rules"), QVariant::fromValue(p_log_rules));
+        }
+
+        connect(config, &DTK_CORE_NAMESPACE::DConfig::valueChanged, this, [this](const QString &key) {
+            updateValue(key);
+        }, Qt::DirectConnection);
+    }
+    void updateValue(const QString &key, const QVariant &fallback = QVariant()) {
+        Q_ASSERT(QThread::currentThread() == m_config.loadRelaxed()->thread());
+        const QVariant &value = m_config.loadRelaxed()->value(key, fallback);
+        if (key == QStringLiteral("log_rules")) {
+            auto newValue = qvariant_cast<QString>(value);
+            QMetaObject::invokeMethod(this, [this, newValue]() {
+                if (p_log_rules != newValue) {
+                    p_log_rules = newValue;
+                    Q_EMIT log_rulesChanged();
+                }
+            });
+            return;
+        }
+    }
+    inline void markPropertySet(const int index) {
+        if (index < 32) {
+            m_propertySetStatus0.fetchAndOrOrdered(1 << (index - 0));
+            return;
+        }
+        Q_UNREACHABLE();
+    }
+    inline bool testPropertySet(const int index) const {
+        if (index < 32) {
+            return (m_propertySetStatus0.loadRelaxed() & (1 << (index - 0)));
+        }
+        Q_UNREACHABLE();
+    }
+    QAtomicPointer<DTK_CORE_NAMESPACE::DConfig> m_config = nullptr;
+    QString p_log_rules { QStringLiteral("*.debug=false;*.info=false;*.warning=true") };
+    QAtomicInteger<quint32> m_propertySetStatus0 = 0;
+};
+
+#endif // ORG_DEEPIN_SYSTEM-MONITOR_H

--- a/deepin-system-monitor-main/configs/json/org_deepin_system-monitor_main.hpp
+++ b/deepin-system-monitor-main/configs/json/org_deepin_system-monitor_main.hpp
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: 2024 - 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef ORG_DEEPIN_SYSTEM-MONITOR_MAIN_H
+#define ORG_DEEPIN_SYSTEM-MONITOR_MAIN_H
+
+#include <QThread>
+#include <QVariant>
+#include <QDebug>
+#include <QAtomicPointer>
+#include <QAtomicInteger>
+#include <DConfig>
+
+class org_deepin_system-monitor_main : public QObject {
+    Q_OBJECT
+
+    Q_PROPERTY(double specialComType READ specialComType WRITE setSpecialComType NOTIFY specialComTypeChanged)
+public:
+    explicit org_deepin_system-monitor_main(QThread *thread, const QString &appId, const QString &name, const QString &subpath, QObject *parent = nullptr)
+        : QObject(parent) {
+
+        if (!thread->isRunning()) {
+            qWarning() << QStringLiteral("Warning: The provided thread is not running.");
+        }
+        Q_ASSERT(QThread::currentThread() != thread);
+        auto worker = new QObject();
+        worker->moveToThread(thread);
+        QMetaObject::invokeMethod(worker, [=]() {
+            auto config = DTK_CORE_NAMESPACE::DConfig::create(appId, name, subpath, nullptr);
+            if (!config) {
+                qWarning() << QStringLiteral("Failed to create DConfig instance.");
+                worker->deleteLater();
+                return;
+            }
+            config->moveToThread(QThread::currentThread());
+            initialize(config);
+            worker->deleteLater();
+        });
+    }
+    explicit org_deepin_system-monitor_main(QThread *thread, DTK_CORE_NAMESPACE::DConfigBackend *backend, const QString &appId, const QString &name, const QString &subpath, QObject *parent = nullptr)
+        : QObject(parent) {
+
+        if (!thread->isRunning()) {
+            qWarning() << QStringLiteral("Warning: The provided thread is not running.");
+        }
+        Q_ASSERT(QThread::currentThread() != thread);
+        auto worker = new QObject();
+        worker->moveToThread(thread);
+        QMetaObject::invokeMethod(worker, [=]() {
+            auto config = DTK_CORE_NAMESPACE::DConfig::create(backend, appId, name, subpath, nullptr);
+            if (!config) {
+                qWarning() << QStringLiteral("Failed to create DConfig instance.");
+                worker->deleteLater();
+                return;
+            }
+            config->moveToThread(QThread::currentThread());
+            initialize(config);
+            worker->deleteLater();
+        });
+    }
+    explicit org_deepin_system-monitor_main(QThread *thread, const QString &name, const QString &subpath, QObject *parent = nullptr)
+        : QObject(parent) {
+
+        if (!thread->isRunning()) {
+            qWarning() << QStringLiteral("Warning: The provided thread is not running.");
+        }
+        Q_ASSERT(QThread::currentThread() != thread);
+        auto worker = new QObject();
+        worker->moveToThread(thread);
+        QMetaObject::invokeMethod(worker, [=]() {
+            auto config = DTK_CORE_NAMESPACE::DConfig::create(name, subpath, nullptr);
+            if (!config) {
+                qWarning() << QStringLiteral("Failed to create DConfig instance.");
+                worker->deleteLater();
+                return;
+            }
+            config->moveToThread(QThread::currentThread());
+            initialize(config);
+            worker->deleteLater();
+        });
+    }
+    explicit org_deepin_system-monitor_main(QThread *thread, DTK_CORE_NAMESPACE::DConfigBackend *backend, const QString &name, const QString &subpath, QObject *parent = nullptr)
+        : QObject(parent) {
+
+        if (!thread->isRunning()) {
+            qWarning() << QStringLiteral("Warning: The provided thread is not running.");
+        }
+        Q_ASSERT(QThread::currentThread() != thread);
+        auto worker = new QObject();
+        worker->moveToThread(thread);
+        QMetaObject::invokeMethod(worker, [=]() {
+            auto config = DTK_CORE_NAMESPACE::DConfig::create(backend, name, subpath, nullptr);
+            if (!config) {
+                qWarning() << QStringLiteral("Failed to create DConfig instance.");
+                worker->deleteLater();
+                return;
+            }
+            config->moveToThread(QThread::currentThread());
+            initialize(config);
+            worker->deleteLater();
+        });
+    }
+    ~org_deepin_system-monitor_main() {
+        if (m_config.loadRelaxed()) {
+            m_config.loadRelaxed()->deleteLater();
+        }
+    }
+
+    double specialComType() const {
+        return p_specialComType;
+    }
+    void setSpecialComType(const double &value) {
+        auto oldValue = p_specialComType;
+        p_specialComType = value;
+        markPropertySet(0);
+        if (auto config = m_config.loadRelaxed()) {
+            QMetaObject::invokeMethod(config, [this, value]() {
+                m_config.loadRelaxed()->setValue(QStringLiteral("specialComType"), value);
+            });
+        }
+        if (p_specialComType != oldValue) {
+            Q_EMIT specialComTypeChanged();
+        }
+    }
+Q_SIGNALS:
+    void specialComTypeChanged();
+private:
+    void initialize(DTK_CORE_NAMESPACE::DConfig *config) {
+        Q_ASSERT(!m_config.loadRelaxed());
+        m_config.storeRelaxed(config);
+        if (testPropertySet(0)) {
+            config->setValue(QStringLiteral("specialComType"), QVariant::fromValue(p_specialComType));
+        } else {
+            updateValue(QStringLiteral("specialComType"), QVariant::fromValue(p_specialComType));
+        }
+
+        connect(config, &DTK_CORE_NAMESPACE::DConfig::valueChanged, this, [this](const QString &key) {
+            updateValue(key);
+        }, Qt::DirectConnection);
+    }
+    void updateValue(const QString &key, const QVariant &fallback = QVariant()) {
+        Q_ASSERT(QThread::currentThread() == m_config.loadRelaxed()->thread());
+        const QVariant &value = m_config.loadRelaxed()->value(key, fallback);
+        if (key == QStringLiteral("specialComType")) {
+            auto newValue = qvariant_cast<double>(value);
+            QMetaObject::invokeMethod(this, [this, newValue]() {
+                if (p_specialComType != newValue) {
+                    p_specialComType = newValue;
+                    Q_EMIT specialComTypeChanged();
+                }
+            });
+            return;
+        }
+    }
+    inline void markPropertySet(const int index) {
+        if (index < 32) {
+            m_propertySetStatus0.fetchAndOrOrdered(1 << (index - 0));
+            return;
+        }
+        Q_UNREACHABLE();
+    }
+    inline bool testPropertySet(const int index) const {
+        if (index < 32) {
+            return (m_propertySetStatus0.loadRelaxed() & (1 << (index - 0)));
+        }
+        Q_UNREACHABLE();
+    }
+    QAtomicPointer<DTK_CORE_NAMESPACE::DConfig> m_config = nullptr;
+    double p_specialComType { -1 };
+    QAtomicInteger<quint32> m_propertySetStatus0 = 0;
+};
+
+#endif // ORG_DEEPIN_SYSTEM-MONITOR_MAIN_H

--- a/deepin-system-monitor-plugin-popup/configs/json/org_deepin_system-monitor_plugin_popup.hpp
+++ b/deepin-system-monitor-plugin-popup/configs/json/org_deepin_system-monitor_plugin_popup.hpp
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: 2024 - 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef ORG_DEEPIN_SYSTEM-MONITOR_PLUGIN_POPUP_H
+#define ORG_DEEPIN_SYSTEM-MONITOR_PLUGIN_POPUP_H
+
+#include <QThread>
+#include <QVariant>
+#include <QDebug>
+#include <QAtomicPointer>
+#include <QAtomicInteger>
+#include <DConfig>
+
+class org_deepin_system-monitor_plugin_popup : public QObject {
+    Q_OBJECT
+
+    Q_PROPERTY(QString log_rules READ log_rules WRITE setLog_rules NOTIFY log_rulesChanged)
+public:
+    explicit org_deepin_system-monitor_plugin_popup(QThread *thread, const QString &appId, const QString &name, const QString &subpath, QObject *parent = nullptr)
+        : QObject(parent) {
+
+        if (!thread->isRunning()) {
+            qWarning() << QStringLiteral("Warning: The provided thread is not running.");
+        }
+        Q_ASSERT(QThread::currentThread() != thread);
+        auto worker = new QObject();
+        worker->moveToThread(thread);
+        QMetaObject::invokeMethod(worker, [=]() {
+            auto config = DTK_CORE_NAMESPACE::DConfig::create(appId, name, subpath, nullptr);
+            if (!config) {
+                qWarning() << QStringLiteral("Failed to create DConfig instance.");
+                worker->deleteLater();
+                return;
+            }
+            config->moveToThread(QThread::currentThread());
+            initialize(config);
+            worker->deleteLater();
+        });
+    }
+    explicit org_deepin_system-monitor_plugin_popup(QThread *thread, DTK_CORE_NAMESPACE::DConfigBackend *backend, const QString &appId, const QString &name, const QString &subpath, QObject *parent = nullptr)
+        : QObject(parent) {
+
+        if (!thread->isRunning()) {
+            qWarning() << QStringLiteral("Warning: The provided thread is not running.");
+        }
+        Q_ASSERT(QThread::currentThread() != thread);
+        auto worker = new QObject();
+        worker->moveToThread(thread);
+        QMetaObject::invokeMethod(worker, [=]() {
+            auto config = DTK_CORE_NAMESPACE::DConfig::create(backend, appId, name, subpath, nullptr);
+            if (!config) {
+                qWarning() << QStringLiteral("Failed to create DConfig instance.");
+                worker->deleteLater();
+                return;
+            }
+            config->moveToThread(QThread::currentThread());
+            initialize(config);
+            worker->deleteLater();
+        });
+    }
+    explicit org_deepin_system-monitor_plugin_popup(QThread *thread, const QString &name, const QString &subpath, QObject *parent = nullptr)
+        : QObject(parent) {
+
+        if (!thread->isRunning()) {
+            qWarning() << QStringLiteral("Warning: The provided thread is not running.");
+        }
+        Q_ASSERT(QThread::currentThread() != thread);
+        auto worker = new QObject();
+        worker->moveToThread(thread);
+        QMetaObject::invokeMethod(worker, [=]() {
+            auto config = DTK_CORE_NAMESPACE::DConfig::create(name, subpath, nullptr);
+            if (!config) {
+                qWarning() << QStringLiteral("Failed to create DConfig instance.");
+                worker->deleteLater();
+                return;
+            }
+            config->moveToThread(QThread::currentThread());
+            initialize(config);
+            worker->deleteLater();
+        });
+    }
+    explicit org_deepin_system-monitor_plugin_popup(QThread *thread, DTK_CORE_NAMESPACE::DConfigBackend *backend, const QString &name, const QString &subpath, QObject *parent = nullptr)
+        : QObject(parent) {
+
+        if (!thread->isRunning()) {
+            qWarning() << QStringLiteral("Warning: The provided thread is not running.");
+        }
+        Q_ASSERT(QThread::currentThread() != thread);
+        auto worker = new QObject();
+        worker->moveToThread(thread);
+        QMetaObject::invokeMethod(worker, [=]() {
+            auto config = DTK_CORE_NAMESPACE::DConfig::create(backend, name, subpath, nullptr);
+            if (!config) {
+                qWarning() << QStringLiteral("Failed to create DConfig instance.");
+                worker->deleteLater();
+                return;
+            }
+            config->moveToThread(QThread::currentThread());
+            initialize(config);
+            worker->deleteLater();
+        });
+    }
+    ~org_deepin_system-monitor_plugin_popup() {
+        if (m_config.loadRelaxed()) {
+            m_config.loadRelaxed()->deleteLater();
+        }
+    }
+
+    QString log_rules() const {
+        return p_log_rules;
+    }
+    void setLog_rules(const QString &value) {
+        auto oldValue = p_log_rules;
+        p_log_rules = value;
+        markPropertySet(0);
+        if (auto config = m_config.loadRelaxed()) {
+            QMetaObject::invokeMethod(config, [this, value]() {
+                m_config.loadRelaxed()->setValue(QStringLiteral("log_rules"), value);
+            });
+        }
+        if (p_log_rules != oldValue) {
+            Q_EMIT log_rulesChanged();
+        }
+    }
+Q_SIGNALS:
+    void log_rulesChanged();
+private:
+    void initialize(DTK_CORE_NAMESPACE::DConfig *config) {
+        Q_ASSERT(!m_config.loadRelaxed());
+        m_config.storeRelaxed(config);
+        if (testPropertySet(0)) {
+            config->setValue(QStringLiteral("log_rules"), QVariant::fromValue(p_log_rules));
+        } else {
+            updateValue(QStringLiteral("log_rules"), QVariant::fromValue(p_log_rules));
+        }
+
+        connect(config, &DTK_CORE_NAMESPACE::DConfig::valueChanged, this, [this](const QString &key) {
+            updateValue(key);
+        }, Qt::DirectConnection);
+    }
+    void updateValue(const QString &key, const QVariant &fallback = QVariant()) {
+        Q_ASSERT(QThread::currentThread() == m_config.loadRelaxed()->thread());
+        const QVariant &value = m_config.loadRelaxed()->value(key, fallback);
+        if (key == QStringLiteral("log_rules")) {
+            auto newValue = qvariant_cast<QString>(value);
+            QMetaObject::invokeMethod(this, [this, newValue]() {
+                if (p_log_rules != newValue) {
+                    p_log_rules = newValue;
+                    Q_EMIT log_rulesChanged();
+                }
+            });
+            return;
+        }
+    }
+    inline void markPropertySet(const int index) {
+        if (index < 32) {
+            m_propertySetStatus0.fetchAndOrOrdered(1 << (index - 0));
+            return;
+        }
+        Q_UNREACHABLE();
+    }
+    inline bool testPropertySet(const int index) const {
+        if (index < 32) {
+            return (m_propertySetStatus0.loadRelaxed() & (1 << (index - 0)));
+        }
+        Q_UNREACHABLE();
+    }
+    QAtomicPointer<DTK_CORE_NAMESPACE::DConfig> m_config = nullptr;
+    QString p_log_rules { QStringLiteral("*.debug=false;*.info=false;*.warning=true") };
+    QAtomicInteger<quint32> m_propertySetStatus0 = 0;
+};
+
+#endif // ORG_DEEPIN_SYSTEM-MONITOR_PLUGIN_POPUP_H

--- a/deepin-system-monitor-plugin/configs/json/org_deepin_system-monitor_plugin.hpp
+++ b/deepin-system-monitor-plugin/configs/json/org_deepin_system-monitor_plugin.hpp
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: 2024 - 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef ORG_DEEPIN_SYSTEM-MONITOR_PLUGIN_H
+#define ORG_DEEPIN_SYSTEM-MONITOR_PLUGIN_H
+
+#include <QThread>
+#include <QVariant>
+#include <QDebug>
+#include <QAtomicPointer>
+#include <QAtomicInteger>
+#include <DConfig>
+
+class org_deepin_system-monitor_plugin : public QObject {
+    Q_OBJECT
+
+    Q_PROPERTY(QString log_rules READ log_rules WRITE setLog_rules NOTIFY log_rulesChanged)
+public:
+    explicit org_deepin_system-monitor_plugin(QThread *thread, const QString &appId, const QString &name, const QString &subpath, QObject *parent = nullptr)
+        : QObject(parent) {
+
+        if (!thread->isRunning()) {
+            qWarning() << QStringLiteral("Warning: The provided thread is not running.");
+        }
+        Q_ASSERT(QThread::currentThread() != thread);
+        auto worker = new QObject();
+        worker->moveToThread(thread);
+        QMetaObject::invokeMethod(worker, [=]() {
+            auto config = DTK_CORE_NAMESPACE::DConfig::create(appId, name, subpath, nullptr);
+            if (!config) {
+                qWarning() << QStringLiteral("Failed to create DConfig instance.");
+                worker->deleteLater();
+                return;
+            }
+            config->moveToThread(QThread::currentThread());
+            initialize(config);
+            worker->deleteLater();
+        });
+    }
+    explicit org_deepin_system-monitor_plugin(QThread *thread, DTK_CORE_NAMESPACE::DConfigBackend *backend, const QString &appId, const QString &name, const QString &subpath, QObject *parent = nullptr)
+        : QObject(parent) {
+
+        if (!thread->isRunning()) {
+            qWarning() << QStringLiteral("Warning: The provided thread is not running.");
+        }
+        Q_ASSERT(QThread::currentThread() != thread);
+        auto worker = new QObject();
+        worker->moveToThread(thread);
+        QMetaObject::invokeMethod(worker, [=]() {
+            auto config = DTK_CORE_NAMESPACE::DConfig::create(backend, appId, name, subpath, nullptr);
+            if (!config) {
+                qWarning() << QStringLiteral("Failed to create DConfig instance.");
+                worker->deleteLater();
+                return;
+            }
+            config->moveToThread(QThread::currentThread());
+            initialize(config);
+            worker->deleteLater();
+        });
+    }
+    explicit org_deepin_system-monitor_plugin(QThread *thread, const QString &name, const QString &subpath, QObject *parent = nullptr)
+        : QObject(parent) {
+
+        if (!thread->isRunning()) {
+            qWarning() << QStringLiteral("Warning: The provided thread is not running.");
+        }
+        Q_ASSERT(QThread::currentThread() != thread);
+        auto worker = new QObject();
+        worker->moveToThread(thread);
+        QMetaObject::invokeMethod(worker, [=]() {
+            auto config = DTK_CORE_NAMESPACE::DConfig::create(name, subpath, nullptr);
+            if (!config) {
+                qWarning() << QStringLiteral("Failed to create DConfig instance.");
+                worker->deleteLater();
+                return;
+            }
+            config->moveToThread(QThread::currentThread());
+            initialize(config);
+            worker->deleteLater();
+        });
+    }
+    explicit org_deepin_system-monitor_plugin(QThread *thread, DTK_CORE_NAMESPACE::DConfigBackend *backend, const QString &name, const QString &subpath, QObject *parent = nullptr)
+        : QObject(parent) {
+
+        if (!thread->isRunning()) {
+            qWarning() << QStringLiteral("Warning: The provided thread is not running.");
+        }
+        Q_ASSERT(QThread::currentThread() != thread);
+        auto worker = new QObject();
+        worker->moveToThread(thread);
+        QMetaObject::invokeMethod(worker, [=]() {
+            auto config = DTK_CORE_NAMESPACE::DConfig::create(backend, name, subpath, nullptr);
+            if (!config) {
+                qWarning() << QStringLiteral("Failed to create DConfig instance.");
+                worker->deleteLater();
+                return;
+            }
+            config->moveToThread(QThread::currentThread());
+            initialize(config);
+            worker->deleteLater();
+        });
+    }
+    ~org_deepin_system-monitor_plugin() {
+        if (m_config.loadRelaxed()) {
+            m_config.loadRelaxed()->deleteLater();
+        }
+    }
+
+    QString log_rules() const {
+        return p_log_rules;
+    }
+    void setLog_rules(const QString &value) {
+        auto oldValue = p_log_rules;
+        p_log_rules = value;
+        markPropertySet(0);
+        if (auto config = m_config.loadRelaxed()) {
+            QMetaObject::invokeMethod(config, [this, value]() {
+                m_config.loadRelaxed()->setValue(QStringLiteral("log_rules"), value);
+            });
+        }
+        if (p_log_rules != oldValue) {
+            Q_EMIT log_rulesChanged();
+        }
+    }
+Q_SIGNALS:
+    void log_rulesChanged();
+private:
+    void initialize(DTK_CORE_NAMESPACE::DConfig *config) {
+        Q_ASSERT(!m_config.loadRelaxed());
+        m_config.storeRelaxed(config);
+        if (testPropertySet(0)) {
+            config->setValue(QStringLiteral("log_rules"), QVariant::fromValue(p_log_rules));
+        } else {
+            updateValue(QStringLiteral("log_rules"), QVariant::fromValue(p_log_rules));
+        }
+
+        connect(config, &DTK_CORE_NAMESPACE::DConfig::valueChanged, this, [this](const QString &key) {
+            updateValue(key);
+        }, Qt::DirectConnection);
+    }
+    void updateValue(const QString &key, const QVariant &fallback = QVariant()) {
+        Q_ASSERT(QThread::currentThread() == m_config.loadRelaxed()->thread());
+        const QVariant &value = m_config.loadRelaxed()->value(key, fallback);
+        if (key == QStringLiteral("log_rules")) {
+            auto newValue = qvariant_cast<QString>(value);
+            QMetaObject::invokeMethod(this, [this, newValue]() {
+                if (p_log_rules != newValue) {
+                    p_log_rules = newValue;
+                    Q_EMIT log_rulesChanged();
+                }
+            });
+            return;
+        }
+    }
+    inline void markPropertySet(const int index) {
+        if (index < 32) {
+            m_propertySetStatus0.fetchAndOrOrdered(1 << (index - 0));
+            return;
+        }
+        Q_UNREACHABLE();
+    }
+    inline bool testPropertySet(const int index) const {
+        if (index < 32) {
+            return (m_propertySetStatus0.loadRelaxed() & (1 << (index - 0)));
+        }
+        Q_UNREACHABLE();
+    }
+    QAtomicPointer<DTK_CORE_NAMESPACE::DConfig> m_config = nullptr;
+    QString p_log_rules { QStringLiteral("*.debug=false;*.info=false;*.warning=true") };
+    QAtomicInteger<quint32> m_propertySetStatus0 = 0;
+};
+
+#endif // ORG_DEEPIN_SYSTEM-MONITOR_PLUGIN_H

--- a/deepin-system-monitor-server/configs/json/org_deepin_system-monitor_server.hpp
+++ b/deepin-system-monitor-server/configs/json/org_deepin_system-monitor_server.hpp
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: 2024 - 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef ORG_DEEPIN_SYSTEM-MONITOR_SERVER_H
+#define ORG_DEEPIN_SYSTEM-MONITOR_SERVER_H
+
+#include <QThread>
+#include <QVariant>
+#include <QDebug>
+#include <QAtomicPointer>
+#include <QAtomicInteger>
+#include <DConfig>
+
+class org_deepin_system-monitor_server : public QObject {
+    Q_OBJECT
+
+    Q_PROPERTY(QString log_rules READ log_rules WRITE setLog_rules NOTIFY log_rulesChanged)
+public:
+    explicit org_deepin_system-monitor_server(QThread *thread, const QString &appId, const QString &name, const QString &subpath, QObject *parent = nullptr)
+        : QObject(parent) {
+
+        if (!thread->isRunning()) {
+            qWarning() << QStringLiteral("Warning: The provided thread is not running.");
+        }
+        Q_ASSERT(QThread::currentThread() != thread);
+        auto worker = new QObject();
+        worker->moveToThread(thread);
+        QMetaObject::invokeMethod(worker, [=]() {
+            auto config = DTK_CORE_NAMESPACE::DConfig::create(appId, name, subpath, nullptr);
+            if (!config) {
+                qWarning() << QStringLiteral("Failed to create DConfig instance.");
+                worker->deleteLater();
+                return;
+            }
+            config->moveToThread(QThread::currentThread());
+            initialize(config);
+            worker->deleteLater();
+        });
+    }
+    explicit org_deepin_system-monitor_server(QThread *thread, DTK_CORE_NAMESPACE::DConfigBackend *backend, const QString &appId, const QString &name, const QString &subpath, QObject *parent = nullptr)
+        : QObject(parent) {
+
+        if (!thread->isRunning()) {
+            qWarning() << QStringLiteral("Warning: The provided thread is not running.");
+        }
+        Q_ASSERT(QThread::currentThread() != thread);
+        auto worker = new QObject();
+        worker->moveToThread(thread);
+        QMetaObject::invokeMethod(worker, [=]() {
+            auto config = DTK_CORE_NAMESPACE::DConfig::create(backend, appId, name, subpath, nullptr);
+            if (!config) {
+                qWarning() << QStringLiteral("Failed to create DConfig instance.");
+                worker->deleteLater();
+                return;
+            }
+            config->moveToThread(QThread::currentThread());
+            initialize(config);
+            worker->deleteLater();
+        });
+    }
+    explicit org_deepin_system-monitor_server(QThread *thread, const QString &name, const QString &subpath, QObject *parent = nullptr)
+        : QObject(parent) {
+
+        if (!thread->isRunning()) {
+            qWarning() << QStringLiteral("Warning: The provided thread is not running.");
+        }
+        Q_ASSERT(QThread::currentThread() != thread);
+        auto worker = new QObject();
+        worker->moveToThread(thread);
+        QMetaObject::invokeMethod(worker, [=]() {
+            auto config = DTK_CORE_NAMESPACE::DConfig::create(name, subpath, nullptr);
+            if (!config) {
+                qWarning() << QStringLiteral("Failed to create DConfig instance.");
+                worker->deleteLater();
+                return;
+            }
+            config->moveToThread(QThread::currentThread());
+            initialize(config);
+            worker->deleteLater();
+        });
+    }
+    explicit org_deepin_system-monitor_server(QThread *thread, DTK_CORE_NAMESPACE::DConfigBackend *backend, const QString &name, const QString &subpath, QObject *parent = nullptr)
+        : QObject(parent) {
+
+        if (!thread->isRunning()) {
+            qWarning() << QStringLiteral("Warning: The provided thread is not running.");
+        }
+        Q_ASSERT(QThread::currentThread() != thread);
+        auto worker = new QObject();
+        worker->moveToThread(thread);
+        QMetaObject::invokeMethod(worker, [=]() {
+            auto config = DTK_CORE_NAMESPACE::DConfig::create(backend, name, subpath, nullptr);
+            if (!config) {
+                qWarning() << QStringLiteral("Failed to create DConfig instance.");
+                worker->deleteLater();
+                return;
+            }
+            config->moveToThread(QThread::currentThread());
+            initialize(config);
+            worker->deleteLater();
+        });
+    }
+    ~org_deepin_system-monitor_server() {
+        if (m_config.loadRelaxed()) {
+            m_config.loadRelaxed()->deleteLater();
+        }
+    }
+
+    QString log_rules() const {
+        return p_log_rules;
+    }
+    void setLog_rules(const QString &value) {
+        auto oldValue = p_log_rules;
+        p_log_rules = value;
+        markPropertySet(0);
+        if (auto config = m_config.loadRelaxed()) {
+            QMetaObject::invokeMethod(config, [this, value]() {
+                m_config.loadRelaxed()->setValue(QStringLiteral("log_rules"), value);
+            });
+        }
+        if (p_log_rules != oldValue) {
+            Q_EMIT log_rulesChanged();
+        }
+    }
+Q_SIGNALS:
+    void log_rulesChanged();
+private:
+    void initialize(DTK_CORE_NAMESPACE::DConfig *config) {
+        Q_ASSERT(!m_config.loadRelaxed());
+        m_config.storeRelaxed(config);
+        if (testPropertySet(0)) {
+            config->setValue(QStringLiteral("log_rules"), QVariant::fromValue(p_log_rules));
+        } else {
+            updateValue(QStringLiteral("log_rules"), QVariant::fromValue(p_log_rules));
+        }
+
+        connect(config, &DTK_CORE_NAMESPACE::DConfig::valueChanged, this, [this](const QString &key) {
+            updateValue(key);
+        }, Qt::DirectConnection);
+    }
+    void updateValue(const QString &key, const QVariant &fallback = QVariant()) {
+        Q_ASSERT(QThread::currentThread() == m_config.loadRelaxed()->thread());
+        const QVariant &value = m_config.loadRelaxed()->value(key, fallback);
+        if (key == QStringLiteral("log_rules")) {
+            auto newValue = qvariant_cast<QString>(value);
+            QMetaObject::invokeMethod(this, [this, newValue]() {
+                if (p_log_rules != newValue) {
+                    p_log_rules = newValue;
+                    Q_EMIT log_rulesChanged();
+                }
+            });
+            return;
+        }
+    }
+    inline void markPropertySet(const int index) {
+        if (index < 32) {
+            m_propertySetStatus0.fetchAndOrOrdered(1 << (index - 0));
+            return;
+        }
+        Q_UNREACHABLE();
+    }
+    inline bool testPropertySet(const int index) const {
+        if (index < 32) {
+            return (m_propertySetStatus0.loadRelaxed() & (1 << (index - 0)));
+        }
+        Q_UNREACHABLE();
+    }
+    QAtomicPointer<DTK_CORE_NAMESPACE::DConfig> m_config = nullptr;
+    QString p_log_rules { QStringLiteral("*.debug=false;*.info=false;*.warning=true") };
+    QAtomicInteger<quint32> m_propertySetStatus0 = 0;
+};
+
+#endif // ORG_DEEPIN_SYSTEM-MONITOR_SERVER_H


### PR DESCRIPTION
- Add thread-safe DConfig wrapper classes for all components
- Implement log rules configuration with default settings
- Support configuration change notifications
- Add configuration backends for daemon, main, plugin, plugin-popup and server

Log: add DConfig wrapper classes for system monitor components