### PR TITLE
fix: optimize gdbus call process in system monitor

### DIFF
--- a/deepin-system-monitor-daemon/src/systemmonitorservice.cpp
+++ b/deepin-system-monitor-daemon/src/systemmonitorservice.cpp
@@ -287,7 +287,8 @@ bool SystemMonitorService::checkCpuAlarm()
             process.start("gdbus", args);
             process.waitForFinished(5000);
             if (process.exitCode() != 0) {
-                QProcess::startDetached(cmd);
+                process.start("gdbus", args);
+                process.waitForFinished(5000);
             }
         });
     }
@@ -314,7 +315,8 @@ bool SystemMonitorService::checkMemoryAlarm()
             process.start("gdbus", args);
             process.waitForFinished(5000);
             if (process.exitCode() != 0) {
-                QProcess::startDetached(cmd);
+                process.start("gdbus", args);
+                process.waitForFinished(5000);
             }
         });
     }

--- a/deepin-system-monitor-main/gui/dialog/systemprotectionsetting.cpp
+++ b/deepin-system-monitor-main/gui/dialog/systemprotectionsetting.cpp
@@ -529,36 +529,38 @@ void SystemProtectionSetting::onSettingItemChanged(const QString &key, const QVa
 
     //QString cmd("qdbus org.deepin.SystemMonitorDaemon /org/deepin/SystemMonitorDaemon org.deepin.SystemMonitorDaemon.");
     //qdbus 改为gdbus
-    QString cmd("gdbus call -e -d  org.deepin.SystemMonitorDaemon -o /org/deepin/SystemMonitorDaemon -m org.deepin.SystemMonitorDaemon.");
-    bool needCall = false;
+    QString program = "gdbus";
+    QStringList arguments;
+    arguments << "call" << "-e" << "-d" << "org.deepin.SystemMonitorDaemon" 
+              << "-o" << "/org/deepin/SystemMonitorDaemon" 
+              << "-m" << "org.deepin.SystemMonitorDaemon.";
 
-    // 拼接dbus调用命令字串
+    // 根据不同的key添加对应的方法名和参数
     if (key == AlarmStatusOptionName) {
-        cmd.append("setSystemProtectionStatus ");   // Method Name
-        cmd.append(value.toString());   // value
-        needCall = true;
+        arguments.last().append("setSystemProtectionStatus");
+        arguments << value.toString();
     } else if (key == AlarmCpuUsageOptionName) {
-        cmd.append("setAlarmUsageOfCpu ");   // Method Name
-        cmd.append(value.toString());   // value
-        needCall = true;
+        arguments.last().append("setAlarmUsageOfCpu"); 
+        arguments << value.toString();
     } else if (key == AlarmMemUsageOptionName) {
-        cmd.append("setAlarmUsageOfMemory ");   // Method Name
-        cmd.append(value.toString());   // value
-        needCall = true;
+        arguments.last().append("setAlarmUsageOfMemory");
+        arguments << value.toString();
     } else if (key == AlarmIntervalOptionName) {
-        cmd.append("setAlarmMsgInterval ");   // Method Name
-        cmd.append(value.toString());   // value
-        needCall = true;
+        arguments.last().append("setAlarmMsgInterval");
+        arguments << value.toString();
     } else if (key == AlarmLastTimeOptionName) {
-        cmd.append("setAlarmLastTimeInterval ");   // Mehthod Name
-        cmd.append(value.toString());
-        needCall = true;
+        arguments.last().append("setAlarmLastTimeInterval");
+        arguments << value.toString();
+    } else {
+        return;
     }
 
-    if (needCall) {
-        qCDebug(app) << __FUNCTION__ << __LINE__ << "，dbus cmd：" << cmd;
-        QTimer::singleShot(100, this, [=]() { QProcess::startDetached(cmd); });
-    }
+    QTimer::singleShot(100, this, [=]() {
+        qCDebug(app) << __FUNCTION__ << __LINE__ << "，dbus cmd：" << program << arguments;
+        QProcess process;
+        process.start(program, arguments);
+        process.waitForFinished(5000);
+    });
 }
 
 DSettings *SystemProtectionSetting::getDSettingPointor()


### PR DESCRIPTION
- Replace QProcess::startDetached with process.start and waitForFinished
- Refactor gdbus command construction using QStringList arguments
- Improve error handling for dbus calls

Log: optimize gdbus call process in system monitor
Bug: https://pms.uniontech.com/bug-view-283139.html