### PR TITLE
fix: optimize window kill process in KDE environment

### DIFF
--- a/deepin-system-monitor-main/gui/main_window.cpp
+++ b/deepin-system-monitor-main/gui/main_window.cpp
@@ -384,9 +384,15 @@ void MainWindow::onKillProcess()
                                                     QStringLiteral("org.kde.KWin"),
                                                     QStringLiteral("killWindow"));
         hide();
-        QDBusConnection::sessionBus().asyncCall(message);
-        QTimer::singleShot(1000,this,[this](){
-            show();
+        QTimer::singleShot(300,this,[this](){
+            auto message = QDBusMessage::createMethodCall(QStringLiteral("org.kde.KWin"),
+                                                        QStringLiteral("/KWin"),
+                                                        QStringLiteral("org.kde.KWin"),
+                                                        QStringLiteral("killWindow"));
+            QDBusConnection::sessionBus().asyncCall(message);
+            QTimer::singleShot(1000,this,[this](){
+                show();
+            });
         });
     }
 }


### PR DESCRIPTION
- Add delay before sending kill window dbus message
- Improve window hide/show timing sequence
- Enhance window state management during kill operation

Log: optimize window kill process in KDE environment
Bug: https://pms.uniontech.com/bug-view-291531.html