### PR TITLE
fix: Adjust pixmap size calculation in MonitorPluginButtonWidget

### DIFF
--- a/deepin-system-monitor-plugin/gui/monitorpluginbuttonwidget.cpp
+++ b/deepin-system-monitor-plugin/gui/monitorpluginbuttonwidget.cpp
@@ -161,7 +161,7 @@ const QPixmap MonitorPluginButtonWidget::loadSvg(const QString &iconName, const 
 {
     QIcon fallbackIcon = QIcon::fromTheme(fallbackIconName);
     QIcon icon = QIcon::fromTheme(iconName, fallbackIcon);
-    int pixmapSize = QCoreApplication::testAttribute(Qt::AA_UseHighDpiPixmaps) ? size : int(size * ratio);
+    int pixmapSize = size;
     if (!icon.isNull()) {
         QPixmap pixmap = icon.pixmap(pixmapSize);
         pixmap.setDevicePixelRatio(ratio);


### PR DESCRIPTION
Updated the pixmap size calculation to use the original size instead of adjusting for high DPI settings. This change ensures that the icon is rendered at the intended size without scaling issues.

bug：https://pms.uniontech.com/bug-view-313925.html