### PR TITLE
fix: Use constant for icon size in CommonIconButton

### DIFF
--- a/deepin-system-monitor-plugin/gui/commoniconbutton.cpp
+++ b/deepin-system-monitor-plugin/gui/commoniconbutton.cpp
@@ -11,6 +11,8 @@
 
 DGUI_USE_NAMESPACE
 
+constexpr int ICON_SIZE = 24;
+
 CommonIconButton::CommonIconButton(QWidget *parent)
     : QWidget(parent)
     , m_refreshTimer(nullptr)
@@ -22,7 +24,7 @@ CommonIconButton::CommonIconButton(QWidget *parent)
     , m_activeState(false)
 {
     setAccessibleName("IconButton");
-    setFixedSize(24, 24);
+    setFixedSize(ICON_SIZE, ICON_SIZE);
     if (parent)
         setForegroundRole(parent->foregroundRole());
 
@@ -168,7 +170,7 @@ void CommonIconButton::paintEvent(QPaintEvent *e)
     if (m_hover && !m_hoverIcon.isNull()) {
         m_hoverIcon.paint(&painter, rect());
     } else if (!m_icon.isNull()) {
-        m_icon.paint(&painter, rect());
+        painter.drawPixmap(rect(), m_icon.pixmap(ICON_SIZE));
     }
 }
 


### PR DESCRIPTION
- Introduced a constant `ICON_SIZE` for the icon dimensions to improve code readability and maintainability.
- Updated the fixed size and pixmap drawing to utilize this constant, ensuring consistency across the component.

This change enhances the clarity of the code and makes future adjustments to the icon size easier.