### PR TITLE
fix: hide window temporarily when killing process via KWin

### DIFF
--- a/deepin-system-monitor-main/gui/main_window.cpp
+++ b/deepin-system-monitor-main/gui/main_window.cpp
@@ -383,6 +383,10 @@ void MainWindow::onKillProcess()
                                                     QStringLiteral("/KWin"),
                                                     QStringLiteral("org.kde.KWin"),
                                                     QStringLiteral("killWindow"));
+        hide();
         QDBusConnection::sessionBus().asyncCall(message);
+        QTimer::singleShot(1000,this,[this](){
+            show();
+        });
     }
 }


### PR DESCRIPTION
- Add hide() before sending killWindow dbus message
- Add QTimer to show window after 1 second
- Improve user experience during process killing

Log: improve window behavior when killing process
Bug: https://pms.uniontech.com/bug-view-291531.html