### PR TITLE
fix: add linglong app support in desktop entry cache updater

### DIFF
--- a/deepin-system-monitor-main/process/desktop_entry_cache.h
+++ b/deepin-system-monitor-main/process/desktop_entry_cache.h
@@ -43,12 +43,20 @@ private:
 
 inline bool DesktopEntryCache::contains(const QString &name) const
 {
-    return m_cache.contains(name);
+    for (auto &key : m_cache.keys()) {
+        if (key.toLower() == name.toLower())
+            return true;
+    }
+    return false;
 }
 
 inline const DesktopEntry DesktopEntryCache::entry(const QString &name) const
 {
-    return m_cache[name];
+    for (auto &key : m_cache.keys()) {
+        if (key.toLower() == name.toLower())
+            return m_cache[key];
+    }
+    return std::make_shared<struct desktop_entry_t>();
 }
 
 inline const DesktopEntry DesktopEntryCache::entryWithSubName(const QString &subName) const


### PR DESCRIPTION
Add special handling for linglong applications by parsing ll-cli output to get app info

Log: add linglong app support in desktop entry cache updater
Bug: https://pms.uniontech.com/bug-view-279859.html
          https://pms.uniontech.com/bug-view-284207.html
          https://pms.uniontech.com/bug-view-304217.html
          https://pms.uniontech.com/bug-view-306483.html