### PR TITLE
fix: update wireless signal strength calculation and improve speed re…

### DIFF
--- a/deepin-system-monitor-main/gui/netif_summary_view_widget.h
+++ b/deepin-system-monitor-main/gui/netif_summary_view_widget.h
@@ -281,7 +281,10 @@ public:
 
                 // 信号强度
                 stInfo.strKey = QApplication::translate("NetInfoModel", "Signal strength");
-                stInfo.strValue = QString("%1 dBm").arg(stNetifInfo->signalLevel());
+                auto strenth = stNetifInfo->signalLevel();
+                // 这个算法可能不是最准确的，后续如果有更准确的算法，可以替换，信号强度转信号等级
+                auto level = -100 + 70 * (1 - strenth / 100.0);
+                stInfo.strValue = QString("%1 dBm").arg(level);
                 m_listInfo << stInfo;
 
                 // 底噪

--- a/deepin-system-monitor-main/system/netif.h
+++ b/deepin-system-monitor-main/system/netif.h
@@ -153,6 +153,7 @@ protected:
     void updateLinkInfo(const NLLink *link);
     void updateWirelessInfo(); // ioctl
     void updateBrandInfo(); // udev
+    double getWirelessSpeed(const QString &interface); // iw dev <interface> link
 
 private:
     QSharedDataPointer<NetifInfoPrivate> d;

--- a/deepin-system-monitor-main/system/wireless.h
+++ b/deepin-system-monitor-main/system/wireless.h
@@ -18,9 +18,9 @@ public:
     ~wireless();
     // 服务器别号
     QByteArray essid();
-    unsigned char link_quality();
-    unsigned char signal_levle();
-    unsigned char noise_level();
+    uint8_t link_quality();
+    uint8_t signal_levle();
+    uint8_t noise_level();
 
     bool is_wireless();
 protected:
@@ -32,9 +32,9 @@ private:
     QByteArray m_ifname;
 
     QByteArray m_essid;
-    unsigned char m_link_quality;
-    unsigned char m_signal_levle;
-    unsigned char m_noise_level;
+    uint8_t m_link_quality;
+    uint8_t m_signal_level;
+    uint8_t m_noise_level;
 };
 
 


### PR DESCRIPTION
…trieval

Updated the signal strength calculation to provide a more accurate representation based on the signal level. Introduced a new method to retrieve wireless speed using the 'iw' command, replacing the previous method that relied on 'iwlist'.

Log: as above.

Bug: https://pms.uniontech.com/bug-view-315553.html