### PR TITLE
fix: improve gdbus call handling for system alarms

### DIFF
--- a/deepin-system-monitor-daemon/src/systemmonitorservice.cpp
+++ b/deepin-system-monitor-daemon/src/systemmonitorservice.cpp
@@ -277,7 +277,19 @@ bool SystemMonitorService::checkCpuAlarm()
     if (mCpuUsage >= mAlarmCpuUsage && diffTime >= timeGap) {
         mLastAlarmTimeStamp = curTimeStamp;
         QString cmd = QString("gdbus call -e -d  com.deepin.SystemMonitorServer -o /com/deepin/SystemMonitorServer -m com.deepin.SystemMonitorServer.showCpuAlarmNotify \"%1\" ").arg(QString::number(mCpuUsage));
-        QTimer::singleShot(100, this, [=]() { QProcess::startDetached(cmd); });
+        QTimer::singleShot(100, this, [=]() {
+            QStringList args;
+            args << "call" << "-e" << "-d" << "com.deepin.SystemMonitorServer"
+                 << "-o" << "/com/deepin/SystemMonitorServer"
+                 << "-m" << "com.deepin.SystemMonitorServer.showCpuAlarmNotify"
+                 << QString::number(mCpuUsage);
+            QProcess process;
+            process.start("gdbus", args);
+            process.waitForFinished(5000);
+            if (process.exitCode() != 0) {
+                QProcess::startDetached(cmd);
+            }
+        });
     }
 
     return false;
@@ -292,7 +304,19 @@ bool SystemMonitorService::checkMemoryAlarm()
     if (mMemoryUsage >= mAlarmMemoryUsage && diffTime > timeGap) {
         mLastAlarmTimeStamp = curTimeStamp;
         QString cmd = QString("gdbus call -e -d  com.deepin.SystemMonitorServer -o /com/deepin/SystemMonitorServer -m com.deepin.SystemMonitorServer.showMemoryAlarmNotify \"%1\" ").arg(QString::number(mMemoryUsage));
-        QTimer::singleShot(100, this, [=]() { QProcess::startDetached(cmd); });
+        QTimer::singleShot(100, this, [=]() {
+            QStringList args;
+            args << "call" << "-e" << "-d" << "com.deepin.SystemMonitorServer"
+                 << "-o" << "/com/deepin/SystemMonitorServer"
+                 << "-m" << "com.deepin.SystemMonitorServer.showMemoryAlarmNotify"
+                 << QString::number(mMemoryUsage);
+            QProcess process;
+            process.start("gdbus", args);
+            process.waitForFinished(5000);
+            if (process.exitCode() != 0) {
+                QProcess::startDetached(cmd);
+            }
+        });
     }
 
     return false;

--- a/deepin-system-monitor-main/common/common.cpp
+++ b/deepin-system-monitor-main/common/common.cpp
@@ -186,7 +186,17 @@ void openFilePathItem(const QString &path)
 {
     bool result = QProcess::startDetached(QString("dde-file-manager --show-item \"%1\"").arg(path));
     if (!result) {
-        QDesktopServices::openUrl(QUrl(path));
+        QUrl displayUrl = QUrl::fromLocalFile(path);
+        QDBusInterface interface(QStringLiteral("org.freedesktop.FileManager1"),
+                                        QStringLiteral("/org/freedesktop/FileManager1"),
+                                        QStringLiteral("org.freedesktop.FileManager1"));
+        if (interface.isValid()) {
+            QStringList list;
+            list << displayUrl.toString();
+            interface.call("ShowItems", list, "");
+        } else {
+            QDesktopServices::openUrl(displayUrl);
+        }
     }
 }
 


### PR DESCRIPTION
- Add fallback mechanism when gdbus call fails
- Add timeout handling for CPU and Memory alarm notifications
- Replace direct command execution with QProcess for better control

Log: improve gdbus call handling for system alarms
Bug: https://pms.uniontech.com/bug-view-283139.html