### PR TITLE
fix: remove debug logs in accounts module

### DIFF
--- a/deepin-system-monitor-main/gui/accounts_widget.cpp
+++ b/deepin-system-monitor-main/gui/accounts_widget.cpp
@@ -17,8 +17,6 @@ AccountsWidget::AccountsWidget(QWidget *parent)
     : QWidget(parent), m_userModel(new AccountsInfoModel(this)), m_userItemModel(new QStandardItemModel(this)), m_userlistView(new UserListView(this))
 {
     m_currentUserType = m_userModel->getCurrentUserType();
-    qCInfo(app) << "AccountsWidget Constructor line 20:"
-                << "current user type:" << m_currentUserType;
     initUI();
     initConnection();
     addInfo(m_userModel);
@@ -127,12 +125,8 @@ void AccountsWidget::onUpdateUserList()
 
 void AccountsWidget::addInfo(AccountsInfoModel *model)
 {
-    qCInfo(app) << "AccountsWidget addInfo line 130:"
-                << "add info from list:" << model->userList();
     //给账户列表添加用户
     for (auto user : model->userList()) {
-        qCInfo(app) << "AccountsWidget addInfo line 132:"
-                    << "add user to listview:" << user->name();
         addUser(user);
     }
 }
@@ -140,8 +134,6 @@ void AccountsWidget::addInfo(AccountsInfoModel *model)
 void AccountsWidget::addUser(User *user)
 {
     //active
-    qCInfo(app) << "AccountsWidget addUser line 141:"
-                << "addUser begins:" << user->name();
     m_userList << user;
     DStandardItem *item = new DStandardItem;
     item->setData(0, AccountsWidget::ItemDataRole);
@@ -153,9 +145,6 @@ void AccountsWidget::addUser(User *user)
     /* 用户列表显示用户类型 */
     auto *subTitleAction = new DViewItemAction;
     setTitelFunc(user->userType(), subTitleAction);
-
-    qCInfo(app) << "AccountsWidget addUser line 156:"
-                << "subTitleAction text:" << subTitleAction->text();
 
     subTitleAction->setFontSize(DFontSizeManager::T8);
     subTitleAction->setTextColorRole(DPalette::TextTips);

--- a/deepin-system-monitor-main/gui/user_page_widget.cpp
+++ b/deepin-system-monitor-main/gui/user_page_widget.cpp
@@ -40,8 +40,6 @@ UserPageWidget::UserPageWidget(DWidget *parent)
     struct passwd *pws;
     pws = getpwuid(getuid());
     m_currentUser = QString(pws->pw_name);
-    qCInfo(app) << "UserPageWidget Construction:"
-                << "currentuser:" << m_currentUser;
     initUI();
     initConnections();
 }
@@ -206,7 +204,6 @@ void UserPageWidget::paintEvent(QPaintEvent *)
 void UserPageWidget::onUserChanged()
 {
     QString userName = m_accountListWidget->getCurrentItemUserName();
-    qCInfo(app) << userName << "user changed";
     m_procTable->setUserModeName(userName);
     onTextContentChanged();
     update();

--- a/deepin-system-monitor-main/model/accounts_info_model.cpp
+++ b/deepin-system-monitor-main/model/accounts_info_model.cpp
@@ -26,17 +26,11 @@ AccountsInfoModel::AccountsInfoModel(QObject *parent)
     struct passwd *pws;
     pws = getpwuid(getuid());
     m_currentUserName = QString(pws->pw_name);
-    qCInfo(app) << "AccountsInfoModel constructor line 26"
-            << "m_currentUserName:" << m_currentUserName;
     //获取online userList
     updateUserOnlineStatus();
-    qCInfo(app) << "AccountsInfoModel constructor line 29"
-            << "online user list:" << m_onlineUsers;
 
     QStringList userList = m_accountsInter->property("UserList").toStringList();
     updateUserList(userList);
-    qCInfo(app) << "AccountsInfoModel constructor line 31"
-            << "Accounts user list:" << userList;
 
     QDBusConnection::systemBus().connect(common::systemInfo().AccountsService, common::systemInfo().AccountsPath, common::systemInfo().AccountsInterface, "UserListChanged",
                                          this, SLOT(onUserListChanged(QStringList)));
@@ -74,8 +68,6 @@ void AccountsInfoModel::onSessionRemoved(const QString &in0, const QDBusObjectPa
 
 void AccountsInfoModel::updateUserList(const QStringList &userPathList)
 {
-    qCInfo(app) << "AccountsInfoModel updateUserList line 61"
-            << "updateUserList begins!";
     // 释放构造对象
     qDeleteAll(m_userMap.values());
     m_userMap.clear();
@@ -95,8 +87,6 @@ void AccountsInfoModel::updateUserList(const QStringList &userPathList)
             newUser->setIsCurrentUser(true);
             m_currentUserType = newUser->userType();
         }
-        qCInfo(app) << "AccountsInfoModel updateUserList line 78"
-                << "get user info of :" << newUser->name();
         m_userMap.insert(newUser->name(), newUser);
 
         delete userDBus;
@@ -105,8 +95,6 @@ void AccountsInfoModel::updateUserList(const QStringList &userPathList)
 
 void AccountsInfoModel::updateUserOnlineStatus()
 {
-    qCInfo(app) << "AccountsInfoModel updateUserOnlineStatus line 88"
-            << "updateUserOnlineStatus begins!";
     m_onlineUsers.clear();
 
     //异步获取SessionList
@@ -134,8 +122,6 @@ QList<User *> AccountsInfoModel::userList() const
             onlineUsers << user;
         }
     }
-    qCInfo(app) << "AccountsInfoModel userList"
-            << "get online users:" << m_onlineUsers;
 
     return onlineUsers;
 }


### PR DESCRIPTION
- Clean up redundant qCInfo debug logs in accounts related components
- Remove verbose logging in AccountsWidget, UserPageWidget and AccountsInfoModel

Log: remove debug logs in accounts module
Bug: https://pms.uniontech.com/bug-view-298213.html