### PR TITLE
feat: add average CPU frequency calculation and display

### DIFF
--- a/deepin-system-monitor-main/gui/cpu_summary_view_widget.h
+++ b/deepin-system-monitor-main/gui/cpu_summary_view_widget.h
@@ -90,12 +90,12 @@ protected:
                 if (column == 0)
                     return QApplication::translate("CPUSummaryTableModel", "Utilization"); //百分比显示，为CPU的总体利用率，显示精度为1%，2秒刷新1次；
                 else if (column == 1)
-                    return QApplication::translate("CPUSummaryTableModel", "Current frequency");//显示当前CPU的实际运行速度，单位说明：如果当前CPU速度大于1GHz，单位为GHz；如果当前CPU速度小于1GHz，显示单位为MHz；
+                    return QApplication::translate("CPUSummaryTableModel", "Average frequency");//显示CPU的平均频率，单位说明：如果当前CPU速度大于1GHz，单位为GHz；如果当前CPU速度小于1GHz，显示单位为MHz；
                 break;
 
             case 1:
                 if (column == 0)    //m_model->cpuSet()->modelName()); //CPU属于的名字及其编号、标称主频；
-                    return QApplication::translate("CPUSummaryTableModel", "Frequency");//最小频率  ~ 最大频率；
+                    return QApplication::translate("CPUSummaryTableModel", "Max frequency");//最大频率；
                 else if (column == 1)
                     return QApplication::translate("CPUSummaryTableModel", "Up time");//最近一次开机到目前的运行时间。格式 天（DDDD）：小时（HH）：分钟（MM），60分自动进位到1小时；24小时自动进位为1天；最大支持 9999天；
                 break;
@@ -150,11 +150,11 @@ protected:
                 if (column == 0)
                     return  QString::number(m_model->cpuAllPercent(), 'f', 0) + "%";
                 else if (column == 1)
-                    return m_model->cpuSet()->curFreq();
+                    return m_model->cpuSet()->avgFreq();
                 break;
             case 1:
                 if (column == 0)
-                    return m_model->cpuSet()->minFreq() + " ~ " + m_model->cpuSet()->maxFreq();
+                    return m_model->cpuSet()->curFreq();
                 else if (column == 1)
                     return m_model->uptime();
                 break;

--- a/deepin-system-monitor-main/system/cpu_set.h
+++ b/deepin-system-monitor-main/system/cpu_set.h
@@ -44,6 +44,8 @@ public://info
 
     QString maxFreq() const;
 
+    QString avgFreq() const;
+
     QString l1dCache() const;
 
     QString l1iCache() const;

--- a/deepin-system-monitor-main/translations/deepin-system-monitor.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>System Monitor</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation type="unfinished"></translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation type="unfinished"></translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -74,12 +74,12 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
+        <source>Average frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
+        <source>Max frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>No search results</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation type="unfinished">Active</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation type="unfinished"></translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>System</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Display shortcuts</translation>
     </message>
@@ -604,50 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Ending this process may cause data loss.
 Are you sure you want to continue?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>End process</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Force ending this process may cause data loss.
 Are you sure you want to continue?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Force ending this application may cause data loss.
 Are you sure you want to continue?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation type="unfinished">Force End</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation type="unfinished">End</translation>
@@ -656,7 +656,7 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation type="unfinished"></translation>
     </message>
@@ -664,7 +664,7 @@ Are you sure you want to continue?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -672,7 +672,7 @@ Are you sure you want to continue?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
@@ -819,17 +819,17 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Command line</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Start time</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
@@ -837,7 +837,7 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Click the application you want to end</translation>
     </message>
@@ -845,16 +845,16 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Memory</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -862,85 +862,85 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Disk read</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Disk write</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Memory</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Swap</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Not enabled</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Download</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Upload</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Network</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Total Received</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Total Sent</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation type="unfinished"></translation>
     </message>
@@ -956,54 +956,54 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Very high</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>High</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Low</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Very low</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Custom</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Invalid</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Error: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Failed to change process priority</translation>
     </message>
@@ -1029,32 +1029,32 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Failed to pause process</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Failed to resume process</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Failed to kill process</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Unknown error</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Failed in sending signal to process</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1070,19 +1070,19 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>No response</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Suspend</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Tray</translation>
     </message>
@@ -1090,42 +1090,42 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>View command location</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Properties</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>End process</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Resume process</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Kill process</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Change priority</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Suspend process</translation>
     </message>
@@ -1133,18 +1133,18 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Custom Priority</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation type="unfinished">Change</translation>
@@ -1221,7 +1221,7 @@ Are you sure you want to continue?</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1264,12 +1264,12 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Failed to set service startup type</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Error: Failed to set service startup type due to the crashed sub process.</translation>
     </message>
@@ -1277,19 +1277,19 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Service instance name</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -1297,41 +1297,41 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Refresh</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Stop</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Restart</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Auto</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Manual</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Startup type</translation>
     </message>
@@ -1382,18 +1382,18 @@ Are you sure you want to continue?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1401,23 +1401,23 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Force end application</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Expand</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Compact</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>View</translation>
     </message>
@@ -1425,8 +1425,8 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Search</translation>
     </message>
@@ -1434,25 +1434,25 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Processes</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Services</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Users</translation>
     </message>
@@ -1460,7 +1460,7 @@ Are you sure you want to continue?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Edit account information</translation>
     </message>
@@ -1468,12 +1468,12 @@ Are you sure you want to continue?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Administrator</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Standard User</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_af.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_af.ts
@@ -4,30 +4,33 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Siste Monitor</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
-        <translation>Siste Monitor is 'n instrument wat reële tyd sisteembelasting, prosesse en dienste wat op jou sisteem loop, sien en beheer.</translation>
+        <translation>Siste Monitor is &apos;n instrument wat reële tyd sisteembelasting, prosesse en dienste wat op jou sisteem loop, sien en beheer.</translation>
     </message>
 </context>
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Versteek besonderhede</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Algemene gebruik</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Individuele gebruik</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Lees</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Skryf</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 sekondes</translation>
     </message>
@@ -56,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 dae %2 ure %3 minute</translation>
     </message>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Huidige frekwensie</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Frekwensie</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 sekondes</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Geen soekresultate</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Besonderhede</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Besonderhede</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>Waarskuwing</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Gebruik</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Beskikbaar</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Gedeel</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Geskuif</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Buffers</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Geskuif Swaap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation type="unfinished">Active</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Inaktief</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Smuttig</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Gemappeer</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Totaal Swaap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Vry Swaap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Slab</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Lees spoed</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Skryf spoed</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Kapasiteit</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Sektore gelees</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Lees/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Sektorers lees/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Lees gemaak/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Sektorers geskryf</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Skrif voltooi</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Skrif gemaak</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Skrif/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Sektorers geskryf/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Skrif gemaak/s</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Sisteem</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Toon snelkoppings</translation>
     </message>
@@ -598,45 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Die einde van hierdie proses kan dataverlies veroorsaak.
 Wees seker jy wil voortgaan?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Beëindig proses</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Dwingend einde van hierdie proses kan dataverlies veroorsaak.
 Wees seker jy wil voortgaan?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Dwingend einde van hierdie toepassing kan dataverlies veroorsaak.
 Wees seker jy wil voortgaan?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation type="unfinished">Force End</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation type="unfinished">End</translation>
@@ -645,7 +656,7 @@ Wees seker jy wil voortgaan?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Uitlog</translation>
     </message>
@@ -653,7 +664,7 @@ Wees seker jy wil voortgaan?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Instellings</translation>
     </message>
@@ -661,7 +672,7 @@ Wees seker jy wil voortgaan?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Grootte</translation>
     </message>
@@ -670,6 +681,7 @@ Wees seker jy wil voortgaan?</translation>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>IP adresse:</translation>
     </message>
@@ -788,11 +800,13 @@ Wees seker jy wil voortgaan?</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>IPv4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>IPv6</translation>
     </message>
@@ -805,17 +819,17 @@ Wees seker jy wil voortgaan?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Command line</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Start tyd</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
@@ -823,7 +837,7 @@ Wees seker jy wil voortgaan?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Klik op die toepassing wat jy wil einde</translation>
     </message>
@@ -831,12 +845,16 @@ Wees seker jy wil voortgaan?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Gedagte</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Ontvang</translation>
     </message>
@@ -844,67 +862,85 @@ Wees seker jy wil voortgaan?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Skryf tot</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Skryf</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Gedagte</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Swap</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Nie geaktiveer</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Afslaan</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Uplaai</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Netwerk</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Totaal ontvang</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Totale gestuur</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Stuur</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Skyns</translation>
     </message>
@@ -920,47 +956,54 @@ Wees seker jy wil voortgaan?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Baie hoog</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Hoog</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normaal</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Laag</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Baie laag</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Aangepas</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Ongeldig</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Fout: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Gestrand om prosesprioriteit te verander</translation>
     </message>
@@ -986,32 +1029,32 @@ Wees seker jy wil voortgaan?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Gestrand om proses te onderbrek</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Gestrand om proses te hervat</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Gestrand om proses te doodmaak</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Onbekende fout</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Gestrand in stuur van tekening na proses</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Gestrand om proses te beëindig</translation>
     </message>
@@ -1027,17 +1070,19 @@ Wees seker jy wil voortgaan?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Geen respons</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Onderbrek</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Vass</translation>
     </message>
@@ -1045,37 +1090,42 @@ Wees seker jy wil voortgaan?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Bekyk die kommando-plek</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Eigenskappe</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Beëindig proses</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Hervat proses</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Moord proses</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Verander prioriteit</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Vraag proses</translation>
     </message>
@@ -1083,18 +1133,18 @@ Wees seker jy wil voortgaan?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Pas Prioriteit</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation type="unfinished">Change</translation>
@@ -1171,7 +1221,7 @@ Wees seker jy wil voortgaan?</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Nie ondersteun</translation>
     </message>
@@ -1214,12 +1264,12 @@ Wees seker jy wil voortgaan?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Gestrand om dienstestarttipe te stel</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Fout: Gestrand om dienstestarttipe te stel vanwege die gekraspte subproses.</translation>
     </message>
@@ -1227,17 +1277,19 @@ Wees seker jy wil voortgaan?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Dienstestansienaam</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -1245,37 +1297,41 @@ Wees seker jy wil voortgaan?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Vernuut</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Stop</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Herstart</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Automaties</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Handmatig</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Starttipe</translation>
     </message>
@@ -1326,17 +1382,18 @@ Wees seker jy wil voortgaan?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Instellings</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Modifiseerbaar)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Interval: %1-%2</translation>
     </message>
@@ -1344,22 +1401,23 @@ Wees seker jy wil voortgaan?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Dwing om toepassing te beëindig</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Uitbrei</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Kompakt</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Weergawe</translation>
     </message>
@@ -1367,7 +1425,8 @@ Wees seker jy wil voortgaan?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Soek</translation>
     </message>
@@ -1375,17 +1434,25 @@ Wees seker jy wil voortgaan?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Prosesse</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Dienste</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Gebruikers</translation>
     </message>
@@ -1393,7 +1460,7 @@ Wees seker jy wil voortgaan?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Wysig rekeninginligting</translation>
     </message>
@@ -1401,12 +1468,12 @@ Wees seker jy wil voortgaan?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Administrator</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Standaardgebruiker</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_am_ET.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_am_ET.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>መረጃ መቆጣጠር</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>መረጃ መቆጣጠር አገልግሎት ነው፣ የአካል መረጃ ማስተካከል፣ የፕሮ세ሰስ እና የአገልግሎቶች ማሳየት እና ማስተዳደር ይችላል።</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>ስምም ማስተዳደር</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>የአጠቃላይ ማስተዳደር</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>የተለያዩ ማስተዳደር</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>ማነጋገር</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>ማድረግ</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 ዓመት</translation>
     </message>
@@ -56,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 ዓመት %2 ሰዓት %3 ዓመት</translation>
     </message>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>አሁን የብዛት ማስተካከል</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>ብዛት</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="100"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">መሰረዣ</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 ዓመት</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>ይቅር ማግኘት የለም</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>ስምም</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>დეტალები</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>გაფრთხილება</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>გამოყენებული</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>ხელმისაწვდომი</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>გაზიარებული</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>კეშდებული</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>ბუფერები</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>კეშდებული სვაპი</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>აქტიური</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>აქტიური არაა</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>გადამუშავებული</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>მართვის მიხედვით</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>სვაპის საერთო რაოდენობა</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>თავისუფალი სვაპი</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>სლაბი</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>მოდელი</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>წაკითხვის სიჩქარე</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>የማቅራት መጋዝ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>ምርጫ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>መረጃ ምስክሌ አንድ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>መረጃ ምስክሌ አንድ/ሰ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>መረጃ ምስክሌ አንድ/ሰ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>ተመራ የመረጃ ምስክሌ አንድ/ሰ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>መረጃ ምስክሌ ማቅራት</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>ማቅራት ይዘት</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>ተመራ ምስክሌ ማቅራት</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>ማቅራት አንድ/ሰ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>መረጃ ምስክሌ ማቅራት/ሰ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>ተመራ ምስክሌ ማቅራት/ሰ</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>አይነ</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>ሲስተም</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>ቅርብ ምስክሌ አሳይ</translation>
     </message>
@@ -598,42 +604,47 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>ፕሮሴስ የዚህ አስተያየት ማጥፋት የድርስት የመረጃ ይመስረቱ ይችላል። የዚህ አስተያየት አስተካክል ይፈልጋል?</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>መጥፋት</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation type="unfinished">ሂደት መጨረሻ</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">መሰረዣ</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>ክብ መጥፋት</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>ፕሮሴስ የዚህ አስተያየት ከክብ መጥፋት የድርስት የመረጃ ይመስረቱ ይችላል። የዚህ አስተያየት አስተካክል ይፈልጋል?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>አፕሊኬሽን የዚህ አስተያየት ከክብ መጥፋት የድርስት የመረጃ ይመስረቱ ይችላል። የዚህ አስተያየት አስተካክል ይፈልጋል?</translation>
@@ -642,7 +653,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>ውጣ</translation>
     </message>
@@ -650,7 +661,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>ቅርብ ምስክሌ</translation>
     </message>
@@ -658,7 +669,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>መጠን</translation>
     </message>
@@ -667,6 +678,7 @@ Are you sure you want to continue?</source>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>ኢፔ አድራሻ:</translation>
     </message>
@@ -695,11 +707,13 @@ Are you sure you want to continue?</source>
     <name>NetInfoModel</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>ኢፔች4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>ኢፔች6</translation>
     </message>
@@ -802,17 +816,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation type="unfinished">የ ትእዛዝ መስመር</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation type="unfinished">ማስጀመሪያ ጊዜ</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation type="unfinished">ስም</translation>
     </message>
@@ -820,7 +834,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation type="unfinished">ይጫኑ መተግበሪያ ላይ መጨረስ የሚፈልጉትን</translation>
     </message>
@@ -828,12 +842,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation type="unfinished">ማስታወሻ</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>გა réცემა</translation>
     </message>
@@ -841,67 +859,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation type="unfinished">ሲፒዩ</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation type="unfinished">ዲስክ ማንበቢያ</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation type="unfinished">ዲስክ ላይ መጻፊያ</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation type="unfinished">ማስታወሻ</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation type="unfinished">Swap</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation type="unfinished">አላስቻሉም</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation type="unfinished">የ ወረደ</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation type="unfinished">መጫኛ</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation type="unfinished">ኔትዎርክ</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>სულ გამოყოფილი</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>სულ გაგზავნილი</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>დისკები</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>გაგზავნა</translation>
     </message>
@@ -917,47 +953,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>ძალიან მაღალი</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>მაღალი</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>ნორმალური</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>დაბალი</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>ძალიან დაბალი</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>የተለይ</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>ያልገባ</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, የውድ አይነት: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>ፕሮ세ስ አይነት ምክንያት በመቀየር ብłą የተሳሳተ ነው</translation>
     </message>
@@ -983,32 +1026,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>ፕሮሴስ በማስተካከል ብłą የተሳሳተ ነው</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>ፕሮሴስ በማስተዳደር ብłą የተሳሳተ ነው</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>ፕሮሴስ በማጥፊያ ብłą የተሳሳተ ነው</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>ያልታወቀ የውድ ነው</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>ፕሮሴስ በመስጥር የውድ ነው</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>ፕሮሴስ በማጥፊያ ብłą የተሳሳተ ነው</translation>
     </message>
@@ -1024,17 +1067,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation type="unfinished">መልስ አልተገኘም</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation type="unfinished">ማገጃ</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>ትራይ</translation>
     </message>
@@ -1042,37 +1087,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>ኮማንድ የቦታ ምልክት</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation type="unfinished">ባህሪዎች</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation type="unfinished">ሂደት መጨረሻ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>ፕሮሴስ ምስተዳደር</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>ፕሮሴስ ምጥፊያ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>አይነት በመቀየር</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>ፕሮሴስ ምስተካከል</translation>
     </message>
@@ -1080,18 +1130,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>የተለይ አይነት</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">መሰረዣ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>ቀይር</translation>
@@ -1203,7 +1253,7 @@ Are you sure you want to continue?</source>
         <translation>შეტყობინებები</translation>
     </message>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>არ მხარდაჭერილია</translation>
     </message>
@@ -1211,12 +1261,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>სერვისის სტარტაპ ტიპის დაყენება ვერ მოხდა</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>შეცდომა: სერვისის სტარტაპ ტიპის დაყენება ვერ მოხდა დამატებით სუბპროცესის გარეშე</translation>
     </message>
@@ -1224,17 +1274,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>კარგად</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">መሰረዣ</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>სერვისის ინსტანციის სახელი</translation>
     </message>
@@ -1242,37 +1294,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>განახლება</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>დასაწყებად</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>შეჩერება</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>გადატვირთვა</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>ავტომატურად</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>ხელით</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>სტარტაპის ტიპი</translation>
     </message>
@@ -1323,17 +1379,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>პარამეტრები</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(გადასარჩევია)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>ინტერვალი: %1-%2</translation>
     </message>
@@ -1341,22 +1398,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>უახლოესი გაჩერება პროგრამის გასასვლელად</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>გაფართოება</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>შეკუმშვა</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>ხედავა</translation>
     </message>
@@ -1364,7 +1422,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation type="unfinished">መፈለጊያ</translation>
     </message>
@@ -1372,17 +1431,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>პროცესები</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>სერვისები</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>მომხმარებლები</translation>
     </message>
@@ -1390,7 +1457,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>መረጃ አካውንት ተመዝግቦ ያድርጉ</translation>
     </message>
@@ -1398,12 +1465,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>አდሚኒስትራተር</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>ማnorm የተመዘገበ</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_ar.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_ar.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>مراقب النظام</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>مراقب النظام هو أداة لمراقبة تحميل النظام في الوقت الفعلي، وعمليات العرض والتحكم، والخدمات التي تعمل على نظامك.</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>إخفاء التفاصيل</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>الاستخدام الكلي</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>الاستخدام الفردي</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>قراءة</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>كتابة</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 ثانية </translation>
     </message>
@@ -56,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 أيام %2 ساعة %3 دقيقة</translation>
     </message>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>التردد الحالي</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>التردد</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">إلغاء</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 ثانية </translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>لا نتائج للبحث</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>تفاصيل</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>تفاصيل</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>تحذير</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>المستخدم</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>المتاح</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>مشترك</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>محكم الصache</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>البوثرز</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>تبديل محكم الشايف</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>تفعيل</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>غير نشط</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>مشوه</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>مخرزا</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>إجمالي التبديل</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>空間交換</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>استل</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>النموذج</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>سرعة القراءة</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>سرعة الكتابة</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>السعة</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>اقرأ مجالات</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>قراءات في الثانية</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>مجالات قرأ في الثانية</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>/navbar-objects/merged- mũiٍ‏تم في الثانية</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>تم написة مجالات</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>الihnامات مكتملة</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>ال Writes مدمجة</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>كتابة في الثانية</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>مجالات مكتوبة في الثانية</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>ال نُسخة مدمجة في الثانية</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>موافق</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>النظام</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>عرض الاختصارات</translation>
     </message>
@@ -598,45 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>قد يؤدي إنهاء هذه العملية إلى فقدان البيانات
 هل أنت متأكد من المتابعة؟</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>إنهاء العملية</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>قد يؤدي فرض إنهاء هذه العملية إلى فقدان البيانات
 هل أنت متأكد من المتابعة؟</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>قد يؤدي فرض إنهاء هذا التطبيق إلى فقدان البيانات
 هل أنت متأكد من المتابعة؟</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>انهاء اجباري</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>انهاء</translation>
@@ -645,7 +656,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>تسجيل الخروج</translation>
     </message>
@@ -653,7 +664,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>الإعدادات</translation>
     </message>
@@ -661,7 +672,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>الحجم</translation>
     </message>
@@ -670,6 +681,7 @@ Are you sure you want to continue?</source>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>عنوان بروتوكول الإنترنت (IP)</translation>
     </message>
@@ -788,11 +800,13 @@ Are you sure you want to continue?</source>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>IPv4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>IPv6</translation>
     </message>
@@ -805,17 +819,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>سطر الأوامر</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>وقت البدء</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>الاسم</translation>
     </message>
@@ -823,7 +837,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>اختر التطبيق الذي تودُ انهاءهُ</translation>
     </message>
@@ -831,12 +845,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>الذاكرة</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>المستلم</translation>
     </message>
@@ -844,67 +862,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>المعالج</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>القراءة من القرص</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>الكتابة على القرص</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>الذاكرة</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>ذاكرة التبديل</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>غير مفعل</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>التنزيل</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>الرفع</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>الشبكة</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>التلقي الإجمالي</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>الإرسال الإجمالي</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>المرسل</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>الأقراص</translation>
     </message>
@@ -920,47 +956,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>مرتفع جداً</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>مرتفع</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>طبيعي</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>منخفض</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>منخفض جداً</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>مخصص</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>غير صالح</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, خطأ: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>فشل في تغيير أولوية العملية</translation>
     </message>
@@ -986,32 +1029,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>فشل في ايقاف العملية</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>فشل في استئناف العملية</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>فشل في قتل العملية</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>خطأ غير معروف</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>فشل في إرسال إشارة للمعالجة</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>فشل إنهاء عملية</translation>
     </message>
@@ -1027,17 +1070,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>لا استجابة</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>تعليق</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>طبق النظام</translation>
     </message>
@@ -1045,37 +1090,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>عرض موقع الأوامر</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>الخصائص</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>إنهاء العملية</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>استئناف العملية</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>قتل العملية</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>تغيير الأولوية</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>تعليق العملية</translation>
     </message>
@@ -1083,18 +1133,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>أولوية مخصصة</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>تغيير</translation>
@@ -1171,7 +1221,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>غير مدعوم</translation>
     </message>
@@ -1214,12 +1264,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>فشل تعيين نوع بدء تشغيل الخدمة</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>خطأ: فشل تعيين نوع بدء تشغيل الخدمة بسبب تعطل العملية الفرعية.</translation>
     </message>
@@ -1227,17 +1277,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>اسم مثيل الخدمة</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>موافق</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
@@ -1245,37 +1297,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>تحديث</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>بدء</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>إيقاف</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>إعادة البدء</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>تلقائي</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>يدوي</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>نوع بدء التشغيل</translation>
     </message>
@@ -1326,17 +1382,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>الإعدادات</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(قابل للتغيير</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>م范畴: %1-%2</translation>
     </message>
@@ -1344,22 +1401,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>فرض إنهاء التطبيق</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>توسيع</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>دمج</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>عرض</translation>
     </message>
@@ -1367,7 +1425,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>بحث</translation>
     </message>
@@ -1375,17 +1434,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>العمليات</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>الخدمات</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>المستخدمون </translation>
     </message>
@@ -1393,7 +1460,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>تعديل معلومات الحساب</translation>
     </message>
@@ -1401,12 +1468,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>المسؤول</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>المستخدم الإفتراضي</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_az.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_az.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Sistem İzləyici</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Sistem İzləyici, sistemin yüklənməsini, sisteminizdəki işlək proseslərə və xidmətlərə baxış və onlara nəzarəti izləmək üçün alətdir.</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Təfərrüatları gizlətmək</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Ümumi istifadə</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Fərdi istifadə</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Oxumaq</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Yazmaq</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 saniyə</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 gün %2 saat %3 dəqiqə</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Cari tezlik</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Tezlik</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">İmtina</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 saniyə</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Axtarış nəticəsi yoxdur</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Təfərrüatlar</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Təfərrüatlar</translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>İstifadə olunan</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Əlçatan</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Paylaşılan</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Keşlənmiş</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Buferlər</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Keşlənmiş mübadilə bölməsi</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Aktiv</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Qeyri-aktiv</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Çirkli</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Xəritələndi</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Ümumi mübadilə bölməsi</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Boş mübadilə bölməsi</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Hissə</translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Oxuma sürəti</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Yazma sürəti</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Tutum</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Oxunan sektorlar</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Oxunur</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Sektorlar oxunur</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Birləşmiş oxunanlar</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Yazılmış sektorlar</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Yazılma başa çatdı</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Birləşdirilmiş yazılar</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Yazılır</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Yazılmış sektorlar</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Birləşdirilmiş yazılar</translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OLDU</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Sistem</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Qısayolları göstərmək</translation>
     </message>
@@ -604,50 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Bu prosesin sonlandırılması ilə verilənlər itirilə bilər.
 Davam etmək istədiyinizə əminsiniz?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Prosesin sonu</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Bu prosesin məcburi sonlandırılması verilənlərin itirilməsi ilə nəticələnər.
 Davam etmək istədiyinizə əminsiniz?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Bu tətbiqin məcburi sonlandırılması ilə verilənlər itirilə bilər.
 Davam etmək istədiyinizə əminsiniz?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Məcburi sonlandırmaq</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Sonlandırmaq</translation>
@@ -656,7 +656,7 @@ Davam etmək istədiyinizə əminsiniz?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Çıxış</translation>
     </message>
@@ -664,7 +664,7 @@ Davam etmək istədiyinizə əminsiniz?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Ayarlar</translation>
     </message>
@@ -672,7 +672,7 @@ Davam etmək istədiyinizə əminsiniz?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Ölçü</translation>
     </message>
@@ -819,17 +819,17 @@ Davam etmək istədiyinizə əminsiniz?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Əmr sətri</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Başlama vaxtı</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Adı</translation>
     </message>
@@ -837,7 +837,7 @@ Davam etmək istədiyinizə əminsiniz?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Sonlandırmaq istədiyiniz tətbiqi seçin</translation>
     </message>
@@ -845,16 +845,16 @@ Davam etmək istədiyinizə əminsiniz?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Yaddaş</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Almaq</translation>
     </message>
@@ -862,85 +862,85 @@ Davam etmək istədiyinizə əminsiniz?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>MP</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Diskin oxunması</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Diskin yazılması</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Yaddaş</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Mübadilə bölməsi</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Qoşulmayıb</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Yükləmək</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Göndərmək</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Şəbəkə</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Ümumi alınan</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Ümumi göndərilən</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Göndərmək</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Disklər</translation>
     </message>
@@ -956,54 +956,54 @@ Davam etmək istədiyinizə əminsiniz?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Çox yüksək</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Yüksək</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Aşağı</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Çox aşağı</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Xüsusi</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Yararsız</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Xəta: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Prosesin üstünlüyünü dəyişmək alınmadı</translation>
     </message>
@@ -1029,32 +1029,32 @@ Davam etmək istədiyinizə əminsiniz?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Prosesə fasilə vermək alınmadı</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Prosesi davam etdirmək alınmadı</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Prosesi məhv etmək alınmadı</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Bilinməyən xəta</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Prosesə siqnal göndərilə bilmədi</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Prosesi sonlandırmaq baş tutmadı</translation>
     </message>
@@ -1070,19 +1070,19 @@ Davam etmək istədiyinizə əminsiniz?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Cavab yoxdur</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Dayandırmaq</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Panel</translation>
     </message>
@@ -1090,42 +1090,42 @@ Davam etmək istədiyinizə əminsiniz?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Əmrin yerinə baxmaq</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Xüsusiyyətlər</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Prosesin sonu</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Prosesə davam</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Prosesi məh etmək</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Üstünlüyü dəyişmək</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Prosesi dayandırmaq</translation>
     </message>
@@ -1133,18 +1133,18 @@ Davam etmək istədiyinizə əminsiniz?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Xüsusi üstünlük</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Dəyişmək</translation>
@@ -1221,7 +1221,7 @@ Davam etmək istədiyinizə əminsiniz?</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Dəstəklənmir</translation>
     </message>
@@ -1264,12 +1264,12 @@ Davam etmək istədiyinizə əminsiniz?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Xidmətin başladılma növünü təyin etmək baş tutmadı</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Xəta: Ona tabe olan proses çökdüyü halda, xidmətin başladılma növü dəyişdirilə bilmədi.</translation>
     </message>
@@ -1277,19 +1277,19 @@ Davam etmək istədiyinizə əminsiniz?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Xidmətin adı</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>OLDU</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>İmtina</translation>
     </message>
@@ -1297,41 +1297,41 @@ Davam etmək istədiyinizə əminsiniz?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Təzələmək</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Başlamaq</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Dayandırmaq</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Yenidən başlatmaq</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Öz-özünə</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Əl ilə</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Başladılma növü</translation>
     </message>
@@ -1382,18 +1382,18 @@ Davam etmək istədiyinizə əminsiniz?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Ayarlar</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Dəyişdiriləbilən)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Aralıq: %1-%2: </translation>
     </message>
@@ -1401,23 +1401,23 @@ Davam etmək istədiyinizə əminsiniz?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Tətbiqi məcburi sonlandırmaq</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Genişləndirmək</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Yığcam</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Görünüş</translation>
     </message>
@@ -1425,8 +1425,8 @@ Davam etmək istədiyinizə əminsiniz?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Axtarış</translation>
     </message>
@@ -1434,25 +1434,25 @@ Davam etmək istədiyinizə əminsiniz?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Proseslər</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Xidmətlər</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>İstifadəçilər</translation>
     </message>
@@ -1460,7 +1460,7 @@ Davam etmək istədiyinizə əminsiniz?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>İstifadəçi məlumatlarına düzəliş edin</translation>
     </message>
@@ -1468,12 +1468,12 @@ Davam etmək istədiyinizə əminsiniz?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>İnzibatçı</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Standart istifadəçi</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_bg.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_bg.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Системен монитор</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Системен монитор е инструмент за проследяване на текущата система за натоварване, преглед и управление на процеси и услуги, изпълняващи се върху вашата система.</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Скриване на подробности</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Общо използване</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Индивидуално използване</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Четене</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Писане</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 секунди</translation>
     </message>
@@ -56,9 +60,9 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
-        <translation>'%1 дни %2 часа %3 минути'</translation>
+        <translation>&apos;%1 дни %2 часа %3 минути&apos;</translation>
     </message>
 </context>
 <context>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Текуща честота</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Честота</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="100"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Отказ</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 секунди</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Няма резултати от търсене</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Детайли</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Детайли</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>Предупреждение</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Използвано</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Достъпно</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Споделено</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Кеширани</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Буфери</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Кеширани обмен</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Активно</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Неактивно</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Загрязнено</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Мапирани</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Общ обмен</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Свободен обмен</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Слаб</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Модел</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Скорост на четене</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Скоростта на запис</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Капацитет</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Сектори за четене</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Четене/с</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Сектори за четене/с</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Сливане на четене/с</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Сектори за запис</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Записи завършени </translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Сливане на запис</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Запис/с</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Сектори за запис/с</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Сливане на запис/с</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Да</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Система</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Покажи кратки съкратки</translation>
     </message>
@@ -598,44 +604,49 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation type="unfinished">Прекратяването на този процес може да причини загуба на данни.
 Сигурни ли сте, че искате да продължите? </translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Краен</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation type="unfinished">Край на процес</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Отказ</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Силно прекратяване</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Силното прекратяване на този процес може да доведе до загуба на данни.
 Сигурни ли сте, че искате да продължите?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Силното прекратяване на това приложение може да доведе до загуба на данни.
@@ -645,7 +656,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Изход</translation>
     </message>
@@ -653,7 +664,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Настройки</translation>
     </message>
@@ -661,7 +672,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Размер</translation>
     </message>
@@ -670,6 +681,7 @@ Are you sure you want to continue?</source>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>IP адрес:</translation>
     </message>
@@ -698,11 +710,13 @@ Are you sure you want to continue?</source>
     <name>NetInfoModel</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>IPv4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>IPv6</translation>
     </message>
@@ -805,17 +819,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation type="unfinished">Команден ред</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation type="unfinished">Време на стартиране</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation type="unfinished">Име</translation>
     </message>
@@ -823,7 +837,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation type="unfinished">Кликнете на приложението, което искате да спрете</translation>
     </message>
@@ -831,12 +845,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation type="unfinished">Памет</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Получаване</translation>
     </message>
@@ -844,67 +862,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation type="unfinished">Процесор</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation type="unfinished">Четене на диска</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation type="unfinished">Запис на диска</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation type="unfinished">Памет</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation type="unfinished">Swap</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation type="unfinished">Не е разрешено</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation type="unfinished">Сваляне</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation type="unfinished">Качване</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation type="unfinished">Мрежа</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Общо получено</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Общо изпратено</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Дискове</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Изпращане</translation>
     </message>
@@ -920,47 +956,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Много висок</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Висок</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Нормален</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Нисок</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Много нисок</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Персонализиран</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Невалиден</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Грешка: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Неуспешно променяване на приоритета на процеса</translation>
     </message>
@@ -986,32 +1029,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Неуспешно приключване на процеса</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Неуспешно възстановяване на процеса</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Неуспешно прекращаване на процеса</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Неизвестна грешка</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Неуспешно изпращане на сигнал към процеса</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Неуспешно приключване на процеса</translation>
     </message>
@@ -1027,17 +1070,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation type="unfinished">Няма отговор</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation type="unfinished">Приспиване</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation type="unfinished">Лента на задачи</translation>
     </message>
@@ -1045,37 +1090,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Покажи позицията на командата</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation type="unfinished">Свойства</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation type="unfinished">Край на процес</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Възстанови процеса</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Прекъсни процеса</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Промени приоритета</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Приключи процеса</translation>
     </message>
@@ -1083,18 +1133,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Персонализиран приоритет</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Отказ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Промени</translation>
@@ -1206,7 +1256,7 @@ Are you sure you want to continue?</source>
         <translation>Уведомления</translation>
     </message>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Не поддържан</translation>
     </message>
@@ -1214,12 +1264,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Неуспешно зададен вид стартиране на услугата</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Грешка: Неуспешно задаване на вид стартиране на услугата поради изчезналия подпроцес.</translation>
     </message>
@@ -1227,17 +1277,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>ДА</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Отказ</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Име на инстанцията на услугата</translation>
     </message>
@@ -1245,37 +1297,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Обнови</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Стартирай</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Стопирай</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Пусни отново</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Автоматично</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Ръчно</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Вид стартиране</translation>
     </message>
@@ -1326,17 +1382,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Настройки</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Променяемо)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Ранг: %1-%2</translation>
     </message>
@@ -1344,22 +1401,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Силно приключване на приложението</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Разширение</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Съкращение</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Преглед</translation>
     </message>
@@ -1367,7 +1425,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation type="unfinished">Търсене</translation>
     </message>
@@ -1375,17 +1434,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Процеси</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Услуги</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Потребители</translation>
     </message>
@@ -1393,7 +1460,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Редактирай информация за акаунта</translation>
     </message>
@@ -1401,12 +1468,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Администратор</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Стандартен потребител</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_bn.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_bn.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>সিস্টেম মনিটর</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>এটি একটি উপকরণ যা সাইনাল সিস্টেমের সময়সূচিত বার্ষিক ভার পর্যবেক্ষণ করতে, প্রক্রিয়া এবং সেবা পর্যবেক্ষণ এবং কন্ট্রোল করার জন্য ব্যবহৃত হয়।</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>বিস্তারিত সরানো</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>মোট ব্যবহার</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>একক ব্যবহার</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>ঢাকা</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>লেখা</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 সেকেন্ড</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 দিন %2 ঘণ্টা %3 মিনিট</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>বর্তমান ব্যবহারের ব্যবধান</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>ব্যবধান</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation>বাতিল</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 সেকেন্ড</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>নাই সার্চ ফলাফল</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>বিস্তারিত</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>বিস্তারিত</translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>এখানে ব্যবহৃত</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>প্রাপ্য</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>যোগাযোগ</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>কেশিতে রাখা</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>বার্সার</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>কেশিতে ব্যবহৃত ব্যান্ড</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>কার্যকর</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>অকার্যকর</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>অপরিষ্কার</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>ম্যাপেড</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>মোট ব্যান্ড</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>বাকি ব্যান্ড</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>স্ল্যাব</translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>মডেল</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>মানচিত্র গ্রহনের গতি</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>মানচিত্র লিখনের গতি</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>ক্যাপাসিটি</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>ডিস্ক সেক্টর পড়া</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>প্রতি সেকেন্ড পড়া</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>প্রতি সেকেন্ড ডিস্ক সেক্টর পড়া</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>প্রতি সেকেন্ড মিশ্রিত পড়া</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>ডিস্ক সেক্টর লিখা</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>লিখা সম্পন্ন</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>লিখা মিশ্রিত</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>প্রতি সেকেন্ড লিখা</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>সংরক্ষিত ইউনিট/সেকেন্ড</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>মিশ্রিত লিখ/সেকেন্ড</translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>স্বাগতম</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>সিস্টেম</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>প্রদর্শন করার ট্যাপগুলি দেখান</translation>
     </message>
@@ -604,7 +604,7 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>এই প্রক্রিয়াটি শেষ করার ক্ষেত্রে ডেটা হানা হতে পারে।
@@ -612,14 +612,14 @@ Are you sure you want to continue?</source>
 </translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>প্রক্রিয়া শেষ করুন</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>ফোর্সে এই প্রক্রিয়াটি শেষ করার ক্ষেত্রে ডেটা হানা হতে পারে।
@@ -627,7 +627,7 @@ Are you sure you want to continue?</source>
 </translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>ফোর্সে এই প্রোগ্রামটি শেষ করার ক্ষেত্রে ডেটা হানা হতে পারে।
@@ -635,22 +635,22 @@ Are you sure you want to continue?</source>
 </translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>বাতিল করুন</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>ফোর্সে শেষ করুন</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>শেষ করুন</translation>
@@ -659,7 +659,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>লগআউট</translation>
     </message>
@@ -667,7 +667,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>সেটিংস</translation>
     </message>
@@ -675,7 +675,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>ব্যাস</translation>
     </message>
@@ -822,17 +822,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>কমান্ড লাইন</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>শুরুর সময়</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>নাম</translation>
     </message>
@@ -840,7 +840,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>চাইলে শেষ করতে একটি অ্যাপ্লিকেশন ক্লিক করুন</translation>
     </message>
@@ -848,16 +848,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>মেমরি</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>প্রাইভেট রিসিভ</translation>
     </message>
@@ -865,85 +865,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>ডিস্ক পড়া</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>ডিস্ক লিখা</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>মেমরি</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>বিন্যাস</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>নেক্সিবল</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>ডাউনলোড</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>আপলোড</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>নেটওয়ার্ক</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>মোট সংগ্রহিত</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>মোট প্রেরিত</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>প্রেরণা</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>ডিস্কস</translation>
     </message>
@@ -959,54 +959,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>খুব উচ্চ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>উচ্চ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>নরম</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>লোয়</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>খুব লোয়</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>স্বাপ্পাত</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>অব্যাহত</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, ত্রুটি: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>প্রক্রিয়ার প্রায়তন পরিবর্তন করা ব্যর্থ হয়েছে</translation>
     </message>
@@ -1032,32 +1032,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>প্রক্রিয়ার প্রায়তন দমন করা ব্যর্থ হয়েছে</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>প্রক্রিয়ার প্রায়তন প্রারম্ভ করা ব্যর্থ হয়েছে</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>প্রক্রিয়া হত্যা করা ব্যর্থ হয়েছে</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>অজানা ত্রুটি</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>প্রক্রিয়ায় সিগন্যাল পাঠার ক্ষেত্রে ত্রুটি</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>প্রক্রিয়া শেষ করার ক্ষেত্রে ত্রুটি</translation>
     </message>
@@ -1073,19 +1073,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>কোনো সংক্ষেপ নেই</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>স্পার্সিভ করুন</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>ত্যারি</translation>
     </message>
@@ -1093,42 +1093,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>কম্যান্ডের স্থান দেখুন</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>প্রবৃত্তি</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>প্রক্রিয়া শেষ করুন</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>প্রক্রিয়া শুরু করুন</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>প্রক্রিয়া হারিয়ে দূর করুন</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>প্রাইオリティを変更</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>প্রক্রিয়া স্পার্সিভ করুন</translation>
     </message>
@@ -1136,18 +1136,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>স্বাপ্নলিখিত প্রাইオリティ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>বাতিল</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>পরিবর্তন করুন</translation>
@@ -1224,7 +1224,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>সমর্থন করা হয়নি</translation>
     </message>
@@ -1267,12 +1267,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>সেবা শুরু ধরন নির্ধারণ করার অস্পষ্টতা</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>পাত্র: উপ-প্রক্রিয়া ক্রস্ট্রাসে কারণে সেবা শুরু ধরন নির্ধারণ করার অস্পষ্টতা</translation>
     </message>
@@ -1280,19 +1280,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>সেবা অনুবাদকের নাম</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>প্রাণসংরক্ষণ</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>বাতিল</translation>
     </message>
@@ -1300,41 +1300,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>আরেকবার পরিসংখ্যান</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>শুরু করুন</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>মোটামুটি</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>পুনরায় শুরু করুন</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>অটো</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>ম্যানুয়াল</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>শুরু ধরন</translation>
     </message>
@@ -1385,18 +1385,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>সেটিংস</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(সম্পাদ্যকর্তা)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>পরিসর: %1-%2</translation>
     </message>
@@ -1404,23 +1404,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>প্রোগ্রাম শেষ করুন</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>প্রসারিত করুন</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>কম্পাক্ট</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>ভিউ</translation>
     </message>
@@ -1428,8 +1428,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>অনুসন্ধান</translation>
     </message>
@@ -1437,25 +1437,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>প্রসেস্সস</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>সেবা</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>ব্যবহারকারীরা</translation>
     </message>
@@ -1463,7 +1463,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>বার্ডার তথ্য সম্পাদনা করুন</translation>
     </message>
@@ -1471,12 +1471,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>অ্যাডমিনিস্ট্রেটর</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>স্ট্যান্ডার্ড ব্যবহারকারী</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_bo.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_bo.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>མ་ལག་ལྟ་སྲུང་ཆས།</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>མ་ལག་ལྟ་སྲུང་ཆས་ནི་མཁྲེགས་ཆས་ཐེག་ཁུར་དང་བྱ་རིམ་བཀོལ་སྤྱོད། མ་ལག་ཞབས་ཞུ་བཅས་ལ་དཔྱད་འཇལ་ལྟ་ཞིབ་དང་བཀོལ་སྤྱོད་དོ་དམ་བྱེད་པའི་མ་ལག་ཡོ་བྱད་ཅིག་རེད།</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>ཞིབ་ཕྲའི་གནས་ཚུལ་ཡིབ་པ།</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>སྤྱིའི་བེད་སྤྱོད་བྱེད་ཚད།</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>སྒེར་གྱི་བེད་སྤྱོད་བྱེད་ཚད།</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>ཀློག་པ།</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>འབྲི་བ།</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>སྐར་ཆ་60</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>ཉིན་%1དང་ཆུ་ཚོད་%2སྐར་མ་%3</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>མིག་སྔའི་ཟློས་ཕྱོད།</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>ཟློས་ཕྱོད།</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">འདོར་བ།</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>སྐར་ཆ་60</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>འཚོལ་ཞིབ་བྱས་འབྲས་མེད།</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>ཞིབ་ཕྲའི་ཆ་འཕྲིན།</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>ཞིབ་ཕྲའི་ཆ་འཕྲིན།</translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>སྤྱད་ཟིན།</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>སྤྱོད་རུང་བ།</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>མཉམ་སྤྱོད་ནང་གསོག</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>མྱུར་མགྱོགས་གསོག་ཉར།</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>གཞི་གྲངས་གསོག་ཉར།</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>བརྗེ་གསོག་ཁུལ།</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>བྱེད་སྒོ།</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>གནས་སྐབས་བེད་སྤྱོད་མེད་པའི་བར་ཁུལ་ཡིག་ཆ།</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>བཙོག་ཤོག</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>རྟེན་འཕྲོ་ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>བརྗེ་སའི་བར་སྟོང་ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>སྤྱོད་རུང་བའི་བརྗེ་སྟོང་།</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>གཞི་གྲངས་གྲུབ་ཚུལ་གསོག་ཉར།</translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>བཟོ་རྟགས།</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>ཀློག་པའི་མྱུར་ཚད།</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>འབྲི་བའི་མྱུར་ཚད།</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>ཤོང་ཚད།</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>གཡབ་ཁུལ་ཀློག་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>སྐར་ཆ་རེར་ཀློག་པའི་སྤྱོད་ཐེངས།</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>སྐར་ཆ་རེའི་གཡབ་ཁུལ་ཀློག་ཐེངས།</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>སྐར་ཆ་རེར་ཟླ་སྒྲིལ་ནས་ཀློག་པའི་སྤྱོད་ཐེངས།</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>གཡབ་ཁུལ་འབྲི་ཐེངས།</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>བྲིས་ཚར་བའི་ཐེངས་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>ཟླ་སྒྲིལ་ནས་བྲིས་ཚར་བའི་ཐེངས་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>སྐར་ཆ་རེར་འབྲི་ཐེངས།</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>སྐར་ཆ་རེའི་གཡབ་ཁུལ་འབྲི་ཐེངས།</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>སྐར་ཆ་རེའི་ཟླ་སྒྲིལ་ནས་འབྲི་ཐེངས།</translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>ཆོག</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>མ་ལག</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>མྱུར་མཐེབ་འཆར་བ།</translation>
     </message>
@@ -604,50 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>བརྒྱུད་རིམ་མཇུག་སྒྲིལ་་བྱས་ན་གཞི་གྲངས་བོར་བའི་ཉེན་ཁ་ཡོད། 
 ཁྱེད་ཀྱིས་བདམས་པའི་བརྒྱུད་རིམ་མཇུག་སྒྲིལ་རྒྱུ་གཏན་འཁེལ་ལམ།</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>བརྒྱུད་རིམ་མཇུག་སྒྲིལ་བ།</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>བཙན་ཐབས་ཀྱིས་བརྒྱུད་རིམ་མཇུག་སྒྲིལ་་བྱས་ན་གཞི་གྲངས་བོར་བའི་ཉེན་ཁ་ཡོད། 
 ཁྱེད་ཀྱིས་བདམས་པའི་བརྒྱུད་རིམ་མཇུག་སྒྲིལ་རྒྱུ་གཏན་འཁེལ་ལམ།</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>བཙན་ཐབས་ཀྱིས་ཉེར་སྤྱོད་མཇུག་སྒྲིལ་་བྱས་ན་གཞི་གྲངས་བོར་བའི་ཉེན་ཁ་ཡོད། 
 ཁྱེད་ཀྱིས་བདམས་པའི་ཉེར་སྤྱོད་མཇུག་སྒྲིལ་རྒྱུ་གཏན་འཁེལ་ལམ།</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>བཙན་ཐབས་ཀྱིས་མཇུག་སྒྲིལ་བ།</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>བརྒྱུད་རིམ་མཇུག་སྒྲིལ་བ།</translation>
@@ -656,7 +656,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>ཕྱིར་འོང་</translation>
     </message>
@@ -664,7 +664,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>སྒྲིག་འགོད།</translation>
     </message>
@@ -672,7 +672,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>ཤོང་ཚད་ཆེ་ཆུང་།</translation>
     </message>
@@ -819,17 +819,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>བཀའི་ཕྲེང་།</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>འགོ་སློང་དུས་ཚོད།</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>མིང་།</translation>
     </message>
@@ -837,7 +837,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>ཁྱེད་ཀྱིས་མཇུག་སྒྲིལ་འདོད་པའི་ཉེར་སྤྱོད་བྱ་རིམ་མནན་རྒྱུ།</translation>
     </message>
@@ -845,16 +845,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>ནང་གསོག</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>དང་ལེན།</translation>
     </message>
@@ -862,85 +862,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>ཐག་གཅོད་ཆས།</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>སྡུད་སྡེར་ཀློག་ལེན།</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>སྡུད་སྡེར་འབྲི་བ།</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>ནང་གསོག</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>བརྗེ་སྤྲོད་བར་སྣང་།</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>སྤྱོད་འགོ་ཚུགས་མེད།</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>ཕབ་ལེན།</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>སྐྱེལ་འཇོག</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>དྲ་བ།</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>བསྡུ་ལེན་བྱས་པའི་བསྡོམས་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>བསྐུར་བའི་བསྡོམས་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>བསྐུར་བ།</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>སྡུད་སྡེར།</translation>
     </message>
@@ -956,54 +956,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>ཧ་ཅང་མཐོ།</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>མཐོ།</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>སྤྱིར་བཏང་།</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>དམའ།</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>ཧ་ཅང་དམའ།</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>རང་སྒྲུབ།</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>ནུས་མེད།</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>བརྒྱུད་རིམ་ཨང་རྟགས། : %1, Error: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>བརྒྱུད་རིམ་གྱི་སྔོན་རིམ་བསྒྱུར་མི་ཐུབ།</translation>
     </message>
@@ -1029,32 +1029,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>བརྒྱུད་རིམ་མཚམས་འཇོག་བྱེད་མི་ཐུབ།</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>བརྒྱུད་རིམ་སླར་གསོ་བྱེད་མི་ཐུབ།</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>བཙན་ཐབས་ཀྱིས་བརྒྱུད་རིམ་མཇུག་སྒྲིལ་མི་ཐུབ།</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>མི་ཤེས་པའི་ནོར་འཁྲུལ།</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>བརྒྱུད་རིམ་དུ་བརྡ་རྟགས་བསྐུར་མི་ཐུབ།</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>བརྒྱུད་རིམ་མཇུག་སྒྲིལ་བྱེད་མི་ཐུབ།</translation>
     </message>
@@ -1070,19 +1070,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>ཡ་ལན་མེད།</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>སྐབས་འཇོག</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>འདེགས་སྡེར།</translation>
     </message>
@@ -1090,42 +1090,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>བཀའ་ཡོད་སའི་ས་གནས་ལྟ་བཤེར་བྱེད་པ།</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>ངོ་བོ།</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>བརྒྱུད་རིམ་མཇུག་སྒྲིལ་བ།</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>བརྒྱུད་རིམ་མུ་མཐུད་སྤྱོད་པ།</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>བཙན་ཐབས་ཀྱིས་བརྒྱུད་རིམ་མཇུག་སྒྲིལ་བ།</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>སྔོན་རིམ་བསྒྱུར་བ།</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>བརྒྱུད་རིམ་མཚམས་འཇོག་པ།</translation>
     </message>
@@ -1133,18 +1133,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>རང་སྒྲུབ་སྔོན་རིམ།</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>བསྒྱུར་བ།</translation>
@@ -1221,7 +1221,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>རྒྱབ་སྐྱོར་མེད་པ།</translation>
     </message>
@@ -1264,12 +1264,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>ཞབས་ཞུའི་འགོ་སློང་བྱེད་ཐབས་སྒྲིག་འགོད་བྱེད་མི་ཐུབ།</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>ནོར་འཁྲུལ། ཡན་ལག་བརྒྱུད་རིམ་ཐོར་བའི་རྐྱེན་གྱིས། ཞབས་ཞུའི་འགོ་སློང་བྱེད་ཐབས་སྒྲིག་འགོད་བྱེད་མི་ཐུབ།</translation>
     </message>
@@ -1277,19 +1277,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>ཞབས་ཞུ་དངོས་དཔེའི་མིང་།</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>ཆོག</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>འདོར་བ།</translation>
     </message>
@@ -1297,41 +1297,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>གསར་འདོན།</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>འགོ་སློང་།</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>མཚམས་འཇོག</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>བསྐྱར་སློང་།</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>རང་འགུལ།</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>ལག་སྒུལ།</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>འགོ་སློང་ཐབས་སྒྲིག་འགོད།</translation>
     </message>
@@ -1382,18 +1382,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>སྒྲིག་འགོད།</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>（གྲངས་ཚད་བཅོས་ཆོག）</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>གྲངས་ཚད་ཀྱི་ཁྱབ་ཁོངས། %1-%2</translation>
     </message>
@@ -1401,23 +1401,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>བཙན་ཐབས་ཀྱིས་ཉེར་སྤྱོད་བྱ་རིམ་མཇུག་སྒྲིལ་བ།</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>ལྷོད་པོ།</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>དམ་པོ།</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>མཐོང་རིས།</translation>
     </message>
@@ -1425,8 +1425,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>འཚོལ་ཞིབ།</translation>
     </message>
@@ -1434,25 +1434,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>བྱ་རིམ་བརྒྱུད་རིམ།</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>མ་ལག་ཞབས་ཞུ།</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>རྒྱུན་ཆེད</translation>
     </message>
@@ -1460,7 +1460,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>རྒྱུན་ཆེད་གོང་གི་ཆ་འགོད་བཟོ་</translation>
     </message>
@@ -1468,12 +1468,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>དཔེ་སྤྱི་གི་དཔེ་</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>རྒྱུན་ཆེད་སྤྱི་</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_br.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_br.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Monitor sistem</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Monitor sistem a zo un ostilh evit gellout merañ karg ar sistem en amzer-wirion, gwelet ha kontroliñ ar prosesusoù hag ar servijoù a zo sekutet en ho sistem.</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>إخفاء التفاصيل</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>استخدام عام</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>استخدام فردي</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>قراءة</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>كتابة</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 ثانية</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 أيام %2 ساعات %3 دقائق</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>التردد الحالي</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>التردد</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Nullañ</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 ثانية</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>N&apos;eus bet kavet disoc&apos;h ebet</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>التفاصيل</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>التفاصيل</translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>المستعمل</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>متاح</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>المشاركة</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>المخزن المؤقت</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>الuffers</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>التبديل المخزن المؤقت</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Oberiant</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>غير النشطة</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>الغير نظيفة</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>المعلقة</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>التبديل الكلي</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>التبديل الخالي</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>السلاب</translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>النموذج</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>سرعة القراءة</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>سرعة الكتابة</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>السعة</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>الأقسام المُقرَأة</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>القراءات/الثانية</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>الأقسام المُقرَأة/الثانية</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>القراءات المدمجة/الثانية</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>الأقسام المكتوبة</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>القراءات/الثانية</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>المدمجة الكتابة</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>الكتابات/الثانية</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>الأقسام المكتوبة/الثانية</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>الكتابات المدمجة/الثانية</translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Mat eo</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Sistem</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Diskouez ar berradurioù</translation>
     </message>
@@ -604,50 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Roadennoù a c&apos;hallfe bezañ kollet en ur baouez ar prosesus-mañ.
 Ha c&apos;hoant ho peus kenderc&apos;hel ganti?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Echuiñ ar prosesus</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Roadennoù a c&apos;hallfe bezañ kollet en ur rediañ paouez ar prosesus-mañ.
 Ha sur oc&apos;h ho peus c&apos;hoant da genderc&apos;hel ganti?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Roadennoù a c&apos;hallfe bezañ kollet en ur rediañ paouez an arload-mañ.
 Ha sur ho peus c&apos;hoant da genderc&apos;hel ganti?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Nullañ</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Rediañ kuitaat</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Fin</translation>
@@ -656,7 +656,7 @@ Ha sur ho peus c&apos;hoant da genderc&apos;hel ganti?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>تسجيل الخروج</translation>
     </message>
@@ -664,7 +664,7 @@ Ha sur ho peus c&apos;hoant da genderc&apos;hel ganti?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>الإعدادات</translation>
     </message>
@@ -672,7 +672,7 @@ Ha sur ho peus c&apos;hoant da genderc&apos;hel ganti?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>الحجم</translation>
     </message>
@@ -819,17 +819,17 @@ Ha sur ho peus c&apos;hoant da genderc&apos;hel ganti?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Linenn urzhiad</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Eurvezh loc&apos;hañ</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Anv</translation>
     </message>
@@ -837,7 +837,7 @@ Ha sur ho peus c&apos;hoant da genderc&apos;hel ganti?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Klikañ war an arload ho peus c&apos;hoant da serriñ</translation>
     </message>
@@ -845,16 +845,16 @@ Ha sur ho peus c&apos;hoant da genderc&apos;hel ganti?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Memor</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Receber</translation>
     </message>
@@ -862,85 +862,85 @@ Ha sur ho peus c&apos;hoant da genderc&apos;hel ganti?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>O lenn an disk</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>O skrivañ an disk</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Memor</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Eskemm</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Nann-enaouet</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Pellgargañ</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Pellgas</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Rouedad</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Hollad resevet</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Kaset en holl</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Enviar</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Discos</translation>
     </message>
@@ -956,54 +956,54 @@ Ha sur ho peus c&apos;hoant da genderc&apos;hel ganti?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Uhel kenañ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Uhel</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Izel</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Izel-tre</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Personnelaet</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Direizh</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Fazi: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>N&apos;heller ket cheñch priorelezh ar perzhioù</translation>
     </message>
@@ -1029,32 +1029,32 @@ Ha sur ho peus c&apos;hoant da genderc&apos;hel ganti?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>N&apos;heller ket paouez ar prosesus</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>N&apos;heller ket adkemer ar prosesus</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>N&apos;heller ket lazhañ ar prosesus</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Fazi dizanv</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>C&apos;hwitet ez eus bet war gasadenn signal ar prosesus</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>C&apos;hwitet ez eus bet war fin ar prosesus</translation>
     </message>
@@ -1070,19 +1070,19 @@ Ha sur ho peus c&apos;hoant da genderc&apos;hel ganti?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Respont ebet</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Suspentañ</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Barrenn</translation>
     </message>
@@ -1090,42 +1090,42 @@ Ha sur ho peus c&apos;hoant da genderc&apos;hel ganti?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Gwelet pelec&apos;h emañ an urzhiad</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Perzhioù</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Echuiñ ar prosesus</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Adloc&apos;hañ ar prosesus</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Lazhañ ar prosesus</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Cheñch ar priorelezh</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Suspantañ ar prosesus</translation>
     </message>
@@ -1133,18 +1133,18 @@ Ha sur ho peus c&apos;hoant da genderc&apos;hel ganti?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Priorelezh personelaet</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Nullañ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Cheñch</translation>
@@ -1221,7 +1221,7 @@ Ha sur ho peus c&apos;hoant da genderc&apos;hel ganti?</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>غير مدعوم</translation>
     </message>
@@ -1264,12 +1264,12 @@ Ha sur ho peus c&apos;hoant da genderc&apos;hel ganti?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>N&apos;heller ket spisaat mod loc&apos;hañ ar servij</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Fazi: C&apos;hwitet ez eus bet war termenadur doare loc&apos;hañ ar servij abalamour d&apos;un isprosesus a zo sac&apos;hat.</translation>
     </message>
@@ -1277,19 +1277,19 @@ Ha sur ho peus c&apos;hoant da genderc&apos;hel ganti?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Anv an iñstañs servijoù</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>Mat eo</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>Nullañ</translation>
     </message>
@@ -1297,41 +1297,41 @@ Ha sur ho peus c&apos;hoant da genderc&apos;hel ganti?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Freskaat</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Loc&apos;hañ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Paouez</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Adloc&apos;hañ</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Emgefreek</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Dornlevr</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Doare loc&apos;hañ</translation>
     </message>
@@ -1382,18 +1382,18 @@ Ha sur ho peus c&apos;hoant da genderc&apos;hel ganti?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>الإعدادات</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(قابلة للتعديل)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>النطاق: %1-%2</translation>
     </message>
@@ -1401,23 +1401,23 @@ Ha sur ho peus c&apos;hoant da genderc&apos;hel ganti?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Kuitaat an arload dre-ret</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Astenn</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Kompakt</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Gwelet</translation>
     </message>
@@ -1425,8 +1425,8 @@ Ha sur ho peus c&apos;hoant da genderc&apos;hel ganti?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Klask</translation>
     </message>
@@ -1434,25 +1434,25 @@ Ha sur ho peus c&apos;hoant da genderc&apos;hel ganti?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Prosesus</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Servijoù</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>المستخدمين</translation>
     </message>
@@ -1460,7 +1460,7 @@ Ha sur ho peus c&apos;hoant da genderc&apos;hel ganti?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>تعديل معلومات الحساب</translation>
     </message>
@@ -1468,12 +1468,12 @@ Ha sur ho peus c&apos;hoant da genderc&apos;hel ganti?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>المدير</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>المستخدم العادي</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_ca.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_ca.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Monitor del sistema</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>El Monitor del sistema és una eina per monitorar la càrrega del sistema en temps real, veure i controlar els processos i serveis que s&apos;executen al sistema.</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Amaga&apos;n els detalls</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Ús general</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Ús individual</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Lectura</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Escriptura</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 segons</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 dies, %2 hores, %3 minuts</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Freqüència actual</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Freqüència</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel·la</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 segons</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Cap resultat de la cerca</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Detalls</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Detalls</translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Usat</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Disponible</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Compartit</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>A la cau</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Memòries intermèdies</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Intercanvi a la cau</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Actiu</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Inactiu</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Brut</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Mapat</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Intercanvi total</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Intercanvi lliure</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Placa</translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Velocitat de lectura</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Velocitat d&apos;escriptura</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Capacitat</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Sectors de lectura</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Lectures</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Sectors de lectura</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Lectures fusionades</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Sectors escrits</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Escriptures completades</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Escriptures fusionades</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Escriptures</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Sectors escrits</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Escriptures fusionades</translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>D&apos;acord</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Mostra les dreceres</translation>
     </message>
@@ -604,50 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Acabar aquest procés pot causar pèrdua de dades.
 Segur que voleu continuar?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Acaba el procés</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Forçar l&apos;acabament d&apos;aquest procés pot causar pèrdua de dades.
 Segur que voleu continuar?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Forçar l&apos;acabament d&apos;aquesta aplicació pot causar pèrdua de dades.
 Segur que voleu continuar?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Força&apos;n l&apos;acabament</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Acaba</translation>
@@ -656,7 +656,7 @@ Segur que voleu continuar?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Tancar la sessió</translation>
     </message>
@@ -664,7 +664,7 @@ Segur que voleu continuar?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Paràmetres</translation>
     </message>
@@ -672,7 +672,7 @@ Segur que voleu continuar?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Mida</translation>
     </message>
@@ -819,17 +819,17 @@ Segur que voleu continuar?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Línia d&apos;ordres</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Hora d&apos;inici</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
@@ -837,7 +837,7 @@ Segur que voleu continuar?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Cliqueu a l&apos;aplicació que vulgueu acabar.</translation>
     </message>
@@ -845,16 +845,16 @@ Segur que voleu continuar?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Memòria</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Rep</translation>
     </message>
@@ -862,85 +862,85 @@ Segur que voleu continuar?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Lectura de disc</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Escriptura de disc</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Memòria</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Intercanvi</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>No habilitat</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Baixa</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Carrega</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Xarxa</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Recepció total</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Enviament total</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Envia</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Discs</translation>
     </message>
@@ -956,54 +956,54 @@ Segur que voleu continuar?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Molt alta</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Alta</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Baixa</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Molt baixa</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Personalitzada</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>No vàlid</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Error: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Ha fallat canviar la prioritat del procés.</translation>
     </message>
@@ -1029,32 +1029,32 @@ Segur que voleu continuar?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Ha fallat interrompre el procés.</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Ha fallat reprendre el procés.</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Ha fallat matar el procés.</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Error desconegut</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Ha fallat enviar el senyal al procés.</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Ha fallat acabar el procés.</translation>
     </message>
@@ -1070,19 +1070,19 @@ Segur que voleu continuar?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Sense resposta</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Suspèn</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Safata</translation>
     </message>
@@ -1090,42 +1090,42 @@ Segur que voleu continuar?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Mostra la ubicació del procés</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Propietats</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Acaba el procés</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Reprèn el procés</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Mata el procés</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Canvia&apos;n la prioritat</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Suspèn el procés</translation>
     </message>
@@ -1133,18 +1133,18 @@ Segur que voleu continuar?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Prioritat personalitzada</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Canvia</translation>
@@ -1221,7 +1221,7 @@ Segur que voleu continuar?</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Sense suport</translation>
     </message>
@@ -1264,12 +1264,12 @@ Segur que voleu continuar?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Ha fallat establir el tipus d&apos;inici del servei.</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Error: no s&apos;ha pogut establir el tipus d&apos;inici del servei a causa de la fallada del subprocés.</translation>
     </message>
@@ -1277,19 +1277,19 @@ Segur que voleu continuar?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Nom de la instància de sistema</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>D&apos;acord</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>Cancel·la</translation>
     </message>
@@ -1297,41 +1297,41 @@ Segur que voleu continuar?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Refresca-ho</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Inicia</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Atura</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Reinicia</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Automàtic</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Manual</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Tipus d&apos;inici</translation>
     </message>
@@ -1382,18 +1382,18 @@ Segur que voleu continuar?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Paràmetres</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Modificable)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Interval: %1-%2</translation>
     </message>
@@ -1401,23 +1401,23 @@ Segur que voleu continuar?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Força l&apos;acabament de l&apos;aplicació</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Expandeix</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Compacta</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Visualització</translation>
     </message>
@@ -1425,8 +1425,8 @@ Segur que voleu continuar?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Cerca</translation>
     </message>
@@ -1434,25 +1434,25 @@ Segur que voleu continuar?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Processos</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Serveis</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Usuaris</translation>
     </message>
@@ -1460,7 +1460,7 @@ Segur que voleu continuar?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Edita la informació del compte</translation>
     </message>
@@ -1468,12 +1468,12 @@ Segur que voleu continuar?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Administrador</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Usuari estàndard</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_cs.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_cs.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Monitor systémových prostředků</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Monitor systémových prostředků je nástroj pro sledování vytížení systému v reálném čase, zobrazování a řízení procesů a služeb spuštěných ve vašem systému.</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Skrýt podrobnosti</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Celková výbava</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Individuální výbava</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Čtení</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Zápis</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 sekund</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 dnů %2 hodin %3 minut</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Stávající frekvence</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Frekvence</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation>Zrušit</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 sekund</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Nic nenalezeno</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Podrobnosti</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Podrobnosti</translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Využito</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>K dispozici</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Sdíleno</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Ve vyrovnávací paměti</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Vyrovnávací paměti</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Odkládací prostor v mezipaměti</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Aktivita</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Neaktivní</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>„Špinavé“</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Mapováno</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Celkem mezipaměti</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Volný odkládací prostor</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Slab</translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Rychlost čtení</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Rychlost zapisování</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Kapacita</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Načteno sektorů</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Čtení/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Čtení sektorů / sek</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Sloučených čtení / sek</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Zapsáno sektorů</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Dokončeno zápisů</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Sloučeno zápisů</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Zápisů/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Zapsáno sektorů / sek</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Sloučeno zápisů / sek</translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Systém</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Zobrazit klávesové zkratky</translation>
     </message>
@@ -604,50 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Ukončení tohoto procesu může vést ke ztrátě dat.
 Opravdu chcete pokračovat?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Ukončit proces</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Vynucení ukončení tohoto procesu může vést ke ztrátě dat.
 Opravdu chcete pokračovat?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Vynucení ukončení této aplikace může vést ke ztrátě dat.
 Opravdu chcete pokračovat?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Vynutit ukončení</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Ukončit</translation>
@@ -656,7 +656,7 @@ Opravdu chcete pokračovat?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Odhlásit se</translation>
     </message>
@@ -664,7 +664,7 @@ Opravdu chcete pokračovat?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Nastavení</translation>
     </message>
@@ -672,7 +672,7 @@ Opravdu chcete pokračovat?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Velikost</translation>
     </message>
@@ -819,17 +819,17 @@ Opravdu chcete pokračovat?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Příkazový řádek</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Okamžik spuštění</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Název</translation>
     </message>
@@ -837,7 +837,7 @@ Opravdu chcete pokračovat?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Klikněte na aplikaci, kterou chcete ukončit</translation>
     </message>
@@ -845,16 +845,16 @@ Opravdu chcete pokračovat?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Operační paměť </translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Obdržet</translation>
     </message>
@@ -862,85 +862,85 @@ Opravdu chcete pokračovat?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>Procesor</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Čtení z úložiště</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Zápis na úložiště</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Operační paměť </translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Odkládací prostor (swap) </translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Nepovoleno</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Příjem</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Odesílání</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Síť</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Celkem přijato</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Celkem odesl.</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Odesláno</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Disky</translation>
     </message>
@@ -956,54 +956,54 @@ Opravdu chcete pokračovat?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Velmi vysoká</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Vysoká</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normální</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Nízká</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Velmi nízká</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Vlastní</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Neplatná</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, chyba: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Nepodařilo se změnit prioritu procesu</translation>
     </message>
@@ -1029,32 +1029,32 @@ Opravdu chcete pokračovat?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Proces se nepodařilo pozastavit</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Nepodařilo se obnovit běh procesu</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Nepodařilo se vynutit ukončení procesu</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Neznámá chyba</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Nepodařilo se poslat procesu signál</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Proces se nepodařilo ukončit</translation>
     </message>
@@ -1070,19 +1070,19 @@ Opravdu chcete pokračovat?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Žádná odpověď</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Uspáno</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Panel</translation>
     </message>
@@ -1090,42 +1090,42 @@ Opravdu chcete pokračovat?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Zobrazit umístění příkazu</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Vlastnosti</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Ukončit proces</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Obnovit proces</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Vynutit ukončení procesu</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Změnit prioritu</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Pozastavit proces</translation>
     </message>
@@ -1133,18 +1133,18 @@ Opravdu chcete pokračovat?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Uživatelsky určená priorita</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Změnit</translation>
@@ -1221,7 +1221,7 @@ Opravdu chcete pokračovat?</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Nepodporováno</translation>
     </message>
@@ -1264,12 +1264,12 @@ Opravdu chcete pokračovat?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Nepodařilo se nastavit typ spouštění služby</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Chyba: Nepodařilo se nastavit typ spouštění služby kvůli zhavarovanému podprocesu.</translation>
     </message>
@@ -1277,19 +1277,19 @@ Opravdu chcete pokračovat?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Název instance služby</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>Storno</translation>
     </message>
@@ -1297,41 +1297,41 @@ Opravdu chcete pokračovat?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Načíst znovu</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Spustit</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Zastavit</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Restartovat</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Automaticky</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Ručně</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Typ spouštění</translation>
     </message>
@@ -1382,18 +1382,18 @@ Opravdu chcete pokračovat?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Nastavení</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Lze změnit)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Rozsah: %1-%2</translation>
     </message>
@@ -1401,23 +1401,23 @@ Opravdu chcete pokračovat?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Vynutit ukončení aplikace</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Rozšířené</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Kompaktní</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Zobrazení</translation>
     </message>
@@ -1425,8 +1425,8 @@ Opravdu chcete pokračovat?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Hledat</translation>
     </message>
@@ -1434,25 +1434,25 @@ Opravdu chcete pokračovat?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Procesy</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Služby</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Uživatelé</translation>
     </message>
@@ -1460,7 +1460,7 @@ Opravdu chcete pokračovat?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Upravit informace o účtu</translation>
     </message>
@@ -1468,12 +1468,12 @@ Opravdu chcete pokračovat?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Administrátor</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Standardní uživatel</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_da.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_da.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Systemovervågning</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Systemovervågning er et værktøj til at overvåge systembelastning i realtid, vise og styre processer og tjenester som kører på dit system.</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Skjul detaljer</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Samlet anvendelse</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Individuel anvendelse</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Læs</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Skriv</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 sekunder</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 dage %2 timer %3 minutter</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Aktuel frekvens</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Frekvens</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Annuller</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 sekunder</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Ingen søgeresultater</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Detaljer</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Detaljer</translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Brugt</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Tilgængelig</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Delvist</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Cache</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Buffer</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Cache swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Aktiv</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Inaktiv</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Bøvret</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Kartlagt</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Total swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Ledig swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Slab</translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Læsespeed</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Skribespeed</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Kapasitet</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Sektorer læst</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Læsninger/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Sektorer læst/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Samlet læsning/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Sektorer skrevet</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Skribesæt færdig</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Samlet skrivning</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Skribesæt/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Sektorer skrevet/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Samlet skrivning/s</translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>System</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Vis genveje</translation>
     </message>
@@ -604,50 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Afslutning af processen kan forårsage tab af data.
 Er du sikker på, at du vil fortsætte?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Afslut proces</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Hvis processen tvinges til afslutte kan det forårsage tab af data.
 Er du sikker på, at du vil fortsætte?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Hvis programmet tvinges til afslutte kan det forårsage tab af data.
 Er du sikker på, at du vil fortsætte?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuller</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Tving afslutning</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Afslut</translation>
@@ -656,7 +656,7 @@ Er du sikker på, at du vil fortsætte?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Log ud</translation>
     </message>
@@ -664,7 +664,7 @@ Er du sikker på, at du vil fortsætte?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Indstillinger</translation>
     </message>
@@ -672,7 +672,7 @@ Er du sikker på, at du vil fortsætte?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Størrelse</translation>
     </message>
@@ -819,17 +819,17 @@ Er du sikker på, at du vil fortsætte?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Kommandolinje</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Starttidspunkt</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Navn</translation>
     </message>
@@ -837,7 +837,7 @@ Er du sikker på, at du vil fortsætte?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Klik på det program, du vil afslutte</translation>
     </message>
@@ -845,16 +845,16 @@ Er du sikker på, at du vil fortsætte?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Hukommelse</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Modtag</translation>
     </message>
@@ -862,85 +862,85 @@ Er du sikker på, at du vil fortsætte?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Disklæsning</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Diskskrivning</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Hukommelse</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Swap</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Ikke aktiveret</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Download</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Upload</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Netværk</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Samlet modtaget</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Samlet sendt</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Send</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Diske</translation>
     </message>
@@ -956,54 +956,54 @@ Er du sikker på, at du vil fortsætte?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Meget høj</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Høj</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Lav</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Meget lav</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Tilpas</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Ugyldig</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, fejl: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Kunne ikke skifte procesprioritet</translation>
     </message>
@@ -1029,32 +1029,32 @@ Er du sikker på, at du vil fortsætte?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Kunne ikke sætte proces på pause</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Kunne ikke genoptage proces</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Kunne ikke dræbe proces</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Ukendt fejl</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Kunne ikke sende signal til proces</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Kunne ikke afslutte proces</translation>
     </message>
@@ -1070,19 +1070,19 @@ Er du sikker på, at du vil fortsætte?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Ingen respons</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Suspender</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Bakke</translation>
     </message>
@@ -1090,42 +1090,42 @@ Er du sikker på, at du vil fortsætte?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Vis placeringen af kommandoen</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Egenskaber</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Afslut proces</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Genoptag proces</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Dræb proces</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Skift prioritet</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Suspender proces</translation>
     </message>
@@ -1133,18 +1133,18 @@ Er du sikker på, at du vil fortsætte?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Tilpasset prioritet</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuller</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Skift</translation>
@@ -1221,7 +1221,7 @@ Er du sikker på, at du vil fortsætte?</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Ikke understøttet</translation>
     </message>
@@ -1264,12 +1264,12 @@ Er du sikker på, at du vil fortsætte?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Kunne ikke indstille tjenestens opstartstype</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Fejl: Kunne ikke indstille tjenestens opstartstype pga. underprocessen som holdt op med at virke.</translation>
     </message>
@@ -1277,19 +1277,19 @@ Er du sikker på, at du vil fortsætte?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Navn på tjenesteinstans</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>Annuller</translation>
     </message>
@@ -1297,41 +1297,41 @@ Er du sikker på, at du vil fortsætte?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Opdater</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Stop</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Genstart</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Automatisk</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Manuelt</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Opstartstype</translation>
     </message>
@@ -1382,18 +1382,18 @@ Er du sikker på, at du vil fortsætte?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Indstillinger</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Ændelig)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Interval: %1-%2</translation>
     </message>
@@ -1401,23 +1401,23 @@ Er du sikker på, at du vil fortsætte?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Tving afslutning af program</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Udfold</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Kompakt</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Vis</translation>
     </message>
@@ -1425,8 +1425,8 @@ Er du sikker på, at du vil fortsætte?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Søg</translation>
     </message>
@@ -1434,25 +1434,25 @@ Er du sikker på, at du vil fortsætte?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Processer</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Tjenester</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Brugere</translation>
     </message>
@@ -1460,7 +1460,7 @@ Er du sikker på, at du vil fortsætte?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Rediger brugerkontoinformation</translation>
     </message>
@@ -1468,12 +1468,12 @@ Er du sikker på, at du vil fortsætte?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Administratør</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Standardbruger</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_de.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_de.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Systemmonitor</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Der Systemmonitor ist ein Werkzeug zur Überwachung der Systemauslastung in Echtzeit sowie zur Anzeige und Kontrolle von Prozessen und Diensten, die auf Ihrem System laufen.</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Details ausblenden</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Gesamtnutzung</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Individuelle Nutzung</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Lesen</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Schreiben</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 Sekunden</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 Tage %2 Stunden %3 Minuten</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Aktuelle Frequenz</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Frequenz</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Abbrechen</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 Sekunden</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Keine Suchergebnisse</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Details</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Details</translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Belegt</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Verfügbar</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Gemeinsam</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Zwischengespeichert</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Puffer</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Zwischengespeicherte Auslagerung</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Aktiv</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Inaktiv</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Verändert</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Zugeordnet</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Auslagerung gesamt</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Freie Auslagerung</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Slab</translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Modell</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Lesegeschwindigkeit</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Schreibgeschwindigkeit</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Kapazität</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Gelesene Sektoren</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Lesevorgänge/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Gelesene Sektoren/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Zusammengefasste Lesevorgänge/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Geschriebene Sektoren</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Abgeschlossene Schreibvorgänge </translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Zusammengefasste Schreibvorgänge</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Schreibvorgänge/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Geschriebene Sektoren/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Zusammengefasste Schreibvorgänge/s</translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>System</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Tastenkombinationen anzeigen</translation>
     </message>
@@ -604,50 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Das Beenden des Prozesses kann zu Datenverlust führen.
 Sind Sie sicher, dass Sie fortfahren möchten?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Prozess beenden</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Das erzwungene Beenden des Prozesses kann zu Datenverlust führen.
 Sind Sie sicher, dass Sie fortfahren möchten?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Das erzwungene Beenden dieser Anwendung kann zu Datenverlust führen.
 Sind Sie sicher, dass Sie fortfahren wollen?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Beenden erzwingen</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Beenden</translation>
@@ -656,7 +656,7 @@ Sind Sie sicher, dass Sie fortfahren wollen?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation type="unfinished"></translation>
     </message>
@@ -664,7 +664,7 @@ Sind Sie sicher, dass Sie fortfahren wollen?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
@@ -672,7 +672,7 @@ Sind Sie sicher, dass Sie fortfahren wollen?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Größe</translation>
     </message>
@@ -819,17 +819,17 @@ Sind Sie sicher, dass Sie fortfahren wollen?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Kommandozeile</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Startzeit</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
@@ -837,7 +837,7 @@ Sind Sie sicher, dass Sie fortfahren wollen?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Klicken Sie auf das Programm, das Sie beenden möchten</translation>
     </message>
@@ -845,16 +845,16 @@ Sind Sie sicher, dass Sie fortfahren wollen?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Arbeitsspeicher</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Empfangen</translation>
     </message>
@@ -862,85 +862,85 @@ Sind Sie sicher, dass Sie fortfahren wollen?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Datenträger lesen</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Datenträger schreiben</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Arbeitsspeicher</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Auslagerung</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Nicht aktiviert</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Download</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Upload</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Netzwerk</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Insgesamt empfangen</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Insgesamt gesendet</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Senden</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Datenträger</translation>
     </message>
@@ -956,54 +956,54 @@ Sind Sie sicher, dass Sie fortfahren wollen?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Sehr hoch</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Hoch</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Niedrig</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Sehr niedrig</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Benutzerdefiniert</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Ungültig</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Fehler: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Prozesspriorität ändern ist fehlgeschlagen</translation>
     </message>
@@ -1029,32 +1029,32 @@ Sind Sie sicher, dass Sie fortfahren wollen?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Prozess pausieren ist fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Prozess fortsetzen ist fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Prozess beenden ist fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Unbekannter Fehler</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Senden eines Signals an den Prozess fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Prozess beenden ist fehlgeschlagen</translation>
     </message>
@@ -1070,19 +1070,19 @@ Sind Sie sicher, dass Sie fortfahren wollen?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Keine Rückmeldung</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Anhalten</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Infobereich</translation>
     </message>
@@ -1090,42 +1090,42 @@ Sind Sie sicher, dass Sie fortfahren wollen?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Prozessort anzeigen</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Prozess beenden</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Prozess fortsetzen</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Prozess abwürgen</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Priorität ändern</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Prozess anhalten</translation>
     </message>
@@ -1133,18 +1133,18 @@ Sind Sie sicher, dass Sie fortfahren wollen?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Benutzerdefinierte Priorität</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Ändern</translation>
@@ -1221,7 +1221,7 @@ Sind Sie sicher, dass Sie fortfahren wollen?</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Nicht unterstützt</translation>
     </message>
@@ -1264,12 +1264,12 @@ Sind Sie sicher, dass Sie fortfahren wollen?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Fehler beim Festlegen des Dienststarttyps</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Fehler: Fehler beim Festlegen des Dienststarttyps aufgrund des abgestürzten Unterprozesses.</translation>
     </message>
@@ -1277,19 +1277,19 @@ Sind Sie sicher, dass Sie fortfahren wollen?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Name der Dienstinstanz</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
@@ -1297,41 +1297,41 @@ Sind Sie sicher, dass Sie fortfahren wollen?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Aktualisieren</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Stopp</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Neustart</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Automatisch</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Manuell</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Starttyp</translation>
     </message>
@@ -1382,18 +1382,18 @@ Sind Sie sicher, dass Sie fortfahren wollen?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Veränderbar)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Bereich: %1 - %2</translation>
     </message>
@@ -1401,23 +1401,23 @@ Sind Sie sicher, dass Sie fortfahren wollen?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Beenden des Programms erzwingen</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Erweitern</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Kompakt</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Ansicht</translation>
     </message>
@@ -1425,8 +1425,8 @@ Sind Sie sicher, dass Sie fortfahren wollen?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Suchen</translation>
     </message>
@@ -1434,25 +1434,25 @@ Sind Sie sicher, dass Sie fortfahren wollen?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Prozesse</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Dienste</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Benutzer</translation>
     </message>
@@ -1460,7 +1460,7 @@ Sind Sie sicher, dass Sie fortfahren wollen?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Kontoinformationen bearbeiten</translation>
     </message>
@@ -1468,12 +1468,12 @@ Sind Sie sicher, dass Sie fortfahren wollen?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Administrator</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Standard-Benutzer</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_el.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_el.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Συστηματικός Εποπτευτής</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Ο Συστηματικός Εποπτευτής είναι ένας εργαλείο για την παρακολούθηση της πραγματικής ώρας φόρτωσης του συστήματος, την προβολή και τον έλεγχο των διεργασιών και υπηρεσιών που εκτελούνται στο σύστημα σας.</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Κρύψιμο πληροφοριών</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Συνολική χρήση</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Ατομική χρήση</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Ανάγνωση</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Γραφή</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 δευτερόλεπτα</translation>
     </message>
@@ -56,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 ημέρες %2 ώρες %3 λεπτά</translation>
     </message>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Παρούσα συχνότητα</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Συχνότητα</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 δευτερόλεπτα</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Δεν υπάρχουν αποτελέσματα αναζήτησης</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Πληροφορίες</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Πληροφορίες</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>Προειδοποίηση</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Χρησιμοποιημένο</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Διαθέσιμο</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Συμπορευόμενο</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Σε κэш</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Κύκλωμα</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Σε κεχ ανταλλαγής</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation type="unfinished">Active</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Μη ενεργό</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Ρύπανση</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Απεικονισμένο</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Σύνολο ανταλλαγής</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Ελεύθερη ανταλλαγή</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Σλάμπ</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Μοντέλο</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Ταχύτητα ανάγνωσης</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Ταχύτητα γραφής</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Κεφαλαιουχική ικανότητα</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Ονομαστικά τμήματα ανάγνωσης</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Αναγνώσεις/δευτερόλεπτο</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Συνολικές αναγνώσεις τμημάτων/δευτερόλεπτο</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Συνδεδεμένες αναγνώσεις/δευτερόλεπτο</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Συνολικές γραμμένες τμήματα</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Γραμμένα ολοκληρώθηκαν</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Συνδεδεμένες γραμμένες</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Γραμμένα/δευτερόλεπτο</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Συνολικές γραμμένες τμήματα/δευτερόλεπτο</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Συνδεδεμένες γραμμένες/δευτερόλεπτο</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Σύστημα</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Εμφάνιση συντομευσεων</translation>
     </message>
@@ -598,45 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Η διακοπή αυτού του διεργασίας μπορεί να προκαλέσει απώλεια δεδομένων.
 Είστε σίγουροι ότι θέλετε να συνεχίσετε;</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Διακοπή διεργασίας</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Η δύναμη διακοπή αυτού του διεργασίας μπορεί να προκαλέσει απώλεια δεδομένων.
 Είστε σίγουροι ότι θέλετε να συνεχίσετε;</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Η δύναμη διακοπή αυτού του προγράμματος μπορεί να προκαλέσει απώλεια στοιχείων.
 Είστε σίγουροι ότι θέλετε να συνεχίσετε;</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation type="unfinished">Force End</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation type="unfinished">End</translation>
@@ -645,7 +656,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Έξοδος</translation>
     </message>
@@ -653,7 +664,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Ρυθμίσεις</translation>
     </message>
@@ -661,7 +672,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Μέγεθος</translation>
     </message>
@@ -670,6 +681,7 @@ Are you sure you want to continue?</source>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>Διεύθυνση IP:</translation>
     </message>
@@ -788,11 +800,13 @@ Are you sure you want to continue?</source>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>IPv4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>IPv6</translation>
     </message>
@@ -805,17 +819,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Γραμμή εντολών</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Ώρα εκκίνησης</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Όνομα</translation>
     </message>
@@ -823,7 +837,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Κάντε κλικ στην εφαρμογή που θέλετε να τερματίσετε</translation>
     </message>
@@ -831,12 +845,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Μνήμη</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Παραλαβή</translation>
     </message>
@@ -844,67 +862,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>Επεξεργαστής</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Ανάγνωση δίσκου</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Γραφή δίσκου</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Μνήμη</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Συναλλαγή</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Δεν είναι ενεργοποιημένο</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Λήψη</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Ανάρτηση</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Δίκτυο</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Συνολική Παραλαβή</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Σύνολο Αποστολής</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Αποστολή</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Δίσκοι</translation>
     </message>
@@ -920,47 +956,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Πολύ υψηλή</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Υψηλή</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Κανονική</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Χαμηλή</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Πολύ χαμηλή</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Προσαρμογή</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Μη έγκυρη</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Σφάλμα: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Αποτυχία αλλαγής προτεραιότητας διεργασίας</translation>
     </message>
@@ -986,32 +1029,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Αποτυχία διακοπής διεργασίας</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Αποτυχία επαναφορτώσεως διεργασίας</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Αποτυχία τερματισμού διεργασίας</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Άγνωστο σφάλμα</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Αποτυχία στο στέλνιμα σήματος σε διεργασία</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Αποτυχία τερματισμού διεργασίας</translation>
     </message>
@@ -1027,17 +1070,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Καμία απάντηση</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Διακοπή</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Πίνακας</translation>
     </message>
@@ -1045,37 +1090,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Εμφάνιση τοποθεσίας εντολής</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Ιδιότητες</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Τερματισμός διεργασίας</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Επαναφόρτωση διεργασίας</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Τerματισμός διεργασίας</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Αλλαγή προτεραιότητας</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Επικοινωνία διεργασίας</translation>
     </message>
@@ -1083,18 +1133,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Προσαρμοσμένη προτεραιότητα</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation type="unfinished">Change</translation>
@@ -1171,7 +1221,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Δεν υποστηρίζεται</translation>
     </message>
@@ -1214,12 +1264,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Αποτυχία στον ορισμό τύπου εκκίνησης του υπηρεσίας</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Σφάλμα: Αποτυχία στον ορισμό τύπου εκκίνησης του υπηρεσίας λόγω της κρασσεμένης υποδιεργασίας</translation>
     </message>
@@ -1227,17 +1277,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Όνομα εγγραφής υπηρεσίας</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -1245,37 +1297,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Ανανέωση</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Εκκίνηση</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Διακοπή</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Επανεκκίνηση</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Αυτόματο</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Χειροκίνητο</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Τύπος εκκίνησης</translation>
     </message>
@@ -1326,17 +1382,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Ρυθμίσεις</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Επεξεργασίμως)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Εύρος: %1-%2</translation>
     </message>
@@ -1344,22 +1401,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Απαίτηση τερματισμού εφαρμογής</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Επεκτείνετε</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Συμπίεστε</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Παρακολούθηση</translation>
     </message>
@@ -1367,7 +1425,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Αναζήτηση</translation>
     </message>
@@ -1375,17 +1434,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Διαδικασίες</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Υπηρεσίες</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Χρήστες</translation>
     </message>
@@ -1393,7 +1460,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Επεξεργασία πληροφοριών λογαριασμού</translation>
     </message>
@@ -1401,12 +1468,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Διαχειριστής</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Κανονικός Χρήστης</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_en.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_en.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>System Monitor</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Hide details</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Overall utilization</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Individual utilization</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Read</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Write</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 seconds</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 days %2 hours %3 minutes</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Current frequency</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Frequency</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 seconds</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>No search results</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Details</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Details</translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Used</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Available</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Shared</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Cached</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Buffers</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Cached swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Active</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Inactive</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Dirty</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Mapped</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Total swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Free swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Slab</translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Read speed</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Write speed</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Capacity</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Sectors read</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Reads/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Sectors read/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Reads merged/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Sectors written</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Writes completed </translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Writes merged</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Writes/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Sectors written/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Writes merged/s</translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>System</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Display shortcuts</translation>
     </message>
@@ -604,50 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Ending this process may cause data loss.
 Are you sure you want to continue?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>End process</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Force ending this process may cause data loss.
 Are you sure you want to continue?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Force ending this application may cause data loss.
 Are you sure you want to continue?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Force End</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>End</translation>
@@ -656,7 +656,7 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation type="unfinished"></translation>
     </message>
@@ -664,7 +664,7 @@ Are you sure you want to continue?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
@@ -672,7 +672,7 @@ Are you sure you want to continue?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Size</translation>
     </message>
@@ -819,17 +819,17 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Command line</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Start time</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
@@ -837,7 +837,7 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Click the application you want to end</translation>
     </message>
@@ -845,16 +845,16 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Memory</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Receive</translation>
     </message>
@@ -862,85 +862,85 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Disk read</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Disk write</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Memory</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Swap</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Not enabled</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Download</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Upload</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Network</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Total Received</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Total Sent</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Send</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Disks</translation>
     </message>
@@ -956,54 +956,54 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Very high</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>High</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Low</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Very low</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Custom</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Invalid</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Error: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Failed to change process priority</translation>
     </message>
@@ -1029,32 +1029,32 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Failed to pause process</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Failed to resume process</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Failed to kill process</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Unknown error</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Failed in sending signal to process</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Failed to end process</translation>
     </message>
@@ -1070,19 +1070,19 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>No response</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Suspend</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Tray</translation>
     </message>
@@ -1090,42 +1090,42 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>View command location</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Properties</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>End process</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Resume process</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Kill process</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Change priority</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Suspend process</translation>
     </message>
@@ -1133,18 +1133,18 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Custom Priority</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Change</translation>
@@ -1221,7 +1221,7 @@ Are you sure you want to continue?</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Not support</translation>
     </message>
@@ -1264,12 +1264,12 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Failed to set service startup type</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Error: Failed to set service startup type due to the crashed sub process.</translation>
     </message>
@@ -1277,19 +1277,19 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Service instance name</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -1297,41 +1297,41 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Refresh</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Stop</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Restart</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Auto</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Manual</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Startup type</translation>
     </message>
@@ -1382,18 +1382,18 @@ Are you sure you want to continue?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Modifiable)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Range: %1-%2</translation>
     </message>
@@ -1401,23 +1401,23 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Force end application</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Expand</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Compact</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>View</translation>
     </message>
@@ -1425,8 +1425,8 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Search</translation>
     </message>
@@ -1434,25 +1434,25 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Processes</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Services</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Users</translation>
     </message>
@@ -1460,7 +1460,7 @@ Are you sure you want to continue?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Edit account information</translation>
     </message>
@@ -1468,12 +1468,12 @@ Are you sure you want to continue?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Administrator</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Standard User</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_en_AU.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_en_AU.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>System Monitor</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Hide details</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Overall utilization</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Individual utilization</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Read</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Write</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 seconds</translation>
     </message>
@@ -56,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 days %2 hours %3 minutes</translation>
     </message>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Current frequency</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Frequency</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 seconds</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>No search results</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Details</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Details</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>Warning</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Used</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Available</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Shared</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Cached</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Buffers</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Cached swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation type="unfinished">Active</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Inactive</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Dirty</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Mapped</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Total swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Free swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Slab</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Read speed</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Write speed</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Capacity</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Sectors read</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Reads/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Sectors read/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Reads merged/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Sectors written</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Writes completed </translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Writes merged</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Writes/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Sectors written/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Writes merged/s</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>System</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Display shortcuts</translation>
     </message>
@@ -598,45 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Ending this process may cause data loss.
 Are you sure you want to continue?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>End process</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Force ending this process may cause data loss.
 Are you sure you want to continue?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Force ending this application may cause data loss.
 Are you sure you want to continue?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation type="unfinished">Force End</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation type="unfinished">End</translation>
@@ -645,7 +656,7 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Logout</translation>
     </message>
@@ -653,7 +664,7 @@ Are you sure you want to continue?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
@@ -661,7 +672,7 @@ Are you sure you want to continue?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Size</translation>
     </message>
@@ -670,6 +681,7 @@ Are you sure you want to continue?</translation>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>IP address:</translation>
     </message>
@@ -788,11 +800,13 @@ Are you sure you want to continue?</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>IPv4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>IPv6</translation>
     </message>
@@ -805,17 +819,17 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Command line</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Start time</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
@@ -823,7 +837,7 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Click the application you want to end</translation>
     </message>
@@ -831,12 +845,16 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Memory</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Receive</translation>
     </message>
@@ -844,67 +862,85 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Disk read</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Disk write</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Memory</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Swap</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Not enabled</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Download</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Upload</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Network</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Total received</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Total Sent</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Send</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Disks</translation>
     </message>
@@ -920,47 +956,54 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Very high</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>High</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Low</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Very low</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Custom</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Invalid</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Error: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Failed to change process priority</translation>
     </message>
@@ -986,32 +1029,32 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Failed to pause process</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Failed to resume process</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Failed to kill process</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Unknown error</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Failed in sending signal to process</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Failed to end process</translation>
     </message>
@@ -1027,17 +1070,19 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>No response</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Suspend</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Tray</translation>
     </message>
@@ -1045,37 +1090,42 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>View command location</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Properties</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>End process</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Resume process</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Terminate process</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Change priority</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Suspend process</translation>
     </message>
@@ -1083,18 +1133,18 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Custom Priority</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation type="unfinished">Change</translation>
@@ -1171,7 +1221,7 @@ Are you sure you want to continue?</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Not supported</translation>
     </message>
@@ -1214,12 +1264,12 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Failed to set service startup type</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Error: Failed to set service startup type due to the crashed sub process.</translation>
     </message>
@@ -1227,17 +1277,19 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Service instance name</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -1245,37 +1297,41 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Refresh</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Stop</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Restart</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Auto</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Manual</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Startup type</translation>
     </message>
@@ -1326,17 +1382,18 @@ Are you sure you want to continue?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Modifiable)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Range: %1-%2</translation>
     </message>
@@ -1344,22 +1401,23 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Force end application</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Expand</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Compact</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>View</translation>
     </message>
@@ -1367,7 +1425,8 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Search</translation>
     </message>
@@ -1375,17 +1434,25 @@ Are you sure you want to continue?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Processes</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Services</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Users</translation>
     </message>
@@ -1393,7 +1460,7 @@ Are you sure you want to continue?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Edit account information</translation>
     </message>
@@ -1401,12 +1468,12 @@ Are you sure you want to continue?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Administrator</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Standard User</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_eo.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_eo.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Sistemo Monitoro</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Sistemo Monitoro estas ilo por monitori la realtempan sistemon, vidi kaj kontroli procezojn kaj servojn kiuj funkcias sur via sistemo.</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Kamuji detalojn</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Ĝenerala uzado</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Individua uzado</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Legi</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Skribi</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 sekundoj</translation>
     </message>
@@ -56,9 +60,9 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
-        <translation>'%1 tagoj %2 horoj %3 minutoj'</translation>
+        <translation>&apos;%1 tagoj %2 horoj %3 minutoj&apos;</translation>
     </message>
 </context>
 <context>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Aktuala frekvenco</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Frekvenco</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 sekundoj</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Neniu rezultato por serĉo</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Detaloj</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Detaloj</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>Averto</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Uzita</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Disponebla</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Kompartita</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Kasita</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Bufferoj</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Kasita swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation type="unfinished">Active</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Neaktiva</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Mutila</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Mapita</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Totala swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Libera swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Slabo</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Leganta rapideco</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Skribanta rapideco</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Kapacito</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Sekcioj legitaj</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Legoj per sekundo</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Sekcioj legitaj per sekundo</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Legoj fuzitaj per sekundo</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Sekcioj skribitaj</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Skriboj kompletigitaj </translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Skriboj fuzitaj</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Skriboj per sekundo</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Sekcioj skribitaj per sekundo</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Skriboj fuzitaj per sekundo</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Montri rapidecojn</translation>
     </message>
@@ -598,45 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Finigi tiun procezon povas kaŭzi perdo de datumoj.
 Ĉu vi certe volas daŭrigi?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Finigi procezon</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Forcigi finigon de tiu procezon povas kaŭzi perdon de datumoj.
 Ĉu vi certe volas daŭrigi?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Forcigi finigon de tiu programo povas kaŭzi perdon de datumoj.
 Ĉu vi certe volas daŭrigi?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation type="unfinished">Force End</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation type="unfinished">End</translation>
@@ -645,7 +656,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Ellogi</translation>
     </message>
@@ -653,7 +664,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Agordoj</translation>
     </message>
@@ -661,7 +672,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Dimensio</translation>
     </message>
@@ -670,6 +681,7 @@ Are you sure you want to continue?</source>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>IP-adreso:</translation>
     </message>
@@ -788,11 +800,13 @@ Are you sure you want to continue?</source>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>IPv4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>IPv6</translation>
     </message>
@@ -805,17 +819,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Komando linio</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Start tempo</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Nomo</translation>
     </message>
@@ -823,7 +837,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Klaku la programon kiun vi volas fini</translation>
     </message>
@@ -831,12 +845,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Memoro</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Ricevi</translation>
     </message>
@@ -844,67 +862,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Disk lego</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Disk skribo</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Memoro</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Swap</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Ne aktivigita</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Elŝuto</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Malkomprimi</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Reto</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Total ricevita</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Total sendita</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Sendi</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Diskoj</translation>
     </message>
@@ -920,47 +956,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Tre alta</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Alta</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normala</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Malsa</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Tre malsa</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Personala</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Nevalida</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Eraro: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Malsukcesis ŝanĝi prioritecon de proceso</translation>
     </message>
@@ -986,32 +1029,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Malsukcesis paŭzi proceson</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Malsukcesis reprendi proceson</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Malsukcesis mortigi proceson</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Nekonata eraro</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Malsukcesis sendi sinjalon al proceso</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Malsukcesis fini proceson</translation>
     </message>
@@ -1027,17 +1070,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Neniu respondo</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Pausi</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Trayo</translation>
     </message>
@@ -1045,37 +1090,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Vidi lokon de komando</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Propraĵoj</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Finigi proceson</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Reprendi proceson</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Mortigi procezon</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Ŝanĝi prioritaton</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Pendigi procezon</translation>
     </message>
@@ -1083,18 +1133,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Speciala prioritato</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation type="unfinished">Change</translation>
@@ -1171,7 +1221,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Ne subtenas</translation>
     </message>
@@ -1214,12 +1264,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Malsukcesis agordi servico start tipo</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Eraro: Malsukcesis agordi servico start tipo pro mortinta subprocezo.</translation>
     </message>
@@ -1227,17 +1277,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Servico instanco nomo</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -1245,37 +1297,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Refreski</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Starti</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Stopi</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Rekomenci</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Aŭtomate</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Manuale</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Tipo de starto</translation>
     </message>
@@ -1326,17 +1382,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Agordoj</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Modifigebla)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Intervalo: %1-%2</translation>
     </message>
@@ -1344,22 +1401,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Forci finon de apliko</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Eksplodi</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Kompakti</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Vidu</translation>
     </message>
@@ -1367,7 +1425,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Serĉi</translation>
     </message>
@@ -1375,17 +1434,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Procesoj</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Servoj</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Uzantoj</translation>
     </message>
@@ -1393,7 +1460,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Redakti kontoinformojn</translation>
     </message>
@@ -1401,12 +1468,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Administranto</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Standara uzanto</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_es.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_es.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Monitor del sistema</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Monitor del sistema de Deepin es una herramienta para monitorear la carga del sistema en tiempo real, ver y controlar los procesos y servicios que se ejecutan en su sistema.</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Ocultar detalles</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Utilización total</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Utilización individual</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Lectura</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Escritura</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 segundos</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 días %2 horas %3 minutos</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Frecuencia actual</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Frecuencia</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 segundos</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>No hay resultados de búsqueda</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Detalles</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Detalles</translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Usado</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Disponible</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Compartido</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>En caché</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Búferes</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Intercambio en caché</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Activo</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Inactivo</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Sucio</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Mapeado</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Intercambio total</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Intercambio libre</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Losa</translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Velocidad de lectura</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Velocidad de escritura</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Capacidad</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Sectores leídos</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Lecturas/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Sectores leídos/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Lecturas fusionadas/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Sectores escritos</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Escrituras completas</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Escrituras fusionadas</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Escrituras/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Sectores escritos/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Escrituras fusionadas/s</translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceptar</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Mostrar atajos</translation>
     </message>
@@ -604,50 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Terminar este proceso puede causar perdida de datos.
 ¿Está seguro que quiere continuar?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Terminar proceso</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Forzar el cierre del proceso puede causar perdida de datos.
 ¿Está seguro que quiere continuar?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Forzar el cierre de la aplicación puede causar perdida de datos.
 ¿Está seguro que quiere continuar?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Forzar cierre</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Finalizar</translation>
@@ -656,7 +656,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation type="unfinished"></translation>
     </message>
@@ -664,7 +664,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
@@ -672,7 +672,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Tamaño</translation>
     </message>
@@ -819,17 +819,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Línea de comandos</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Tiempo de inicio</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
@@ -837,7 +837,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Clic en la aplicación que quiere cerrar</translation>
     </message>
@@ -845,16 +845,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Memoria</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Recibido</translation>
     </message>
@@ -862,85 +862,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Lectura del disco</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Escritura del disco</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Memoria</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Intercambio</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Inhabilitado</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Descarga</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Subida</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Red</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Total recibido</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Total enviado</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Enviado</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Discos</translation>
     </message>
@@ -956,54 +956,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Muy alto</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Alto</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Regular</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Bajo</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Personalizado</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Inválido</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Error: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>No se modificó la prioridad del proceso</translation>
     </message>
@@ -1029,32 +1029,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>No se ha podido detener el proceso</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>No se reanudó el proceso</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Fallo la eliminación del proceso</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Error desconocido</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Falló en el envío de la señal para procesar</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>No se pudo terminar el proceso</translation>
     </message>
@@ -1070,19 +1070,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>No responde</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Suspendido</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Bandeja</translation>
     </message>
@@ -1090,42 +1090,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Ver ubicación del comando</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Terminar proceso</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Reanudar proceso</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Matar proceso</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Cambiar prioridad</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Suspender proceso</translation>
     </message>
@@ -1133,18 +1133,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Prioridad personalizada</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Cambiar</translation>
@@ -1221,7 +1221,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>No compatible</translation>
     </message>
@@ -1264,12 +1264,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Error al establecer el tipo de inicio del servicio</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Error: Falla al establecer el tipo de inicio del servicio debido al subproceso bloqueado.</translation>
     </message>
@@ -1277,19 +1277,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Nombre de instancia del servicio</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>Aceptar</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -1297,41 +1297,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Actualizar</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Inicio</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Detener</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Reiniciar</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Automático</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Manual</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Tipo de inicio</translation>
     </message>
@@ -1382,18 +1382,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Modificable)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Rango: %1-%2</translation>
     </message>
@@ -1401,23 +1401,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Forzar cierre de aplicación</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Expandida</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Compacta</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Vista</translation>
     </message>
@@ -1425,8 +1425,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Buscar</translation>
     </message>
@@ -1434,25 +1434,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Procesos</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Servicios</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Usuarios</translation>
     </message>
@@ -1460,7 +1460,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Editar información de la cuenta</translation>
     </message>
@@ -1468,12 +1468,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Administrador</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Usuario estándar</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_et.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_et.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Süsteemi monitor</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Süsteemi monitor on gliiseline süsteemi laste jälgimise, protsesside ja teenuste kuvamise ja kontrollimise väline.</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Peida detailid</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Kokku arvatud kasutamine</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Singulárga kasutamine</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Lugemine</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Kirjutamine</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 sekundit</translation>
     </message>
@@ -56,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 päeva %2 tundit %3 minutit</translation>
     </message>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Praegune kohustus</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Kohustus</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation>Tühista</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 sekundit</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Otsimisel ei leitud tulemusi</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Lisainfo</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Lisainfo</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>Hoiatus</translation>
     </message>
@@ -437,67 +443,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation> kasutatud</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>võrreldes kättesaadav</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>jagatud</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>pöördenud</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>büferid</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>pöördenud vaihutall</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>aktiivne</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>inaktiivne</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>võrreldes tõsiseltvõetav</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>määramine</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>kogu vaihutall</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>vapardavat vaihutall</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>slab</translation>
     </message>
@@ -505,72 +511,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>model</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>lugemise kiirus</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>kirjutamise kiirus</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>kätevus</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>lugetu sektori number</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>lugeid/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>lugetu sektori number/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>märgitud lugeid/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>kirjutatud sektori number</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>lõpetatud kirjutused</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>märgitud kirjutusi</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>kirjutusi/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Sektori kirjutatud/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Kirjutatud kombineeritud/s</translation>
     </message>
@@ -578,7 +584,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Võimalik</translation>
@@ -587,12 +593,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Süsteem</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Näita pikaehitustikke</translation>
     </message>
@@ -600,45 +606,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>See protsess lõpetamine võib andmete kaotamiseks ressursse kasutada.
 Püüad otsesult jatuda?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Lõpeta protsess</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>See protsess lõpetamine võib andmete kaotamiseks ressursse kasutada.
 Püüad otsesult jatuda?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>See rakendus lõpetamine võib andmete kaotamiseks ressursse kasutada.
 Püüad otsesult jatuda?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Loetle</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Lõpeta püüakse</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Lõpeta</translation>
@@ -647,7 +658,7 @@ Püüad otsesult jatuda?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Logi välja</translation>
     </message>
@@ -655,7 +666,7 @@ Püüad otsesult jatuda?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Seaded</translation>
     </message>
@@ -663,7 +674,7 @@ Püüad otsesult jatuda?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Size</translation>
     </message>
@@ -672,6 +683,7 @@ Püüad otsesult jatuda?</translation>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>IP aadress:</translation>
     </message>
@@ -790,11 +802,13 @@ Püüad otsesult jatuda?</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>IPv4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>IPv6</translation>
     </message>
@@ -807,17 +821,17 @@ Püüad otsesult jatuda?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Käsuread</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Alustamise aeg</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation type="unfinished">Nimi</translation>
     </message>
@@ -825,7 +839,7 @@ Püüad otsesult jatuda?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Klõpsa siin saabuvale rakendusele, mida soovid lõpeta</translation>
     </message>
@@ -833,12 +847,16 @@ Püüad otsesult jatuda?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation type="unfinished">Muist</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Saama</translation>
     </message>
@@ -846,67 +864,85 @@ Püüad otsesult jatuda?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation type="unfinished">CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation type="unfinished">Plaaditele lugemine</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation type="unfinished">Plaaditele kirjutamine</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation type="unfinished">Muist</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Vahetus</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Mitteaktilise</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Laeb alla</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Laeb üles</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Võrgustik</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Kokku saamud</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Kokku saatud</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Saatmine</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Diskid</translation>
     </message>
@@ -922,47 +958,54 @@ Püüad otsesult jatuda?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Väga kõrge</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Kõrge</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normaalne</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Vähem kõrge</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Väga väiksem</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Mõista</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Vigane</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Viga: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Protsessi prioriteedi muutmine ebaõnnestus</translation>
     </message>
@@ -988,32 +1031,32 @@ Püüad otsesult jatuda?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Protsessi pööramine ebaõnnestus</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Protsessi jatkamine ebaõnnestus</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Protsessi lõpetamine ebaõnnestus</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Tundmatu viga</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Viimast signaali prosessele saadeti ebaõnnestus</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Protsessi lõpetamisel tekkis viga</translation>
     </message>
@@ -1029,17 +1072,19 @@ Püüad otsesult jatuda?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Vastust pole</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Päring</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Põhikujundus</translation>
     </message>
@@ -1047,37 +1092,42 @@ Püüad otsesult jatuda?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Vaata käsklokalit</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Omadused</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Lõpeta prosess</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Taasalusta prosesse</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Lõpetage prosess</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Muuda prioriteetit</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Pära prossess</translation>
     </message>
@@ -1085,18 +1135,18 @@ Püüad otsesult jatuda?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Mõnda prioriteet</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Tühista</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Muuda</translation>
@@ -1173,7 +1223,7 @@ Püüad otsesult jatuda?</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Eemaldatud</translation>
     </message>
@@ -1216,12 +1266,12 @@ Püüad otsesult jatuda?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Ei õnnestunud määrata teenuse käivitustüüpi</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Viga: Ei õnnestunud määrata teenuse käivitustüüpi, sest alamprotsess on põhjustanud</translation>
     </message>
@@ -1229,17 +1279,19 @@ Püüad otsesult jatuda?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Teenuse näide nimi</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>Vajuta</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>Katkesta</translation>
     </message>
@@ -1247,37 +1299,41 @@ Püüad otsesult jatuda?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Pärast uuesti</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Alusta</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Lõpeta</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Uuesti käivita</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Auto</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Manuaalne</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Käivitustüüp</translation>
     </message>
@@ -1328,17 +1384,18 @@ Püüad otsesult jatuda?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Seaded</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Muudatav</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Vahemik: %1-%2</translation>
     </message>
@@ -1346,22 +1403,23 @@ Püüad otsesult jatuda?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Jagada rakendust</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Laia välja</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Kompakt</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Vaata</translation>
     </message>
@@ -1369,7 +1427,8 @@ Püüad otsesult jatuda?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Otsi</translation>
     </message>
@@ -1377,17 +1436,25 @@ Püüad otsesult jatuda?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Protsessid</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation> teenused</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Kasutajad</translation>
     </message>
@@ -1395,7 +1462,7 @@ Püüad otsesult jatuda?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Muuda kasutajanimeandet</translation>
     </message>
@@ -1403,12 +1470,12 @@ Püüad otsesult jatuda?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Administraator</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Vordne kasutaja</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_eu.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_eu.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Sistema Monitora</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Sistema Monitora da herramienta batetik sistema karga real-time, prozesuak eta zerbitzuak aztertzen eta kontrolatzen dira zure sistemaan.</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Detallean egokia</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Karga orokorra</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Karga individuala</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Irakurri</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Idatzi</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 segundo</translation>
     </message>
@@ -56,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 egun %2 ordu %3 minuto</translation>
     </message>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Frenketza orokorra</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Frenketza</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 segundo</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Bilaketa emaitza ez da</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Detallean</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Detallean</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>Kontsulta</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Erabili</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Disponibila</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Zaharrak</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Cache</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Buffer</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Swap cache</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation type="unfinished">Active</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Inaktibo</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Mendekoa</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Mapatuta</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Swap osoa</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Swap libera</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Slab</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Modeloa</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Lortze speedoak</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Idazte speedoak</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Kapazitatea</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Sektoreak lortze</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Ler/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Sektorek irakurri/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Lerak merged/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Sektorek idatzi</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Idatziak amaitu</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Idatziak merged</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Idatzi/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Sektorek idatzi/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Idatziak merged/s</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Sakaturiak erakutsi</translation>
     </message>
@@ -598,45 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Prozesu hau amaitzeak datu galdeak izan daiteke.
 Seguru zaitez hurrengoa jarri nahi duzula?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Prozesu amaitu</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Prozesu hau eraginkorra amaitzeak datu galdeak izan daiteke.
 Seguru zaitez hurrengoa jarri nahi duzula?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Aplikazio hau eraginkorra amaitzeak datu galdeak izan daiteke.
 Seguru zaitez hurrengoa jarri nahi duzula?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation type="unfinished">Force End</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation type="unfinished">End</translation>
@@ -645,7 +656,7 @@ Seguru zaitez hurrengoa jarri nahi duzula?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Logout</translation>
     </message>
@@ -653,7 +664,7 @@ Seguru zaitez hurrengoa jarri nahi duzula?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Ezarpenak</translation>
     </message>
@@ -661,7 +672,7 @@ Seguru zaitez hurrengoa jarri nahi duzula?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Neurria</translation>
     </message>
@@ -670,6 +681,7 @@ Seguru zaitez hurrengoa jarri nahi duzula?</translation>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>IP helbidea:</translation>
     </message>
@@ -788,11 +800,13 @@ Seguru zaitez hurrengoa jarri nahi duzula?</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>IPv4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>IPv6</translation>
     </message>
@@ -805,17 +819,17 @@ Seguru zaitez hurrengoa jarri nahi duzula?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Ordaintze lerroa</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Hasiera denbora</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Izena</translation>
     </message>
@@ -823,7 +837,7 @@ Seguru zaitez hurrengoa jarri nahi duzula?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Saiatu aplikazioa bukatu nahi duzun</translation>
     </message>
@@ -831,12 +845,16 @@ Seguru zaitez hurrengoa jarri nahi duzula?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Hitzaren memoria</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Jasotzen</translation>
     </message>
@@ -844,67 +862,85 @@ Seguru zaitez hurrengoa jarri nahi duzula?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Disko irakurketa</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Disko idazketa</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Hitzaren memoria</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Swap</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Gaituta ez da</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Jasotzen</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Iritzia</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Zarabidea</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Guztira jasotzen</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Guztira bidet</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Bidet</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Diskoen</translation>
     </message>
@@ -920,47 +956,54 @@ Seguru zaitez hurrengoa jarri nahi duzula?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Berezi altua</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Altua</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normala</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Baxua</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Berezi baxua</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Erabiltzailearen</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Baliogabea</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Errorea: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Prozesuaren prioritatea aldatzea huts egin du</translation>
     </message>
@@ -986,32 +1029,32 @@ Seguru zaitez hurrengoa jarri nahi duzula?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Prozesuaren pausatzea huts egin du</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Prozesuaren berresumatzea huts egin du</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Prozesuaren zaharratzea huts egin du</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Ezezaguna errorea</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Prozesuari signal bidetzean huts egin du</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Prozesuaren amaitzea huts egin du</translation>
     </message>
@@ -1027,17 +1070,19 @@ Seguru zaitez hurrengoa jarri nahi duzula?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>No response</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Pausatu</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Tray</translation>
     </message>
@@ -1045,37 +1090,42 @@ Seguru zaitez hurrengoa jarri nahi duzula?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Komentatu ordenearen kokalekua</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Propietateak</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Prozesuaren amaitzea</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Prozesuaren berresumatzea</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Matxatza procesua</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Aldatu prioritatea</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Pausatu procesua</translation>
     </message>
@@ -1083,18 +1133,18 @@ Seguru zaitez hurrengoa jarri nahi duzula?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Prioritate pertsonalizatua</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation type="unfinished">Change</translation>
@@ -1171,7 +1221,7 @@ Seguru zaitez hurrengoa jarri nahi duzula?</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Ez da onartzen</translation>
     </message>
@@ -1214,12 +1264,12 @@ Seguru zaitez hurrengoa jarri nahi duzula?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Ezin izan da zerbitzuaren hasieratze modua ezarri</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Errorea: Ezin izan da zerbitzuaren hasieratze modua ezarri, sub-prozesua kaltetzeagatik.</translation>
     </message>
@@ -1227,17 +1277,19 @@ Seguru zaitez hurrengoa jarri nahi duzula?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Zerbitzu instantzia izena</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -1245,37 +1297,41 @@ Seguru zaitez hurrengoa jarri nahi duzula?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Berriztu</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Hasieratu</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Berretze</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Berrabiarra</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Automatikoa</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Manuala</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Abiaraztea mota</translation>
     </message>
@@ -1326,17 +1382,18 @@ Seguru zaitez hurrengoa jarri nahi duzula?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Ezarpenak</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Aldaketa egitea posa</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Barrua: %1-%2</translation>
     </message>
@@ -1344,22 +1401,23 @@ Seguru zaitez hurrengoa jarri nahi duzula?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Zorrotz amaieratu aplikazioa</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Hargatze</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Kompaktua</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Ikusi</translation>
     </message>
@@ -1367,7 +1425,8 @@ Seguru zaitez hurrengoa jarri nahi duzula?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Bilatu</translation>
     </message>
@@ -1375,17 +1434,25 @@ Seguru zaitez hurrengoa jarri nahi duzula?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Prozesuak</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Servizioak</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Erabiltzaileak</translation>
     </message>
@@ -1393,7 +1460,7 @@ Seguru zaitez hurrengoa jarri nahi duzula?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Aukera kontu informazioa</translation>
     </message>
@@ -1401,12 +1468,12 @@ Seguru zaitez hurrengoa jarri nahi duzula?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Administratzailea</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Estandarra erabiltzailea</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_fa.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_fa.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>ناظر سیستم</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>ناظر سیستم ابزاری است که بار کار سیستم را در حال حاضر نظارت می‌کند، فرآیندها و خدماتی که روی سیستم شما اجرا می‌شوند را نمایش و کنترل می‌کند.</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>پنهان کردن جزئیات</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>استفاده کلی</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>استفاده فردی</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>خواندن</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>نوشتن</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 ثانیه</translation>
     </message>
@@ -56,9 +60,9 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
-        <translation>'%1 روز %2 ساعت %3 دقیقه'</translation>
+        <translation>&apos;%1 روز %2 ساعت %3 دقیقه&apos;</translation>
     </message>
 </context>
 <context>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>کمیت فرکانس فعلی</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>فرکانس</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 ثانیه</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>نتایجی برای جستجو یافت نشد</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>جزئیات</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>جزئیات</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>هشدار</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>استفاده شده</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>در دسترس</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>اشتراکی</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>کش شده</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>پشته‌ها</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>کش جابجایی</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation type="unfinished">Active</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>غیر فعال</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>خراب</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>مپ شده</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>جمع جابجایی</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>جابجایی آزاد</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>سلاب</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>مدل</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>سرعت خواندن</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>سرعت نوشتن</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>容积</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>زیر مجموعه‌های خوانده شده</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>خواندن/ثانیه</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>سکتورهای خوانده شده/ثانیه</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>خواندن های ادغام شده/ثانیه</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>سکتورهای نوشته شده</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>نوشته‌ها به پایان رسید</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>نوشته‌های ادغام شده</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>نوشتن/ثانیه</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>سکتورهای نوشته شده/ثانیه</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>نوشته‌های ادغام شده/ثانیه</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>سیستم</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>نمایش کلیدهای ترکیبی</translation>
     </message>
@@ -598,45 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>پایان دادن به این فرآیند ممکن است باعث از دست دادن داده شود.
 آیا مطمئن هستید که می‌خواهید ادامه دهید؟</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>پایان دادن به فرآیند</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>پایان دادن قوی به این فرآیند ممکن است باعث از دست دادن داده شود.
 آیا مطمئن هستید که می‌خواهید ادامه دهید؟</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>پایان دادن قوی به این برنامه ممکن است باعث از دست دادن داده شود.
 آیا مطمئن هستید که می‌خواهید ادامه دهید؟</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation type="unfinished">Force End</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation type="unfinished">End</translation>
@@ -645,7 +656,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>خروج</translation>
     </message>
@@ -653,7 +664,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>تنظیمات</translation>
     </message>
@@ -661,7 +672,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>اندازه</translation>
     </message>
@@ -670,6 +681,7 @@ Are you sure you want to continue?</source>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>آدرس IP:</translation>
     </message>
@@ -788,11 +800,13 @@ Are you sure you want to continue?</source>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>آی پی وی چهارم</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>آی پی وی ششم</translation>
     </message>
@@ -805,17 +819,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>خط فرمان</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>زمان شروع</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>نام</translation>
     </message>
@@ -823,7 +837,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>بر روی برنامه ای که می خواهید قطع شود کلیک کنید</translation>
     </message>
@@ -831,12 +845,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>حافظه</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>دریافت</translation>
     </message>
@@ -844,67 +862,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>پردازنده</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>خواندن دیسک</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>نوشتن دیسک</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>حافظه</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>سوپ</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>غیر فعال است</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>دانلود</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>آپلود</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>شبکه</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>کل دریافت شده</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>کل ارسال شده</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>ارسال</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>دیسک‌ها</translation>
     </message>
@@ -920,47 +956,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>بسیار بالا</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>بالا</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>معمولی</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>کم</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>بسیار کم</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>سفارشی</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>نامعتبر</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1، خطا: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>تغییر اولویت فرآیند با شکست مواجه شد</translation>
     </message>
@@ -986,32 +1029,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>توقف فرآیند با شکست مواجه شد</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>استمرار فرآیند با شکست مواجه شد</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>کشتن فرآیند با شکست مواجه شد</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>خطا ناشناخته</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>ارسال سیگنال به فرآیند با شکست مواجه شد</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>پایان فرآیند با شکست مواجه شد</translation>
     </message>
@@ -1027,17 +1070,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>پاسخی ندارد</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>معلق کردن</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>پالت</translation>
     </message>
@@ -1045,37 +1090,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>موقعیت دستور را نمایش دهید</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>ویژگی‌ها</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>پایان فرآیند</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>استمرار فرآیند</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>کیل پروسه</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>تغییر اولویت</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>معلق کردن پروسه</translation>
     </message>
@@ -1083,18 +1133,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>اولویت سفارشی</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation type="unfinished">Change</translation>
@@ -1171,7 +1221,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>پشتیبانی نمی‌شود</translation>
     </message>
@@ -1214,12 +1264,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>نوع شروع سرویس تنظیم نشد</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>خطا: نوع شروع سرویس تنظیم نشد به دلیل خراب شدن زیر پروسه</translation>
     </message>
@@ -1227,17 +1277,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>نام نمونه سرویس</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -1245,37 +1297,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>بروزرسانی</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>شروع</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>توقف</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>重启</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>خودکار</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>دستی</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>نوع شروع</translation>
     </message>
@@ -1326,17 +1382,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation> تنظیمات</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(قابل ویرایش)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>محدوده: %1-%2</translation>
     </message>
@@ -1344,22 +1401,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>نیرومند پایان دهی برنامه</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>گسترش</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>کمپکت</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>نمایش</translation>
     </message>
@@ -1367,7 +1425,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>جستجو</translation>
     </message>
@@ -1375,17 +1434,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation> فرآیندها</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation> خدمات</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>کاربران</translation>
     </message>
@@ -1393,7 +1460,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>ویرایش اطلاعات حساب</translation>
     </message>
@@ -1401,12 +1468,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>مدیر</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>کاربر استاندارد</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_fi.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_fi.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Järjestelmän valvonta</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Järjestelmän valvonta on työkalu, jolla voidaan seurata järjestelmän reaaliaikaista kuormitusta, tarkastella, hallita käynnissä olevia prosesseja ja palveluita.</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Piilota tiedot</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Käyttöaste</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Käyttö</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Luku</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Kirjoitus</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 sekuntia</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 pv %2 t %3 min</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Nykyinen taajuus</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Taajuus</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Peru</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 sekuntia</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Ei hakutuloksia</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Tiedot</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Tiedot</translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Käytetty</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Saatavilla</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Jaettu</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Välimuisti</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Puskurit</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Välimuisti swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Aktiivinen</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Toimeton</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Huono</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Kartoitettu </translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Yhteensä swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Vapaa swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Laatta</translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Malli</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Lukunopeus</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Kirjoitusnopeus</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Kapasiteetti</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Luetut sektorit</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Luku/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Luetut sektorit/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Yhdistetty luku/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Kirjoitetut sektorit</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Kirjoitus valmis</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Yhdistetty kirjoitus</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Kirjoitus/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Kirjoitetut sektorit/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Yhdistetty kirjoitus/s</translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Järjestelmä</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Näytä pikakuvakkeet</translation>
     </message>
@@ -604,50 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Tämän prosessin lopettaminen voi aiheuttaa tietojen häviämistä.
 Haluatko varmasti jatkaa?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Lopeta prosessi</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Tämän prosessin lopettaminen pakottamalla voi aiheuttaa tietojen häviämistä.
 Haluatko varmasti jatkaa?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Sovelluksen lopettaminen voi aiheuttaa tietojen häviämisen.
 Haluatko varmasti jatkaa?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Peru</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Pakota lopetus</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Loppu</translation>
@@ -656,7 +656,7 @@ Haluatko varmasti jatkaa?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Kirjaudu ulos</translation>
     </message>
@@ -664,7 +664,7 @@ Haluatko varmasti jatkaa?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Asetukset</translation>
     </message>
@@ -672,7 +672,7 @@ Haluatko varmasti jatkaa?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Koko</translation>
     </message>
@@ -819,17 +819,17 @@ Haluatko varmasti jatkaa?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Komentorivi</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Aloitusaika</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
@@ -837,7 +837,7 @@ Haluatko varmasti jatkaa?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Napsauta sovellusta, jonka haluat lopettaa</translation>
     </message>
@@ -845,16 +845,16 @@ Haluatko varmasti jatkaa?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Muisti </translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Saatu</translation>
     </message>
@@ -862,85 +862,85 @@ Haluatko varmasti jatkaa?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>Kuorma</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Luku</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Kirjoitus</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Muisti </translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Swap </translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Ei käytössä</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Lataus</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Lähetys</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Verkko</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Saatu</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Lähetetty</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Lähetys</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Levyt</translation>
     </message>
@@ -956,54 +956,54 @@ Haluatko varmasti jatkaa?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Erittäin korkea</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Korkea</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normaali</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Matala</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Erittäin matala</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Mukautettu</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Viallinen</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Virhe: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Prosessin prioriteettia ei voitu muuttaa</translation>
     </message>
@@ -1029,32 +1029,32 @@ Haluatko varmasti jatkaa?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Prosessin pysäytys epäonnistui</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Prosessin jatkaminen epäonnistui</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Prosessin tappaminen epäonnistui</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Tuntematon virhe</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Viestin lähettäminen käsittelyyn epäonnistui</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Prosessin lopetus epäonnistui</translation>
     </message>
@@ -1070,19 +1070,19 @@ Haluatko varmasti jatkaa?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Ei vastausta</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Keskeytä</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Valikko</translation>
     </message>
@@ -1090,42 +1090,42 @@ Haluatko varmasti jatkaa?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Näytä komennon sijainti</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Ominaisuudet</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Lopeta prosessi</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Jatka prosessia</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Lopeta prosessi</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Vaihda prioriteetti</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Keskeytä prosessi</translation>
     </message>
@@ -1133,18 +1133,18 @@ Haluatko varmasti jatkaa?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Muokattu prioriteetti</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Peru</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Muutos</translation>
@@ -1221,7 +1221,7 @@ Haluatko varmasti jatkaa?</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Ei tukea</translation>
     </message>
@@ -1264,12 +1264,12 @@ Haluatko varmasti jatkaa?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Palvelun käynnistystyypin määrittäminen epäonnistui</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Virhe: Palvelun käynnistystyypin määrittäminen epäonnistui kaatuneen alaprosessin vuoksi.</translation>
     </message>
@@ -1277,19 +1277,19 @@ Haluatko varmasti jatkaa?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Palvelun esiintymän nimi</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>Peru</translation>
     </message>
@@ -1297,41 +1297,41 @@ Haluatko varmasti jatkaa?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Virkistä</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Aloita</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Pysäytä</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Uudelleen</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Automaatti</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Manuaalinen</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Käynnistyksen tyyppi</translation>
     </message>
@@ -1382,18 +1382,18 @@ Haluatko varmasti jatkaa?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Asetukset</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Muokattavissa)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Alue: %1-%2</translation>
     </message>
@@ -1401,23 +1401,23 @@ Haluatko varmasti jatkaa?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Pakota sovelluksen lopettaminen</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Laajenna</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Tiivis</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Katso</translation>
     </message>
@@ -1425,8 +1425,8 @@ Haluatko varmasti jatkaa?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Hae</translation>
     </message>
@@ -1434,25 +1434,25 @@ Haluatko varmasti jatkaa?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Prosessit</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Palvelut</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Käyttäjät</translation>
     </message>
@@ -1460,7 +1460,7 @@ Haluatko varmasti jatkaa?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Muokkaa tilitietoja</translation>
     </message>
@@ -1468,12 +1468,12 @@ Haluatko varmasti jatkaa?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Järjestelmänvalvoja</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Tavallinen käyttäjä</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_fil.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_fil.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Sistema ng Monitor</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Ang System Monitor ay isang tool upang monitorhin ang load ng sistema sa real-time, tingnan at kontrolin ang mga proseso at serbisyo na nangunguna sa iyong sistema.</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>I-hide ang mga detalye</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Kabuuang paggamit</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Indibidwal na paggamit</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Basa</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Isulat</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 segundo</translation>
     </message>
@@ -56,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 araw %2 oras %3 minuto</translation>
     </message>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Kasalukuyang frequency</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Frequency</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 segundo</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Walang mga resulta ng paghahanap</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Mga Detalye</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Mga Detalye</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>Uwian</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Ginamit</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Nagagamit</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Ibinahagi</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Nakalagay</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Buffers</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Nakalagay na swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation type="unfinished">Active</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Wala nang aktibo</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Mapait</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Nakakalat</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Kabug-osang swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Libreng swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Slab</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Layo ng bilis</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Bilis ng pagsulat</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Kapasidad</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Sectors na binasa</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Basa/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Sektors na basa/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Basa na mits合并/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Sektors na isulat</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Isulat na tapos </translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Isulat na mits合并</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Isulat/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Sektors na isulat/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Isulat na mits合并/s</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Ipakita ang mga shortcut</translation>
     </message>
@@ -598,45 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Pagtatapos ng proseso ay maaaring magresulta sa pagkawala ng data.
 Sigurado ka bang nais mong magpatuloy?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Tapos ang proseso</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Pagtatapos ng proseso ay maaaring magresulta sa pagkawala ng data.
 Sigurado ka bang nais mong magpatuloy?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Pagtatapos ng aplikasyon ay maaaring magresulta sa pagkawala ng data.
 Sigurado ka bang nais mong magpatuloy?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation type="unfinished">Force End</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation type="unfinished">End</translation>
@@ -645,7 +656,7 @@ Sigurado ka bang nais mong magpatuloy?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Ilog out</translation>
     </message>
@@ -653,7 +664,7 @@ Sigurado ka bang nais mong magpatuloy?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Mga setting</translation>
     </message>
@@ -661,7 +672,7 @@ Sigurado ka bang nais mong magpatuloy?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Laki</translation>
     </message>
@@ -670,6 +681,7 @@ Sigurado ka bang nais mong magpatuloy?</translation>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>Alamat ng IP:</translation>
     </message>
@@ -788,11 +800,13 @@ Sigurado ka bang nais mong magpatuloy?</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>IPv4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>IPv6</translation>
     </message>
@@ -805,17 +819,17 @@ Sigurado ka bang nais mong magpatuloy?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Command line</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Start time</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
@@ -823,7 +837,7 @@ Sigurado ka bang nais mong magpatuloy?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Click the application you want to end</translation>
     </message>
@@ -831,12 +845,16 @@ Sigurado ka bang nais mong magpatuloy?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Memory</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Receive</translation>
     </message>
@@ -844,67 +862,85 @@ Sigurado ka bang nais mong magpatuloy?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Disk read</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Disk write</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Memory</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Swap</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Not enabled</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Download</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Upload</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Network</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Total Received</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Kabugtang Natapos</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Ipadala</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Disko</translation>
     </message>
@@ -920,47 +956,54 @@ Sigurado ka bang nais mong magpatuloy?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Mangunguna</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Mataas</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Mababa</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Mangunguna</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Pang-ibigay</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Balewalay</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Error: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Nagkabigo ang pagbabago ng prioridad ng proseso</translation>
     </message>
@@ -986,32 +1029,32 @@ Sigurado ka bang nais mong magpatuloy?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Nagkabigo ang pag-iilaw ng proseso</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Nagkabigo ang pagbawi ng proseso</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Nagkabigo ang pag-ibigay ng proseso</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Di kilala ang error</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Nagkabigo ang pagpapadala ng signal sa proseso</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Nagkabigo ang pagtapos ng proseso</translation>
     </message>
@@ -1027,17 +1070,19 @@ Sigurado ka bang nais mong magpatuloy?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Walang tugon</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>I-suspend</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Tray</translation>
     </message>
@@ -1045,37 +1090,42 @@ Sigurado ka bang nais mong magpatuloy?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Pananatili ang lokasyon ng utos</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Mga katangian</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Tapusin ang proseso</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Bawiin ang proseso</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Ito ang proseso</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Baguhin ang prioridad</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Pausuhin ang proseso</translation>
     </message>
@@ -1083,18 +1133,18 @@ Sigurado ka bang nais mong magpatuloy?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Mga Paboritong Paggawa</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation type="unfinished">Change</translation>
@@ -1171,7 +1221,7 @@ Sigurado ka bang nais mong magpatuloy?</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Hindi suportado</translation>
     </message>
@@ -1214,12 +1264,12 @@ Sigurado ka bang nais mong magpatuloy?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Nagawa ang pag-iskedyul ng serbisyo</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Error: Nagawa ang pag-iskedyul ng serbisyo dahil sa crash na sub process.</translation>
     </message>
@@ -1227,17 +1277,19 @@ Sigurado ka bang nais mong magpatuloy?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Pangalan ng instance ng serbisyo</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -1245,37 +1297,41 @@ Sigurado ka bang nais mong magpatuloy?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Pangalawang Paglilipat</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Pagsimula</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Tumigil</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Ibalik</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Awtomatiko</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Manwal</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Uri ng Pagpapalad</translation>
     </message>
@@ -1326,17 +1382,18 @@ Sigurado ka bang nais mong magpatuloy?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Mga Pagpipilian</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Mga Maayos na Pagbabago)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Ranggo: %1-%2</translation>
     </message>
@@ -1344,22 +1401,23 @@ Sigurado ka bang nais mong magpatuloy?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Mag-apply ng karahasan</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>I-expand</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>I-compact</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Pananood</translation>
     </message>
@@ -1367,7 +1425,8 @@ Sigurado ka bang nais mong magpatuloy?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Paghahanap</translation>
     </message>
@@ -1375,17 +1434,25 @@ Sigurado ka bang nais mong magpatuloy?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Mga Proseso</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Mga Serbisyo</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Mga Gumagamit</translation>
     </message>
@@ -1393,7 +1460,7 @@ Sigurado ka bang nais mong magpatuloy?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>I-edit ang impormasyon ng account</translation>
     </message>
@@ -1401,12 +1468,12 @@ Sigurado ka bang nais mong magpatuloy?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Administrator</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Standard User</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_fr.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_fr.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Moniteur système</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Le Moniteur système est un outil pour surveiller la charge du système en temps réel, afficher et contrôler les processus et services exécutés sur votre système.</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Cacher les détails</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Utilisation globale</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Utilisation individuelle</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Lire</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Écrire</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 secondes</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 jours %2 heures %3 minutes</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Fréquence actuelle</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Fréquence</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Annuler</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 secondes</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Aucun résultat trouvé</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Détails</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Détails</translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Utilisé</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Disponible</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Partagé</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>En cache</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Tampons</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Swap en cache</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Actif</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Inactif</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Mauvais</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Mappé</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Échange total</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Échange gratuit</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Slab</translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Modèle</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Vitesse de lecture</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Vitesse d&apos;écriture</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Capacité</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Secteurs lus</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Lectures/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Secteurs lus/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Lectures accomplies/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Secteurs écrits</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Écritures terminées </translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Écritures accomplies</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Écritures/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Secteurs écrits/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Écritures accomplies/s</translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Système</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Afficher les raccourcis</translation>
     </message>
@@ -604,50 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>La fin de ce processus peut entraîner une perte de données. 
 Êtes-vous sur de vouloir continuer ?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Terminer le processus</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>La fin de ce processus peut entraîner une perte de données.
 Êtes-vous sur de vouloir continuer ?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Forcer la fermeture de cette application peut entraîner une perte de données.
 Es-tu sûr de vouloir continuer ?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Forcer à quitter</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Fin</translation>
@@ -656,7 +656,7 @@ Es-tu sûr de vouloir continuer ?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Déconnexion</translation>
     </message>
@@ -664,7 +664,7 @@ Es-tu sûr de vouloir continuer ?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Préférences</translation>
     </message>
@@ -672,7 +672,7 @@ Es-tu sûr de vouloir continuer ?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Taille</translation>
     </message>
@@ -819,17 +819,17 @@ Es-tu sûr de vouloir continuer ?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Ligne de commande</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Heure de début</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
@@ -837,7 +837,7 @@ Es-tu sûr de vouloir continuer ?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Cliquer sur l&apos;application que vous souhaitez fermer</translation>
     </message>
@@ -845,16 +845,16 @@ Es-tu sûr de vouloir continuer ?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Mémoire</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Recevoir</translation>
     </message>
@@ -862,85 +862,85 @@ Es-tu sûr de vouloir continuer ?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Lecture du disque</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Écriture du disque</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Mémoire</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Mémoire virtuelle</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Non activé</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Réception</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Téléversement</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Réseau</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Total reçu</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Total envoyé</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Envoyer</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Disques</translation>
     </message>
@@ -956,54 +956,54 @@ Es-tu sûr de vouloir continuer ?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Très élevé</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Élevé</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Faible</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Très faible</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Personnalisé</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Non valide</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID : %1, Erreur : [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Impossible de modifier la priorité du processus</translation>
     </message>
@@ -1029,32 +1029,32 @@ Es-tu sûr de vouloir continuer ?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Impossible de suspendre le processus</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Impossible de reprendre le processus</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Impossible de tuer le processus</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Erreur inconnue</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Échec de l&apos;envoi du signal au processus</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Échec de la fin du processus</translation>
     </message>
@@ -1070,19 +1070,19 @@ Es-tu sûr de vouloir continuer ?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Pas de réponse</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Suspendre</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Barre</translation>
     </message>
@@ -1090,42 +1090,42 @@ Es-tu sûr de vouloir continuer ?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Afficher l&apos;emplacement de la commande</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Propriétés</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Terminer le processus</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Reprendre le processus</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Tuer le processus</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Modifier la priorité</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Suspendre le processus</translation>
     </message>
@@ -1133,18 +1133,18 @@ Es-tu sûr de vouloir continuer ?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Priorité personnalisée</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Changer</translation>
@@ -1221,7 +1221,7 @@ Es-tu sûr de vouloir continuer ?</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Pas de support</translation>
     </message>
@@ -1264,12 +1264,12 @@ Es-tu sûr de vouloir continuer ?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Impossible de définir le mode démarrage du service</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Erreur : impossible de définir le type de démarrage du service en raison du sous-processus en panne.</translation>
     </message>
@@ -1277,19 +1277,19 @@ Es-tu sûr de vouloir continuer ?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Nom de l&apos;instance de service</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
@@ -1297,41 +1297,41 @@ Es-tu sûr de vouloir continuer ?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Actualiser</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Démarrer</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Arrêter</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Redémarrer</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Automatique</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Manuel</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Type de démarrage</translation>
     </message>
@@ -1382,18 +1382,18 @@ Es-tu sûr de vouloir continuer ?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Préférences</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Modifiable)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Intervalle : %1-%2</translation>
     </message>
@@ -1401,23 +1401,23 @@ Es-tu sûr de vouloir continuer ?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Forcer à quitter l&apos;application</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Développer</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Compact</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Afficher</translation>
     </message>
@@ -1425,8 +1425,8 @@ Es-tu sûr de vouloir continuer ?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Rechercher</translation>
     </message>
@@ -1434,25 +1434,25 @@ Es-tu sûr de vouloir continuer ?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Processus</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Services</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Utilisateurs</translation>
     </message>
@@ -1460,7 +1460,7 @@ Es-tu sûr de vouloir continuer ?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Éditer les informations du compte</translation>
     </message>
@@ -1468,12 +1468,12 @@ Es-tu sûr de vouloir continuer ?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Administrateur&#xa0;</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Utilisateur standard</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_gl_ES.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_gl_ES.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Monitor do sistema</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>System Monitor é unha ferramenta para supervisar a carga do sistema, ver e controlar os procesos e servizos executados no seu sistema.</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Amosar detalls</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Utilización total</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Utilización individual</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Lectura</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Escritura</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 segundos</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 días %2 horas %3 minutos</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Frequencia actual</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Frequencia</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 segundos</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Non hai resultados para a túa busca</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Detalles</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Detalles</translation>
     </message>
@@ -443,67 +443,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Usado</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Dispoñible</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Compartido</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Caché</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Buffers</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Caché de swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Activar</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Inactivo</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Contaminado</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Mapeado</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Total de swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Swap libre</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Slab</translation>
     </message>
@@ -511,72 +511,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Velocidade de lectura</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Velocidade de escrita</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Capacidade</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Sectores leidos</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Lecturas/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Sectores leidos/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>lecturas combinadas/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>sectores escritos</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>escribiúse escrituras completas</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>escrituras combinadas</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>escrituras/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>sectores escritos/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>escrituras combinadas/s</translation>
     </message>
@@ -584,7 +584,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceptar</translation>
@@ -593,12 +593,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Amosar atallos</translation>
     </message>
@@ -606,50 +606,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Rematar este proceso pode causar perda de datos.
 Estás seguro de que queres continuar?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>O proceso rematou</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Forza de rematar este proceso pode causar perda de datos.
 Estás seguro de que queres continuar?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Forza de rematar este aplicativo pode causar perda de datos.
 Estás seguro de que queres continuar?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Forzar finalización</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Final</translation>
@@ -658,7 +658,7 @@ Estás seguro de que queres continuar?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Saída</translation>
     </message>
@@ -666,7 +666,7 @@ Estás seguro de que queres continuar?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Configuración</translation>
     </message>
@@ -674,7 +674,7 @@ Estás seguro de que queres continuar?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Tamaño</translation>
     </message>
@@ -821,17 +821,17 @@ Estás seguro de que queres continuar?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Liña de comando</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Tempo de comezo</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
@@ -839,7 +839,7 @@ Estás seguro de que queres continuar?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Prema no aplicativo que desexa rematar</translation>
     </message>
@@ -847,16 +847,16 @@ Estás seguro de que queres continuar?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Memoria</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Recibir</translation>
     </message>
@@ -864,85 +864,85 @@ Estás seguro de que queres continuar?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Lectura do disco</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Disco de escritura</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Memoria</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Intercambiar</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Non activo</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Descargar</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Actualizar</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Rede</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Total recibido</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Total enviado</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Enviar</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Discos</translation>
     </message>
@@ -958,54 +958,54 @@ Estás seguro de que queres continuar?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Moi alto</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Alto</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Baixo</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Moi baixo</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Personalizar</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Inválido</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Erro: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Erro ao cambiar a prioridade do proceso</translation>
     </message>
@@ -1031,32 +1031,32 @@ Estás seguro de que queres continuar?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Fallou o proceso de pausa</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Erro ao continuar o proceso</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Fallou o proceso de Kill</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Erro descoñecido</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Erro ao enviar o sinal para procesar</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Erro ao finalizar o proceso</translation>
     </message>
@@ -1072,19 +1072,19 @@ Estás seguro de que queres continuar?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Non hai resposta</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Suspender</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Bandexa</translation>
     </message>
@@ -1092,42 +1092,42 @@ Estás seguro de que queres continuar?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Ver a situación do comando</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>O proceso rematou</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Retomar o proceso</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Proceso de Kill</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Cambiar prioridade</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Suspender proceso</translation>
     </message>
@@ -1135,18 +1135,18 @@ Estás seguro de que queres continuar?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Personalizar prioridades</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Cambiar</translation>
@@ -1223,7 +1223,7 @@ Estás seguro de que queres continuar?</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Non se paxa</translation>
     </message>
@@ -1266,12 +1266,12 @@ Estás seguro de que queres continuar?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Erro ao configurar o tipo de inicio de servizo</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Erro: non se puido establecer o tipo de inicio de servizo debido ao subproceso errado.</translation>
     </message>
@@ -1279,19 +1279,19 @@ Estás seguro de que queres continuar?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Nome da instancia do servizo</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>Aceptar</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -1299,41 +1299,41 @@ Estás seguro de que queres continuar?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Recargar</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Comezar</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Parar</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Volver a comezar</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Automático</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Manual</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Tipo de inicio</translation>
     </message>
@@ -1384,18 +1384,18 @@ Estás seguro de que queres continuar?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Configuración</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Modificable</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Intervalo: %1-%2</translation>
     </message>
@@ -1403,23 +1403,23 @@ Estás seguro de que queres continuar?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Forzar o fin do aplicativo</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Expandir</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Compactar</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Ver</translation>
     </message>
@@ -1427,8 +1427,8 @@ Estás seguro de que queres continuar?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Buscar</translation>
     </message>
@@ -1436,25 +1436,25 @@ Estás seguro de que queres continuar?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Procesos</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Servizos</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Usuarios</translation>
     </message>
@@ -1462,7 +1462,7 @@ Estás seguro de que queres continuar?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Editar información de la cuenta</translation>
     </message>
@@ -1470,12 +1470,12 @@ Estás seguro de que queres continuar?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Administrador</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Usuario Estándar</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_he.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_he.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>מוניטור מערכת</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>מוניטור מערכת הוא-tooל להצטברת בזמן אמת של нагрузת המערכת, לצפות ולכTRL על התהליך והשירותים שפעלו במערכת שלך.</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>הצגת פרטים</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>שימוש כללי</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>שימוש אישי</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>קריאה</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>כתיבה</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>שעתיים</translation>
     </message>
@@ -56,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 ימים %2 שעות %3 דקות</translation>
     </message>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>הتردد הנוכחי</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>تردد</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">ביטול</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>פרטים</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>,No תוצאות לחיפוש</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>אזהרה</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>שימוש במעבד שלך גבוה יותר מ-%1%!</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>שימוש הזיכרון שלך גבוה יותר מ-%1%!</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>נעשה שימוש בו</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>متاح</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>נشارك</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>נמחק</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>бу퍼ס</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>החלפת זיכרון מוסתר</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation type="unfinished">פעיל</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>לא פעיל</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>בצורה לא נכונה</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>מופה</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>החלפת זיכרון כללית</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>החלפת זיכרון פנימית</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>שבל</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>מודל</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>מהירות קריאה</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>מהירות כתיבה</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>קיבולת</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>שכבות נקראו</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>reads/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>שכבות נקראו/שעתיים</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>reads merged/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>שכבות נכתבו</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>כתובות שהושלמו</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>כתובות מותאמות</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>writes/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>שכבות נכתבו/שעתיים</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>writes merged/s</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">אישור</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>מערכת</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>הצג מקצצות</translation>
     </message>
@@ -598,7 +604,7 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>הסתייה (!((进程)))可能会导致数据丢失。
@@ -606,12 +612,14 @@ Are you sure you want to continue?</source>
 </translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>סיום התהליך</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>FORCE הסתייה (!((进程)))可能会导致数据丢失。
@@ -619,7 +627,7 @@ Are you sure you want to continue?</source>
 </translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>FORCE הסתייה-With Application-可能会导致数据丢失。
@@ -627,19 +635,22 @@ Are you sure you want to continue?</source>
 </translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>ביטול</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>סיום מוחלט</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>סיום</translation>
@@ -648,7 +659,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>יציאה</translation>
     </message>
@@ -656,7 +667,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>הגדרות</translation>
     </message>
@@ -664,7 +675,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>גודל</translation>
     </message>
@@ -673,6 +684,7 @@ Are you sure you want to continue?</source>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>כתובת IP:</translation>
     </message>
@@ -791,11 +803,13 @@ Are you sure you want to continue?</source>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>IPv4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>IPv6</translation>
     </message>
@@ -808,17 +822,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>שורת פקודה</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>מועד ההתחלה</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>שם</translation>
     </message>
@@ -826,7 +840,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>יש ללחוץ על היישום שברצונך לסגור</translation>
     </message>
@@ -834,12 +848,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>זיכרון</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>קבלה</translation>
     </message>
@@ -847,67 +865,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>מעבד</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>קריאה מהכונן</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>כתיבה לכונן</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>זיכרון</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>החלפה</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>לא פעיל</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>הורדה</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>העלאה</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>רשת</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>总量接收</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>总量发送</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>שליחה</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>דיסקים</translation>
     </message>
@@ -923,47 +959,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation> מאוד גבוה</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>висOCK</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>רגילים</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>נמוך</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation> מאוד נמוך</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation> Cástom</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation> לא תקין</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Error: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>נכשל בהgemäßת עדיפות תהליך</translation>
     </message>
@@ -989,32 +1032,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>נכשל להיעצר תהליך</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>נכשל להתחמם תהליך</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>נכשל להסתיים תהליך</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>שגיאה לא ידועה</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>נכשל בה norsigal ל-(תהליך</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>לא הצליח להסתיים מהחדר</translation>
     </message>
@@ -1030,17 +1073,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>אין תגובה</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>השהיה</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>מדפסת</translation>
     </message>
@@ -1048,37 +1093,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>הצג מיקום הפקודה</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>מאפיינים</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>סיום התהליך</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>ה возיחת תהליך</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>הסתיים תהליך</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>שינוי עדיפות</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>הסתיו תהליך</translation>
     </message>
@@ -1086,18 +1136,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>עדיפות פרטית</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>ביטול</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>לְשַׁקֵּל</translation>
@@ -1174,7 +1224,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>לא נתמך</translation>
     </message>
@@ -1217,12 +1267,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>לא הצליח להגדיר את סוג התחלה של השירות</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>שגיאה: לא הצליח להגדיר את סוג התחלה של השירות בשל תהליך תחתוני שטיפל</translation>
     </message>
@@ -1230,17 +1280,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>שם דוגמה שירות</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>אישור</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>ביטול</translation>
     </message>
@@ -1248,37 +1300,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>�新鲜</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>התחל</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>עצור</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>החל שוב</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>אוטומטי</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>ידני</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>סוג התחלה</translation>
     </message>
@@ -1329,17 +1385,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>הגדרות</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(قابل לעריכה)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>טווח: %1-%2</translation>
     </message>
@@ -1347,22 +1404,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>סיים את האפליקציה ברצף</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>הרחב</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>축소</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>הצג</translation>
     </message>
@@ -1370,7 +1428,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>חיפוש</translation>
     </message>
@@ -1378,17 +1437,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>กระบวนות</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>שירותים</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>משתמשים</translation>
     </message>
@@ -1396,7 +1463,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>ערוך מידע החשבון</translation>
     </message>
@@ -1404,12 +1471,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>מנהל</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>משתמש סטנדרטי</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_hi_IN.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_hi_IN.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>सिस्टम मॉनिटर</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>सिस्टम मॉनिटर एक टूल है जो आपके सिस्टम पर चल रहे प्रोसेस और सेवाओं को देखने और नियंत्रित करने के लिए वास्तविक समय पर सिस्टम लोड को निगरानी करता है।</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>डिटेल छुपाएं</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>सामान्य उपयोग</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>व्यक्तिगत उपयोग</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>पढ़ें</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>लिखें</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 सेकंड</translation>
     </message>
@@ -56,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 दिन %2 घंटे %3 मिनट</translation>
     </message>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>वर्तमान आवृत्ति</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>आवृत्ति</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 सेकंड</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>कोई खोज रिजल्ट नहीं मिला</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>डिटेल</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>डिटेल</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>चेतावनी</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>उपयोग किया गया</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>उपलब्ध</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>साझा</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>कैश किया गया</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>बफर्स</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>कैश स्वैप</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation type="unfinished">Active</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>अक्रिय</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>गंदा</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>मैप किया गया</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>कुल स्वैप</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>मुक्त स्वैप</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>स्लैब</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>मॉडल</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>पढ़ने की गति</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>लिखने की गति</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>क्षमता</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>खंड पढ़े गए</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>पढ़े/स</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>सेक्टर पढ़े/स</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>मर्ज किए गए पढ़े/स</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>सेक्टर लिखे गए</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>लिखे गए पूरा किए गए</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>मर्ज किए गए लिखे गए</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>लिखे/स</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>सेक्टर लिखे/स</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>मर्ज किए गए लिखे/स</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>सिस्टम</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>शॉर्टकट दिखाएं</translation>
     </message>
@@ -598,45 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>इस प्रोसेस को ख़ामोश करने से डेटा खो जाएगा।
 आप काफ़ी निश्चित है कि आप आगे बढ़ना चाहते हैं?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>प्रोसेस ख़ामोश करें</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>इस प्रोसेस को बल ख़ामोश करने से डेटा खो जाएगा।
 आप काफ़ी निश्चित है कि आप आगे बढ़ना चाहते हैं?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>इस एप्लिकेशन को बल ख़ामोश करने से डेटा खो जाएगा।
 आप काफ़ी निश्चित है कि आप आगे बढ़ना चाहते हैं?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation type="unfinished">Force End</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation type="unfinished">End</translation>
@@ -645,7 +656,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>लॉगआउट</translation>
     </message>
@@ -653,7 +664,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>सेटिंग्स</translation>
     </message>
@@ -661,7 +672,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>आकार</translation>
     </message>
@@ -670,6 +681,7 @@ Are you sure you want to continue?</source>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>आईपी पता:</translation>
     </message>
@@ -788,11 +800,13 @@ Are you sure you want to continue?</source>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>आईपीवी4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>आईपीवी6</translation>
     </message>
@@ -805,17 +819,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>कमांड लाइन</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>शुरू करने का समय</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>नाम</translation>
     </message>
@@ -823,7 +837,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>खत्म करने के लिए अप्लिकेशन क्लिक करें</translation>
     </message>
@@ -831,12 +845,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>मेमोरी</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>प्राप्त</translation>
     </message>
@@ -844,67 +862,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>सीपीयू</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>डिस्क पढ़ें</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>डिस्क लिखें</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>मेमोरी</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>स्वैप</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>अक्षम</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>डाउनलोड</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>अपलोड</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>नेटवर्क</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>कुल प्राप्त</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>कुल भेजा गया</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>भेजें</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>डिस्क्स</translation>
     </message>
@@ -920,47 +956,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>अत्यधिक उच्च</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>उच्च</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>सामान्य</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>निम्न</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>अत्यधिक निम्न</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>कस्टम</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>अमान्य</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>प्रोसेस आईडी: %1, त्रुटि: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>प्रोसेस प्राथमिकता बदलने में विफल</translation>
     </message>
@@ -986,32 +1029,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>प्रोसेस को रोकने में विफल</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>प्रोसेस को फिर से शुरू करने में विफल</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>प्रोसेस को मारने में विफल</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>अज्ञात त्रुटि</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>प्रोसेस में संकेत भेजने में विफल</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>प्रोसेस को खत्म करने में विफल</translation>
     </message>
@@ -1027,17 +1070,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>कोई जवाब नहीं</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>सुपेंड</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>ट्रे</translation>
     </message>
@@ -1045,37 +1090,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>कमांड स्थान को देखें</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>गुण</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>प्रोसेस खत्म करें</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>प्रोसेस फिर से शुरू करें</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>प्रोसेस को मारें</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>प्राथमिकता बदलें</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>प्रोसेस को रोकें</translation>
     </message>
@@ -1083,18 +1133,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>कस्टम प्राथमिकता</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation type="unfinished">Change</translation>
@@ -1171,7 +1221,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>समर्थित नहीं है</translation>
     </message>
@@ -1214,12 +1264,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>सेवा शुरू करने के प्रकार को सेट करने में विफल</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>त्रुटि: सेवा शुरू करने के प्रकार को सेट करने में विफल, उप-प्रक्रिया में विफलता के कारण</translation>
     </message>
@@ -1227,17 +1277,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>सेवा इंस्टेंस नाम</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -1245,37 +1297,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>अपडेट करें</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>शुरू करें</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>रोकें</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>पुनः शुरू करें</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>स्वचालित</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>हाथ से</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>शुरू करने का प्रकार</translation>
     </message>
@@ -1326,17 +1382,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>सेटिंग्स</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(संशोधनीय)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>श्रेणी: %1-%2</translation>
     </message>
@@ -1344,22 +1401,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>प्रोग्राम को बलपूर्वक अंत करें</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>विस्तार</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>संकुचित</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>देखें</translation>
     </message>
@@ -1367,7 +1425,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>खोज</translation>
     </message>
@@ -1375,17 +1434,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>प्रोसेस</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>सेवाएं</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>उपयोगकर्ता</translation>
     </message>
@@ -1393,7 +1460,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>खाता जानकारी संपादित करें</translation>
     </message>
@@ -1401,12 +1468,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>अदमिनिस्ट्रेटर</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>स्टैंडर्ड उपयोगकर्ता</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_hr.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_hr.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Nadzor sustava</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Nadzor sustava je alat koji u realnom vremenu nadzire učitavanje sustava i kontrolira procesa i servise koji su pokrenuti u vašem sustavu.</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Sakrij pojedinosti</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation> Ukupna iskorištenost</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation> Individualna iskorištenost</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Čitaj</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Piši</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 sekunda</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 dana %2 sati %3 minute</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Trenutna frekvencija</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Frekvencija</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Otkaži</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 sekunda</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Nema rezultata pretrage</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Pojedinosti</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Pojedinosti</translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Korišteno</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Dostupno</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Dijeljeno</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>U cache</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Bufferi</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>U cache swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Aktivan</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Neaktivno</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Začinjeno</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Mapirano</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Ukupni swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Slobodni swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Slab</translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Brzina čitanja</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Brzina pisanja</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Kapacitet</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Sektori pročitani</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Pročitano/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Pročitani sektor/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Spajanje pročitanih/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Sektori napisani</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Napisano</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Spajanje napisanih</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Napisano/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Napisani sektor/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Spajanje napisanih/s</translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>U redu</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Sustav</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Prikaži prečace</translation>
     </message>
@@ -604,50 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Završetak ovog procesa može uzrokovati gubitak podataka.
 Jeste li sigurni da želite nastaviti?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Završi proces</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Prisiljavanje završetka ovog procesa može uzrokovati gubitak podataka.
 Jeste li sigurni da želite nastaviti?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Prisiljavanje završetka ovog programa može uzrokovati gubitak podataka.
 Jeste li sigurni da želite nastaviti?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Otkaži</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Prisilno završavanje</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Kraj</translation>
@@ -656,7 +656,7 @@ Jeste li sigurni da želite nastaviti?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Odjava</translation>
     </message>
@@ -664,7 +664,7 @@ Jeste li sigurni da želite nastaviti?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Postavke</translation>
     </message>
@@ -672,7 +672,7 @@ Jeste li sigurni da želite nastaviti?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Veličina</translation>
     </message>
@@ -819,17 +819,17 @@ Jeste li sigurni da želite nastaviti?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Naredbeni redak</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Vrijeme početka</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Ime</translation>
     </message>
@@ -837,7 +837,7 @@ Jeste li sigurni da želite nastaviti?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Кликните на прикључену прилику коју желите да зауставите</translation>
     </message>
@@ -845,16 +845,16 @@ Jeste li sigurni da želite nastaviti?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Memorija</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Прими</translation>
     </message>
@@ -862,85 +862,85 @@ Jeste li sigurni da želite nastaviti?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Читање диска</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Писање диска</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Memorija</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Swap</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Nije omogućeno</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Preuzimanje</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Slanje</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Mreža</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Ukupno primljeno</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Ukupno poslano</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Пошаљи</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Diskovi</translation>
     </message>
@@ -956,54 +956,54 @@ Jeste li sigurni da želite nastaviti?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Vrlo visoko</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Visoko</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normalno</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Nisko</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Vrlo nisko</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Prilagođeno</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Neispravno</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Greška: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Неуспешно промољење приоритета процеса</translation>
     </message>
@@ -1029,32 +1029,32 @@ Jeste li sigurni da želite nastaviti?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Neuspjelo pauziranje procesa</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Неуспешно поновно покретање процеса</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Неуспешно заустављање процеса</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Nepoznata greška</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Неуспешно пошаљиње сигнала процесу</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Neuspjelo završavanje procesa</translation>
     </message>
@@ -1070,19 +1070,19 @@ Jeste li sigurni da želite nastaviti?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Nema odgovora</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Suspendiraj</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Tray</translation>
     </message>
@@ -1090,42 +1090,42 @@ Jeste li sigurni da želite nastaviti?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Pogledaj lokaciju naredbe</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Osobitosti</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Završi proces</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Nastavi proces</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Убаци процес</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Promijeni prioritet</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Suspendiraj proces</translation>
     </message>
@@ -1133,18 +1133,18 @@ Jeste li sigurni da želite nastaviti?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Prilagođeni prioritet</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Otkaži</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Promijeni</translation>
@@ -1221,7 +1221,7 @@ Jeste li sigurni da želite nastaviti?</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Nije podržan</translation>
     </message>
@@ -1264,12 +1264,12 @@ Jeste li sigurni da želite nastaviti?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Nije uspješno postavljen tip pokretanja usluge</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Greška: Nije uspješno postavljen tip pokretanja usluge zbog prekida sub procesa.</translation>
     </message>
@@ -1277,19 +1277,19 @@ Jeste li sigurni da želite nastaviti?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Naziv instance usluge</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>U redu</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>Otkaži</translation>
     </message>
@@ -1297,41 +1297,41 @@ Jeste li sigurni da želite nastaviti?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Osvježi</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Pokreni</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Zaustavi</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Ponovno poreni</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Automatski</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Ručno</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Tip pokretanja</translation>
     </message>
@@ -1382,18 +1382,18 @@ Jeste li sigurni da želite nastaviti?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Postavke</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Promjenjivo)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Opseg: %1-%2</translation>
     </message>
@@ -1401,23 +1401,23 @@ Jeste li sigurni da želite nastaviti?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Prisili završetak programa</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Proširi</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Kompaktan</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Pogled</translation>
     </message>
@@ -1425,8 +1425,8 @@ Jeste li sigurni da želite nastaviti?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Traži</translation>
     </message>
@@ -1434,25 +1434,25 @@ Jeste li sigurni da želite nastaviti?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Procesi</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Servisi</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Korisnici</translation>
     </message>
@@ -1460,7 +1460,7 @@ Jeste li sigurni da želite nastaviti?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Uredi informacije o računu</translation>
     </message>
@@ -1468,12 +1468,12 @@ Jeste li sigurni da želite nastaviti?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Administrator</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Standardni korisnik</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_hu.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_hu.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Rendszerfigyelő</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>A Rendszerfigyelő egy eszköz, a valós idejű rendszerterhelés figyelemmel kísérésére, a rendszeren futó folyamatok és szolgáltatások megtekintésére és vezérlésére.</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Részletek elrejtése</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Általános kihasználtság</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Egyéni kihasználtság</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Olvasás</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Írás</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 másodperc</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 nap %2 óra %3 perc</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Jelenlegi frekvencia</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Frekvencia</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Mégsem</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 másodperc</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Nincs keresési eredmény</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Részletek</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Részletek</translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Használt</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Elérhető</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Megosztott</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Gyorsítótárazott</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Pufferek</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Gyorsítótárazott cserehely</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Aktív</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Tétlen</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Szennyezett</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Feltérképezett</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Teljes cserehely</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Szabad cserehely</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Tömb</translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Modell</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Olvasási sebesség</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Írási sebesség</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Kapacitás</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Olvasott szektorok</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Olvasások/mp</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Olvasott szektorok/mp</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Összevont olvasások/mp</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Írt szektorok</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Az írások befejeződtek</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Összevont írások</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Írások/mp</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Írt szektorok/mp</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Összevont írások/mp</translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Rendszer</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Parancsikonok megjelenítése</translation>
     </message>
@@ -604,49 +604,49 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>A folyamat befejezése adatvesztést okozhat.
 Biztos benne, hogy folytatni akarja?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Folyamat befejezése</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>A folyamat kényszerített befejezése adatvesztést okozhat.
 Biztos benne, hogy folytatni akarja?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Az alkalmazás kényszerített befejezése adatvesztést okozhat. Biztos benne, hogy folytatja?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Kényszerített befejezés</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Befejezés</translation>
@@ -655,7 +655,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Kijelentkezés</translation>
     </message>
@@ -663,7 +663,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Beállítások</translation>
     </message>
@@ -671,7 +671,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Méret</translation>
     </message>
@@ -818,17 +818,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Parancssor</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Kezdési idő</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Név</translation>
     </message>
@@ -836,7 +836,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Kattintson a bezárni kívánt alkalmazásra</translation>
     </message>
@@ -844,16 +844,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Memória</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Fogadás</translation>
     </message>
@@ -861,85 +861,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>Processzor</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Lemez olvasás</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Lemez írás</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Memória</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Cserehely</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Nincs engedélyezve</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Letöltés</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Feltöltés</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Hálózat</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Összes beérkezett</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Összes küldött</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Küldés</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Lemezek</translation>
     </message>
@@ -955,54 +955,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Nagyon magas</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Magas</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normál</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Alacsony</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Nagyon alacsony</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Egyéni</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Érvénytelen</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Hiba: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Nem sikerült megváltoztatni a folyamat prioritását</translation>
     </message>
@@ -1028,32 +1028,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Nem sikerült szüneteltetni a folyamatot</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Nem sikerült folytatni a folyamatot</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Nem sikerült kilőni a folyamatot</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Ismeretlen hiba</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Nem sikerült elküldeni a jelet a feldolgozáshoz</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Nem sikerült befejezni a folyamatokat</translation>
     </message>
@@ -1069,19 +1069,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Nem válaszol</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Felfüggesztés</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Tálca</translation>
     </message>
@@ -1089,42 +1089,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>A parancs helyének megtekintése</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Tulajdonságok</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Folyamat befejezése</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Folyamat folytatása</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Folyamat kilövése</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Prioritás megváltoztatása</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Folyamat felfüggesztése</translation>
     </message>
@@ -1132,18 +1132,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Egyedi prioritás</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Változtatás</translation>
@@ -1220,7 +1220,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Nem támogatott</translation>
     </message>
@@ -1263,12 +1263,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>A szolgáltatás indítási típusának beállítása sikertelen</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Hiba: Nem sikerült beállítani a szolgáltatás indítási típusát az összeomlott alfolyamat miatt.</translation>
     </message>
@@ -1276,19 +1276,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Szolgáltatási példány neve</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>Mégsem</translation>
     </message>
@@ -1296,41 +1296,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Frissítés</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Indítás</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Leállítás</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Újraindítás</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Automatikus</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Kézi</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Indítási típus</translation>
     </message>
@@ -1381,18 +1381,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Beállítások</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Módosítható)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Tartomány: %1-%2</translation>
     </message>
@@ -1400,23 +1400,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Kényszerített alkalmazás leállítás</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Kibővített</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Tömörített</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Nézet</translation>
     </message>
@@ -1424,8 +1424,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Keresés</translation>
     </message>
@@ -1433,25 +1433,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Folyamatok</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Szolgáltatások</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Felhasználók</translation>
     </message>
@@ -1459,7 +1459,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Felhasználói fiók adatainak szerkesztése</translation>
     </message>
@@ -1467,12 +1467,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Rendszergazda</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Alap Felhasználó</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_hy.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_hy.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>համակարգի հետևումը</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Համակարգի հետևումը համակարգի կայանալի վահանակայանությամբ հետևումը կատարող արագացուցիչ արտադրող և կառավարող ծառայություններ և պրոցեսներ համակարգում տեսնելու և կառավարելու համար գործիք է</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>կարգավորումները բացահայտել</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>ընդհանուր օգտագործումը</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>անհատական օգտագործումը</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>կարդալ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>գրել</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 վայրկյան</translation>
     </message>
@@ -56,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 օր %2 ժամ %3 րոպե</translation>
     </message>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>այս պահի հաճախականությունը</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>հաճախականությունը</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 վայրկյան</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>որոշակի արդյունքներ չկան</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>տարբերակը</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Տեսական</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>Զետեղում</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Օգտագործված</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Անօգտագործված</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Ընդհանուր</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Կэշ</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Բաֆերներ</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Կեշ փոխանցում</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation type="unfinished">Active</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Անգործունակ</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Բարդ</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Արտացոլված</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Ընդհանուր փոխանցում</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Ազատ փոխանցում</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Սլաբ</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Մոդել</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Ընթերցման արագություն</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Գրման արագություն</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Արտադրողականություն</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Սեկտորներ ընթերցված</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>կարդալ/վայրկյան</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>հատվածներ կարդալ/վայրկյան</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>միացված կարդալ/վայրկյան</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>հատվածներ գրված</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>գրումներ կատարված</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>միացված գրումներ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>գրումներ/վայրկյան</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>հատվածներ գրվող/վայրկյան</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>միացված գրումներ/վայրկյան</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Համակարգ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Ցուցադրել կրճատացումները</translation>
     </message>
@@ -598,42 +604,47 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Այս պրոցեսը ավարտելը կարող է առաջացնել տվյալների կորցումը։ Անհատական մատուցել է ցանկանում կատարել ավարտը։</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Ավարտել պրոցեսը</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Ընդ强制 ավարտել այս պրոցեսը կարող է առաջացնել տվյալների կորցումը։ Անհատական մատուցել է ցանկանում կատարել ավարտը։</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Ընդ强制 ավարտել այս ծրագիրը կարող է առաջացնել տվյալների կորցումը։ Անհատական մատուցել է ցանկանում կատարել ավարտը։</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation type="unfinished">Force End</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation type="unfinished">End</translation>
@@ -642,7 +653,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Ելք</translation>
     </message>
@@ -650,7 +661,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Կարգավորումներ</translation>
     </message>
@@ -658,7 +669,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Չափս</translation>
     </message>
@@ -667,6 +678,7 @@ Are you sure you want to continue?</source>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>IP հասցե:</translation>
     </message>
@@ -785,11 +797,13 @@ Are you sure you want to continue?</source>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>IPv4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>IPv6</translation>
     </message>
@@ -802,17 +816,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Կոմանդային տող</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Սկիզբ ընդունել</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Անուն</translation>
     </message>
@@ -820,7 +834,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Ընտրեք այն ծրագիրը, որը ցանկանում եք ավարտել</translation>
     </message>
@@ -828,12 +842,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Հիշողություն</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Ստանձնել</translation>
     </message>
@@ -841,67 +859,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>Կոմպյուտեր</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Սկանդային կարդալ</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Սկանդային գրել</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Հիշողություն</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Փոխանակություն</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Չի ակտիվացվել</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Նվազեցնել</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Վերբեռնել</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Շղթա</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Ընդհանուր ստացված</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Ընդհանուր ուղղված հաղորդագրությունները</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Ուղղված հաղորդագրությունները</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Դիսկեր</translation>
     </message>
@@ -917,47 +953,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Ամենաբարձր</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Բարձր</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Ընդհանուր</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Ընդհանուր</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Ամենացածր</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Անձնական</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Ոչ վավեր</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, սխալը: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Ընթացիկ գործընթացի պրիորիտետը փոխելը կատարվեց անջատված</translation>
     </message>
@@ -983,32 +1026,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Գործընթացը անցման վայրաքանդելը դադարեցնելը կատարվեց անջատված</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Գործընթացը վերականգնելը կատարվեց անջատված</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Գործընթացը սպանելը կատարվեց անջատված</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Անհայտ սխալ</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Ծրագրի նշանը ուղարկելը կատարվեց անջատված</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Գործընթացը ավարտելը կատարվեց անջատված</translation>
     </message>
@@ -1024,17 +1067,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Ընդունվող պատասխանը բացակայում է</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Անցման վայրաքանդել</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Տրեյ</translation>
     </message>
@@ -1042,37 +1087,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Տեսնել հրահանգի տեղը</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Հատկությունները</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Ավարտել գործընթացը</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Վերականգնել գործընթացը</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>հանգամանքը վարձակալությունը վերջացրել</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>հանգամանքը վարձակալությունը կարգավորել</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>հանգամանքը վարձակալությունը դադարեցնել</translation>
     </message>
@@ -1080,18 +1130,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>անհատական կարգավորում</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation type="unfinished">Change</translation>
@@ -1168,7 +1218,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Չի աջակցում</translation>
     </message>
@@ -1211,12 +1261,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Ծառայության սկզբնական տեսակը սահմանելու համար հնարավոր չէ</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Սխալ: Ծառայության սկզբնական տեսակը սահմանելու համար հնարավոր չէ, քանի որ առաջացել է սեփական ենթապրոցեսի կործանումը</translation>
     </message>
@@ -1224,17 +1274,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Ծառայության ինստանսիայի անվանումը</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -1242,37 +1294,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Ամրապնդել</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Սկսել</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Կանգ առնել</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Վերականգարարել</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Ավտոմատ</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Չափազանց</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Սկանдалային տիպ</translation>
     </message>
@@ -1323,17 +1379,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Կարգավորումներ</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Փոխելի)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Ընդամենը: %1-%2</translation>
     </message>
@@ -1341,22 +1398,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Անհրաժեշտ է կանգնալ կամ ավարտել ծրագիրը</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Ընդամենը բացել</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Ընդամենը փակել</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Տեսանկար</translation>
     </message>
@@ -1364,7 +1422,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Որոնում</translation>
     </message>
@@ -1372,17 +1431,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Ծրագրեր</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Ծրագրեր</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Օգտատիրոցի</translation>
     </message>
@@ -1390,7 +1457,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Խմբագրել աշխատատեղի տեղեկությունը</translation>
     </message>
@@ -1398,12 +1465,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Հարցազրույցատիրոցի</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Ստանդարտ օգտատիրոցի</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_id.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_id.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Monitor Sistem</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Monitor Sistem adalah alat untuk memantau beban sistem secara waktu nyata, melihat dan mengontrol proses dan layanan yang berjalan di sistem Anda.</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Sembunyikan detail</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Penggunaan secara keseluruhan</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Penggunaan per individu</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Baca</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Tulis</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 detik</translation>
     </message>
@@ -56,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 hari %2 jam %3 menit</translation>
     </message>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Frekuensi sekarang</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Frekuensi</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Batalkan</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 detik</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Tidak ada hasil pencarian</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Detail</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Detail</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>Peringatan</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Digunakan</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Tersedia</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Dibagikan</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Ditahan</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Buffer</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Ditahan pertukaran</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Aktif</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Nonaktif</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Kotor</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Dipetakan</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Total swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Bebaskan swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Slab</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Kecepatan membaca</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Kecepatan menulis</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Kapasitas</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Sektor dibaca</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Reads/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Sektor read/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Baca merged/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Sektor ditulis</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Tulisan selesai </translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Tulisan digabungkan</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Tulis</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Sektor written/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Writes merged/s</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Sistem</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Tampilkan pemintas</translation>
     </message>
@@ -598,45 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Mengakhiri proses ini dapat menyebabkan kehilangan data.
 Anda yakin untuk melanjutkan?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Akhiri proses</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Mengakhiri proses ini dengan paksa dapat menyebabkan kehilangan data.
 Anda yakin akan melanjutkannya?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Memaksa mengakhiri aplikasi ini dapat menyebabkan kehilangan data. 
 Apakah anda yakin ingin melanjutkan?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Batalkan</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Paksa berhenti</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Akhiri</translation>
@@ -645,7 +656,7 @@ Apakah anda yakin ingin melanjutkan?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Keluar</translation>
     </message>
@@ -653,7 +664,7 @@ Apakah anda yakin ingin melanjutkan?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Pengaturan</translation>
     </message>
@@ -661,7 +672,7 @@ Apakah anda yakin ingin melanjutkan?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Ukuran</translation>
     </message>
@@ -670,6 +681,7 @@ Apakah anda yakin ingin melanjutkan?</translation>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>Alamat IP:</translation>
     </message>
@@ -788,11 +800,13 @@ Apakah anda yakin ingin melanjutkan?</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>IPv4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>IPv6</translation>
     </message>
@@ -805,17 +819,17 @@ Apakah anda yakin ingin melanjutkan?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Baris perintah</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Waktu mulai</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Nama</translation>
     </message>
@@ -823,7 +837,7 @@ Apakah anda yakin ingin melanjutkan?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Klik aplikasi yang ingin Anda hentikan</translation>
     </message>
@@ -831,12 +845,16 @@ Apakah anda yakin ingin melanjutkan?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Memori</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Menerima</translation>
     </message>
@@ -844,67 +862,85 @@ Apakah anda yakin ingin melanjutkan?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Baca diska</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Tulis diska</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Memori</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Swap</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Tidak diaktifkan</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Unduh</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Unggah</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Jaringan</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Total diterima</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Total dikirim</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Kirim</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Diska</translation>
     </message>
@@ -920,47 +956,54 @@ Apakah anda yakin ingin melanjutkan?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Sangat tinggi</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Tinggi</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Rendah</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Sangat rendah</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Kustom</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Tidak valid</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Galat: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Gagal mengubah prioritas proses</translation>
     </message>
@@ -986,32 +1029,32 @@ Apakah anda yakin ingin melanjutkan?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Gagal menjeda proses</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Gagal melanjutkan proses</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Gagal mematikan proses</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Galat tidak diketahui</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Gagal mengirim sinyal ke proses</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Gagal mengakhiri proses</translation>
     </message>
@@ -1027,17 +1070,19 @@ Apakah anda yakin ingin melanjutkan?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Tak ada respons</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Tangguhkan</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Baki</translation>
     </message>
@@ -1045,37 +1090,42 @@ Apakah anda yakin ingin melanjutkan?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Lihat lokasi perintah</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Properti</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Akhiri proses</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Lanjutkan proses</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Matikan proses</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Ubah prioritas</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Tangguhkan proses</translation>
     </message>
@@ -1083,18 +1133,18 @@ Apakah anda yakin ingin melanjutkan?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Prioritas kustom</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Batalkan</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Ubah</translation>
@@ -1171,7 +1221,7 @@ Apakah anda yakin ingin melanjutkan?</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Tidak didukung</translation>
     </message>
@@ -1214,12 +1264,12 @@ Apakah anda yakin ingin melanjutkan?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Gagal menyetel jenis layanan startup</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Galat: Gagal menyetel tipe layanan startup karena subproses macet.</translation>
     </message>
@@ -1227,17 +1277,19 @@ Apakah anda yakin ingin melanjutkan?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Nama model layanan</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>Batalkan</translation>
     </message>
@@ -1245,37 +1297,41 @@ Apakah anda yakin ingin melanjutkan?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Segarkan</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Mulai</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Setop</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Mulai ulang</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Otomatis</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Manual</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Tipe startup</translation>
     </message>
@@ -1326,17 +1382,18 @@ Apakah anda yakin ingin melanjutkan?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Pengaturan</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Dapat Diubah)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Rentang: %1-%2</translation>
     </message>
@@ -1344,22 +1401,23 @@ Apakah anda yakin ingin melanjutkan?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Paksa akhiri aplikasi</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Luaskan</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Ringkas</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Lihat</translation>
     </message>
@@ -1367,7 +1425,8 @@ Apakah anda yakin ingin melanjutkan?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Cari</translation>
     </message>
@@ -1375,17 +1434,25 @@ Apakah anda yakin ingin melanjutkan?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Proses</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Layanan</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Pengguna</translation>
     </message>
@@ -1393,7 +1460,7 @@ Apakah anda yakin ingin melanjutkan?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Sunting informasi akun</translation>
     </message>
@@ -1401,12 +1468,12 @@ Apakah anda yakin ingin melanjutkan?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Administrator</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Pengguna Biasa</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_it.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_it.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Gestore Attività</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Il Gestore Attività è uno strumento per monitorare lo stato del sistema in tempo reale, visualizzare e controllare processi e servizi in esecuzione sul sistema.
 Localizzazione italiana a cura di Massimo A. Carofano.</translation>
@@ -19,19 +19,19 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Nascondi dettagli</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Utilizzo generale</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Utilizzo individuale</translation>
     </message>
@@ -39,12 +39,12 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Lettura</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Scrittura</translation>
     </message>
@@ -52,8 +52,8 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 secondi</translation>
     </message>
@@ -61,7 +61,7 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 giorni %2 ore %3 minuti</translation>
     </message>
@@ -75,13 +75,13 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Frequenza attuale</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Frequenza</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -162,7 +162,7 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Annulla</translation>
     </message>
@@ -170,7 +170,7 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 secondi</translation>
     </message>
@@ -178,8 +178,8 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Nessun risultato</translation>
     </message>
@@ -187,7 +187,7 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Dettagli</translation>
     </message>
@@ -195,7 +195,7 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Dettagli</translation>
     </message>
@@ -442,67 +442,67 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Utilizzato</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Disponibile</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Condiviso</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Cache</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Buffer</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Swap cache</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Attivo</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Non attivo</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Sporco</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Mappato</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Swap totale</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Swap libera</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Slab</translation>
     </message>
@@ -510,72 +510,72 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Modello</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Velocità di lettura</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Velocità di scrittura</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Capacità</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Settori letti</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Letti/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Settori letti/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Letture unite/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Settori scritti</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Scritture completate</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Scritture unite</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Scrittura/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Settori scritti/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Scritture unite/s</translation>
     </message>
@@ -583,7 +583,7 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -592,12 +592,12 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Visualizza scorciatoie</translation>
     </message>
@@ -605,50 +605,50 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Terminare questo processo potrebbe causare una perdita di dati.
 Sicuro di voler terminarlo?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Termina processo</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Terminare questo processo potrebbe causare una perdita di dati.
 Sicuro di voler terminarlo?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Terminare quest&apos;app potrebbe causare una perdita di dati.
 Sicuro di voler terminarla?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Forza chiusura</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Termina</translation>
@@ -657,7 +657,7 @@ Sicuro di voler terminarla?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation type="unfinished"></translation>
     </message>
@@ -665,7 +665,7 @@ Sicuro di voler terminarla?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
@@ -673,7 +673,7 @@ Sicuro di voler terminarla?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Dimensioni</translation>
     </message>
@@ -820,17 +820,17 @@ Sicuro di voler terminarla?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Linea di comando</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Tempo di esecuzione</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
@@ -838,7 +838,7 @@ Sicuro di voler terminarla?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Clicca sull&apos;App che vuoi terminare</translation>
     </message>
@@ -846,16 +846,16 @@ Sicuro di voler terminarla?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Memoria</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Ricevuti</translation>
     </message>
@@ -863,85 +863,85 @@ Sicuro di voler terminarla?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Lettura disco</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Scrittura disco</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Memoria</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Swap</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Non attivo</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Download</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Upload</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Rete</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Totale Ricevuti</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Totale inviati</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Inviati</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Dischi</translation>
     </message>
@@ -957,54 +957,54 @@ Sicuro di voler terminarla?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Molto alta</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Alta</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normale</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Bassa</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Molto bassa</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Personalizza</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Non valido</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Errore: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Variazione della priorità del Processo fallita</translation>
     </message>
@@ -1030,32 +1030,32 @@ Sicuro di voler terminarla?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Pausa del processo fallita</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Ripristino del processo fallito</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Soppressione processo fallita</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Errore sconosciuto</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Invio segnale al processo fallito</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Terminazione processo fallita</translation>
     </message>
@@ -1071,19 +1071,19 @@ Sicuro di voler terminarla?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Nessuna risposta</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Sospendi</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Tray</translation>
     </message>
@@ -1091,42 +1091,42 @@ Sicuro di voler terminarla?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Visualizza locazione</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Proprietà</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Termina processo</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Riprendi processo</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Termina processo</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Cambia priorità</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Sospendi processo</translation>
     </message>
@@ -1134,18 +1134,18 @@ Sicuro di voler terminarla?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Priorità personalizzata</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Cambia</translation>
@@ -1222,7 +1222,7 @@ Sicuro di voler terminarla?</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Non supportato</translation>
     </message>
@@ -1265,12 +1265,12 @@ Sicuro di voler terminarla?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Impossibile settare il tipo di avvio del servizio</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Errore: impossibile settare il tipo di avvio del servizio per via del crash di un sotto-processo.</translation>
     </message>
@@ -1278,19 +1278,19 @@ Sicuro di voler terminarla?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Nome istanza di Servizio</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
@@ -1298,41 +1298,41 @@ Sicuro di voler terminarla?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Aggiorna</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Avvia</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Stoppa</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Riavvia</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Auto</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Manuale</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Tipo di avvio</translation>
     </message>
@@ -1383,18 +1383,18 @@ Sicuro di voler terminarla?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Modificabile)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Soglia: %1-%2</translation>
     </message>
@@ -1402,23 +1402,23 @@ Sicuro di voler terminarla?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Forza chiusura App</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Espandi</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Comprimi</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Visualizza</translation>
     </message>
@@ -1426,8 +1426,8 @@ Sicuro di voler terminarla?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Cerca</translation>
     </message>
@@ -1435,25 +1435,25 @@ Sicuro di voler terminarla?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Processi</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Servizi</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Utenti</translation>
     </message>
@@ -1461,7 +1461,7 @@ Sicuro di voler terminarla?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Modifica info account</translation>
     </message>
@@ -1469,12 +1469,12 @@ Sicuro di voler terminarla?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Amministratore</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Utente standard</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_ja.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_ja.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation type="unfinished"></translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation type="unfinished"></translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -74,12 +74,12 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
+        <source>Average frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
+        <source>Max frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">キャンセル</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation type="unfinished"></translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -604,47 +604,47 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation type="unfinished">プロセスを終了</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation type="unfinished"></translation>
@@ -653,7 +653,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation type="unfinished"></translation>
     </message>
@@ -661,7 +661,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -669,7 +669,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
@@ -816,17 +816,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation type="unfinished">コマンドライン</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation type="unfinished">開始時刻</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation type="unfinished">名前</translation>
     </message>
@@ -834,7 +834,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation type="unfinished">終了させたいアプリケーションをクリックしてください</translation>
     </message>
@@ -842,16 +842,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation type="unfinished">メモリ</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -859,85 +859,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation type="unfinished">CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation type="unfinished">ディスク読込</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation type="unfinished">ディスク書込</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation type="unfinished">メモリ</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation type="unfinished">スワップ</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation type="unfinished">未有効</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation type="unfinished">ダウンロード</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation type="unfinished">アップロード</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation type="unfinished">ネットワーク</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation type="unfinished"></translation>
     </message>
@@ -953,54 +953,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1026,32 +1026,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1067,19 +1067,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation type="unfinished">応答なし</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation type="unfinished">サスペンド</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation type="unfinished">トレイ</translation>
     </message>
@@ -1087,42 +1087,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation type="unfinished">プロパティ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation type="unfinished">プロセスを終了</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1130,18 +1130,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
@@ -1253,7 +1253,7 @@ Are you sure you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1261,12 +1261,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1274,19 +1274,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1294,41 +1294,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1379,18 +1379,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1398,23 +1398,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1422,8 +1422,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation type="unfinished">検索</translation>
     </message>
@@ -1431,25 +1431,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,7 +1457,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1465,12 +1465,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation type="unfinished"></translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_ka.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_ka.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>სისტემის მონიტორი</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>სისტემის მონიტორი არის ინსტრუმენტი, რომელიც საშიშროების მონიტორინგს საშიშროების სიმაღლეს, პროცესებს და სერვისებს შესახვედის მონიტორინგს უზრუნველყოფს თქვენს სისტემაზე.</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>დეტალების დამალვა</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>სრული გამოყენება</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>ინდივიდუალური გამოყენება</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>წაკითხვა</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>ჩაწერა</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 წამი</translation>
     </message>
@@ -56,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 დღე %2 საათი %3 წუთი</translation>
     </message>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>მიმდინარე სიხშირე</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>სიხშირე</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 წამი</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>ძებნის შედეგები არ არსებობს</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>დეტალები</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>ინფორმაცია</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>გაფრთხილება</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>გამოყენებული</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>ხელმისაწვდომი</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>გაზრდილი</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>საშენი</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>ბუფერები</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>საშენი სვეპი</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation type="unfinished">Active</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>აქტიური არაა</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>სუნთქული</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>მარტივად გამოყოფილი</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>სრული სვეპი</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>თავისუფალი სვეპი</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>სლები</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>მოდელი</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>მიმ read სიჩქარე</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>მიმ write სიჩქარე</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>ტევარადება</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>მიმ read სექტორები</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>რედს/ს</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>სექტორები რედს/ს</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>რედს შეკრივის/ს</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>სექტორები წერის</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>წერილები შესრულდა </translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>წერილები შეკრივის</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>წერილები/ს</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>სექტორები წერილები/ს</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>წერილები შეკრივის/ს</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>სისტემა</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>სიმბოლოების ჩანაწერების გამოყოფა</translation>
     </message>
@@ -598,7 +604,7 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>|-
@@ -606,12 +612,14 @@ Are you sure you want to continue?</source>
 გსურთ დასრულების გაგრძელება?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>პროცესის დასრულება</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>|-
@@ -619,7 +627,7 @@ Are you sure you want to continue?</source>
 გსურთ დასრულების გაგრძელება?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>|-
@@ -627,19 +635,22 @@ Are you sure you want to continue?</source>
 გსურთ დასრულების გაგრძელება?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation type="unfinished">Force End</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation type="unfinished">End</translation>
@@ -648,7 +659,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>გასვლა</translation>
     </message>
@@ -656,7 +667,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>პარამეტრები</translation>
     </message>
@@ -664,7 +675,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>ზომა</translation>
     </message>
@@ -673,6 +684,7 @@ Are you sure you want to continue?</source>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>იპ მისამართი:</translation>
     </message>
@@ -791,11 +803,13 @@ Are you sure you want to continue?</source>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>IPv4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>IPv6</translation>
     </message>
@@ -808,17 +822,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>კომანდის ლინიი</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>სტარტის დრო</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>სახელი</translation>
     </message>
@@ -826,7 +840,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>დააჭირეთ სასურველ პროგრამას, რომ დაასრულოთ</translation>
     </message>
@@ -834,12 +848,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>მეხუთი</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>მიღება</translation>
     </message>
@@ -847,67 +865,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>პირდაპირი</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>დისკის წაკითხვა</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>დისკის ჩაწერა</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>მეხუთი</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>სვაპი</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>ჩართული არ არის</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>ჩატვირთვა</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>გატვირთვა</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>ქსია</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>სრული მიღებული</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>სულ გაგზავნილი</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>გაგზავნე</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>დისკები</translation>
     </message>
@@ -923,47 +959,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>ძალიან მაღალი</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>მაღალი</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>ნორმალური</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>დაბალი</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>ძალიან დაბალი</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>საკონფიგურაციო</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>არასწორი</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, შეცდომა: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>პროცესის პრიორიტეტის შეცვლა ვერ მოხდა</translation>
     </message>
@@ -989,32 +1032,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>პროცესის გაჩერება ვერ მოხდა</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>პროცესის გააგრძელება ვერ მოხდა</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>პროცესის გადაკეტება ვერ მოხდა</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>უცნობი შეცდომა</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>სიგნალის გაგზავნა პროცესში ვერ მოხდა</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>პროცესის დასრულება ვერ მოხდა</translation>
     </message>
@@ -1030,17 +1073,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>არ არსებობს პასუხი</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>ჩაჩერება</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>ტრეი</translation>
     </message>
@@ -1048,37 +1093,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>კომანდის მდებარეობის ნახვა</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>თვისებები</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>პროცესის დასრულება</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>პროცესის გააგრძელება</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>პროცესის დამხობა</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>პრიორიტეტის შეცვლა</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>პროცესის გაჩერება</translation>
     </message>
@@ -1086,18 +1136,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>სამართალიანი პრიორიტეტი</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation type="unfinished">Change</translation>
@@ -1174,7 +1224,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>არ არსებობს</translation>
     </message>
@@ -1217,12 +1267,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>სერვისის სტარტაპის ტიპის დასადგestად შეუძლია არა</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>შეცდომა: სერვისის სტარტაპის ტიპის დასადგestად შეუძლია არა მიუხედავად დამალული ქვეპროცესის გამო</translation>
     </message>
@@ -1230,17 +1280,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>სერვისის ინსტანციის სახელი</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -1248,37 +1300,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>განახლება</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>სტარტი</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>გაჩერება</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>ხელახლა გასატვირთა</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>ავტომატურად</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>ხელით</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>სტარტის ტიპი</translation>
     </message>
@@ -1329,17 +1385,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>პარამეტრები</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(ჩასწორებადი)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>ფართობი: %1-%2</translation>
     </message>
@@ -1347,22 +1404,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>სამართლის გარეშე გასასვლელი პროგრამის დასრულება</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>გაფართოება</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>კომპაქტურად</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>ხედავა</translation>
     </message>
@@ -1370,7 +1428,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>ძებნა</translation>
     </message>
@@ -1378,17 +1437,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>პროცესები</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>სერვისები</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>მომხმარებლები</translation>
     </message>
@@ -1396,7 +1463,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>ანგარიშის ინფორმაციის რედაქტირება</translation>
     </message>
@@ -1404,12 +1471,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>ადმინისტრატორი</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>სტანდარტული მომხმარებელი</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_km_KH.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_km_KH.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>ម៉ាស៊ីនមើលប្រព័ន្ធមួយ</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>ម៉ាស៊ីនមើលប្រព័ន្ធមួយគឺជា​ឧបករណ៍​ដែល​ប្រើ​ដើម្បី​តាមដាន​ការ​ប្រើ​ប្រាស់​ប្រព័ន្ធនៅ​ពេល​វេលា​បច្ចុប្បន្ន, មើល​និង​គ្រប់គ្រង​ការ​ដំណើរការ​និង​សេវាកម្ម​ដែល​កំពុង​ដំណើរការ​នៅ​លើ​ប្រព័ន្ធរបស់​អ្នក។</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>បិទ​ព័ត៌មាន​បន្ថែម</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>ការ​ប្រើ​ប្រាស់​សរុប</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>ការ​ប្រើ​ប្រាស់​ផ្នែក​មូល</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>អាន</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>សរសេរ</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>៦០​វែង</translation>
     </message>
@@ -56,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 ថ្ងៃ %2 ម៉ោង %3 នាទី</translation>
     </message>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>បំពង់​កម្ម​បច្ចុប្បន្ន</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>បំពង់​កម្ម</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>ំ០​វែង</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>គ្មាន​លទ្ធផល​ស្វែងរក</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>ព័ត៌មាន​បន្ថែម</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>ព័ត៌មាន​បន្ថែម</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>ការជប់ប្រយោគ</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>ប្រើប្រាស់</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>មានប្រើប្រាស់បាន</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>ចំណោម</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>ការចូលដោយស្វ័យប្រវត្តិ</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>តំបន់កម្រិត</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>ការផ្ទះនៅក្នុងអេក្រង់បានចូលដោយស្វ័យប្រវត្តិ</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation type="unfinished">Active</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>មិនប្រើប្រាស់</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>មានការផ្លាស់ប្ដូរ</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>បានស្នើសុំ</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>សរុប swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>សំណាក់ swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>តំបន់ការគ្រប់គ្រង</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>ម៉ូដែល</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>ល្បឿនអាន</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>ល្បឿនសរសេរ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>កំលัง</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>ដំណើរការអានក្នុង sectors</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>អាន/វដ្ត</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>តំបន់អាន/វដ្ត</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>អានដែលបានចុះបញ្ញើ/វដ្ត</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>តំបន់ដែលបានសរសេរ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>សរសេរបានបញ្ចប់</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>សរសេរដែលបានចុះបញ្ញើ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>សរសេរ/វដ្ត</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>តំបន់សរសេរ/វដ្ត</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>សរសេរដែលបានចុះបញ្ញើ/វដ្ត</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>ប្រព័ន្ធទំនាក់ទំនង</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>បង្ហាញការបើកបរ</translation>
     </message>
@@ -598,45 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>ការបញ្ចប់កម្មវិធីនេះអាចបណ្តាលឱ្យបាត់បង់ទិន្នន័យ។
 តើអ្នកជឿជាក់ថា​អ្នកចង់បន្តទេ?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>បញ្ចប់កម្មវិធី</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>ការបញ្ចប់កម្មវិធីដោយកម្លាំងពីរនេះអាចបណ្តាលឱ្យបាត់បង់ទិន្នន័យ។
 តើអ្នកជឿជាក់ថាអ្នកចង់បន្តទេ?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>ការបញ្ចប់កម្មវិធីដោយកម្លាំងពីរនេះអាចបណ្តាលឱ្យបាត់បង់ទិន្នន័យ។
 តើអ្នកជឿជាក់ថា​អ្នកចង់បន្តទេ?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation type="unfinished">Force End</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation type="unfinished">End</translation>
@@ -645,7 +656,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>ចេញពីប្រព័ន្ធទំនាក់ទំនង</translation>
     </message>
@@ -653,7 +664,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>ការកំណត់ត្រាទំនាក់ទំនង</translation>
     </message>
@@ -661,7 +672,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>ទំហំ</translation>
     </message>
@@ -670,6 +681,7 @@ Are you sure you want to continue?</source>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>អាស៊ីប៊ីអាស៊ីអាស៊ី៖</translation>
     </message>
@@ -788,11 +800,13 @@ Are you sure you want to continue?</source>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>IPv4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>IPv6</translation>
     </message>
@@ -805,17 +819,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>បណ្ដាញកម្មវិធី</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>ពេលផ្ដល់ចំណុចចាប់ផ្តើម</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>ឈ្មោះ</translation>
     </message>
@@ -823,7 +837,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>ចុចកម្មវិធីដែលអ្នកចង់បញ្ចប់</translation>
     </message>
@@ -831,12 +845,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>ផ្ទះកំហុស</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>ទទួល</translation>
     </message>
@@ -844,67 +862,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>ប្រព័ន្ធទំនាក់ទំនង</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>អាចអានក្រាហ្វិក</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>អាចសរសេរក្រាហ្វិក</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>ផ្ទះកំហុស</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>ផ្លាស់ប្ដូរ</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>មិនបានបើក</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>ទាញយក</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>ផ្ញើ</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>ប្រព័ន្ធទំនាក់ទំនង</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>ប្រាក់ទទួលទាំងអស់</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>សរុបដែលបានបញ្ចេញ</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>បញ្ចេញ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>ឌីស</translation>
     </message>
@@ -920,47 +956,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>ខ្ពស់ណាស់</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>ខ្ពស់</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>ធម្មតា</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>ទាប</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>ទាបណាស់</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>បើកបរ</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>មិនមែន</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Error: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>បានបិទការផ្លាស់ប្ដូរកម្រិតដំណើរដំណើរការ</translation>
     </message>
@@ -986,32 +1029,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>បានបិទការផ្គត់ផ្គង់ដំណើរការ</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>បានបិទការបិទដំណើរការ</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>បានបិទការសម្អាតដំណើរការ</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>សំគាល់តែមួយ</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>បានបិទការបញ្ជាក់សញ្ញាដំណើរការ</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>បានបិទការបញ្ចប់ដំណើរការ</translation>
     </message>
@@ -1027,17 +1070,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>គ្មានការឆ្លើយតប</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>បិទផ្គត់ផ្គង់</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>តំបន់បញ្ចូល</translation>
     </message>
@@ -1045,37 +1090,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>មើលទីតាំងនៃការបញ្ជា</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>លក្ខណៈ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>បញ្ចប់ដំណើរការ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>បញ្ចូលវិញដំណើរការ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>បិទការងារ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>ផ្លាស់ប្ដូ reb ប្រតិបត្តិការ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>បិទការងារ</translation>
     </message>
@@ -1083,18 +1133,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>ប្រតិបត្តិការផ្ទាល់</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation type="unfinished">Change</translation>
@@ -1171,7 +1221,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>មិនគាំទ្រ</translation>
     </message>
@@ -1214,12 +1264,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>មិនអាចកំណត់ប្រភេទការចាប់ផ្ដើមសេវា</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>កំហុស៖ មិនអាចកំណត់ប្រភេទការចាប់ផ្ដើមសេវាបានដោយសារការរញ្ជួយនៃការប្រើប្រាស់សេវារៀងរាល់</translation>
     </message>
@@ -1227,17 +1277,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>ឈ្មោះសេវារៀងរាល់</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -1245,37 +1297,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>កែតម្រូវឡើងវិញ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>ចាប់ផ្ដើម</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>បិទ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>បើកឡើងវិញ</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>អ automate</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>ដោយដៃ</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>ប្រភេទការបើកដំណើរការ</translation>
     </message>
@@ -1326,17 +1382,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>ការកំណត់</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(អាចកំណត់បាន)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>អាក្រាង: %1-%2</translation>
     </message>
@@ -1344,22 +1401,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>ដំណើរការបិទដោយដៃ</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>ពន្លាត</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>បន្ទុះ</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>មើល</translation>
     </message>
@@ -1367,7 +1425,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>ស្វែងរក</translation>
     </message>
@@ -1375,17 +1434,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>ដំណើរការ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>សេវាកម្ម</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>អ្នកប្រើប្រាស់</translation>
     </message>
@@ -1393,7 +1460,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>កែប្រែពត៌មានគណនី</translation>
     </message>
@@ -1401,12 +1468,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>អ្នកគ្រប់គ្រង</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>អ្នកប្រើប្រាស្រ័យដែលមានសិទ្ធិដើម</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_kn_IN.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_kn_IN.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>ಸಿಸ್ಟಂ ಮಾನಿಟರ್</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>ಸಿಸ್ಟಂ ಮಾನಿಟರ್ ಒಂದು ಸಿಸ್ಟಂ ಲೋಡ್ ಅನ್ನು ಅನುಸರಿಸಿ ನೋಡಲು ಮತ್ತು ನಿಯಂತ್ರಿಸಲು ಸಿಸ್ಟಂದಲ್ಲಿ ಕಾರ್ಯನಿರ್ವಹಿಸುತ್ತಿರುವ ಪ್ರಕ್ರಿಯೆಗಳು ಮತ್ತು ಸೇವೆಗಳನ್ನು ಅನುಸರಿಸಿ ನೋಡಲು ಮತ್ತು ನಿಯಂತ್ರಿಸಲು ಬಳಸಲಾಗುವ ಸಾಧನವಾಗಿದೆ.</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>ವಿವರಗಳನ್ನು ಕಾಣದಂತೆ ಮಾಡಿ</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>ಸಂಪೂರ್ಣ ಬಳಕೆ</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>ಒಬ್ಬಾರ್ ಬಳಕೆ</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>ಚಿತ್ರಗಳನ್ನು ಓದಿ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>ಚಿತ್ರಗಳನ್ನು ಬರೆಯಿ</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 ಸೆಕೆಂಡುಗಳು</translation>
     </message>
@@ -56,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 ದಿನಗಳು %2 ಗಂಟೆಗಳು %3 ನಿಮಿಷಗಳು</translation>
     </message>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>ಸದ್ಯದ ಆವರ್ತನ</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>ಆವರ್ತನ</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 ಸೆಕೆಂಡುಗಳು</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>ಸರ್ಚ್ ಫಲಿತಾಂಶಗಳಿಲ್ಲ</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>ವಿವರಗಳು</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>ವಿವರಗಳು</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>ಪ್ರಶ್ನಾ</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>ಬಳಕೆಯಲ್ಲಿರುವ</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>ಸಂಭಾವ್ಯ</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>ಸಂಯೋಜಿತ</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>ಚಿಪ್ಪು</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>ಬಫರ್ಸ್</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>ಚಿಪ್ಪು ಸ್ವ್ಯಾಪ್</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation type="unfinished">Active</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>ಅಕ್ಟಿವ್ ಆಗಿಲ್ಲ</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>ಅನಾರೋಗ್ಯ</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>ಮ್ಯಾಪ್ ಮಾಡಿದ</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>ಒಟ್ಟು ಸ್ವ್ಯಾಪ್</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>ಅನುಸ್ಥಿತ ಸ್ವ್ಯಾಪ್</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>ಸ್ಲಾಬ್</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>ಮಾದರಿ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>ಗ್ರಾಹಕ ವೇಗ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>ರೈಟ್ ವೇಗ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>ಕ್ಯಾಪಾಸಿಟಿ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>ಸೆಕ್ಟರ್ಸ್ ಗ್ರಾಹಕ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>ಮಾಹಿತಿ ಓದಿದೆ/ಸೆಕೆಂಡ್</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>ಸೆಕ್ಟರ್ಗಳು ಓದಿದೆ/ಸೆಕೆಂಡ್</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>ಮರುಗೂಡಿದ ಓದಿದೆ/ಸೆಕೆಂಡ್</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>ಸೆಕ್ಟರ್ಗಳು ಬರೆಯಲಾಗಿದೆ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>ಬರೆಯಲಾಗಿದೆ ಪೂರ್ಣಗೊಂಡಿದೆ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>ಮರುಗೂಡಿದ ಬರೆಯಲಾಗಿದೆ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>ಬರೆಯಲಾಗಿದೆ/ಸೆಕೆಂಡ್</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>ಸೆಕ್ಟರ್ಗಳು ಬರೆಯಲಾಗಿದೆ/ಸೆಕೆಂಡ್</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>ಮರುಗೂಡಿದ ಬರೆಯಲಾಗಿದೆ/ಸೆಕೆಂಡ್</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>ಸಿಸ್ಟಂ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>ಶರ್ಟ್ಕಟ್ಗಳನ್ನು ತೋರಿಸಿ</translation>
     </message>
@@ -598,45 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>ಈ ಪ್ರೋಸೆಸ್ ಅನ್ನು ಅಂತ್ಯಗೊಳಿಸುವುದು ಡೇಟಾ ಕಳೆದುಹೋಗುವ ಸಾಧ್ಯತೆಯನ್ನು ಹೊಂದಿದೆ.
 ನೀವು ಮತ್ತಷ್ಟು ಮುಂದುವರಿಸಲು ನಿಂತಿದ್ದೀರಾ?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>ಪ್ರೋಸೆಸ್ ಅಂತ್ಯಗೊಳಿಸಿ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>ಪ್ರೋಸೆಸ್ ಅನ್ನು ಬಲವಾಗಿ ಅಂತ್ಯಗೊಳಿಸುವುದು ಡೇಟಾ ಕಳೆದುಹೋಗುವ ಸಾಧ್ಯತೆಯನ್ನು ಹೊಂದಿದೆ.
 ನೀವು ಮತ್ತಷ್ಟು ಮುಂದುವರೆಯಲು ನಿಂತಿದ್ದೀರಾ?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>ಅಪ್ಲಿಕೇಶನ್ ಅನ್ನು ಬಲವಾಗಿ ಅಂತ್ಯಗೊಳಿಸುವುದು ಡೇಟಾ ಕಳೆದುಹೋಗುವ ಸಾಧ್ಯತೆಯನ್ನು ಹೊಂದಿದೆ.
 ನೀವು ಮತ್ತಷ್ಟು ಮುಂದುವರೆಯಲು ನಿಂತಿದ್ದೀರಾ?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation type="unfinished">Force End</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation type="unfinished">End</translation>
@@ -645,7 +656,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>ಸಿಸ್ಟಂ ಹೊರಗೆಡವಿ</translation>
     </message>
@@ -653,7 +664,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>ಸೆಟ್ಟಿಂಗ್ಸ್</translation>
     </message>
@@ -661,7 +672,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>ವ್ಯಾಪಕತೆ</translation>
     </message>
@@ -670,6 +681,7 @@ Are you sure you want to continue?</source>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>ಐಪಿ ಅಧಿಕಾರಿಗಳು:</translation>
     </message>
@@ -788,11 +800,13 @@ Are you sure you want to continue?</source>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>आईपीवी4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>आईपीवी6</translation>
     </message>
@@ -805,17 +819,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>कमांड लाइन</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>शुरू करने का समय</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>नाम</translation>
     </message>
@@ -823,7 +837,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>किस ऐप को बंद करना चाहिए उसे टैप करें</translation>
     </message>
@@ -831,12 +845,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>एमएम</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>प्राप्त करें</translation>
     </message>
@@ -844,67 +862,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>सीपीयू</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>डिस्क रीड</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>डिस्क व्राइट</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>एमएम</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>स्वैप</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>अक्षम कर रहे हैं</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>डाउनलोड</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>अपलोड</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>नेटवर्क</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>कुछ प्राप्त करें</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>ಕೊಟ್ಟುದು ಒಟ್ಟು</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>ಕೊಡು</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>ಡಿಸ್ಕ್‌ಗಳು</translation>
     </message>
@@ -920,47 +956,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>ಅತ್ಯುತ್ತಮ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>ಆಯುತ್ತಮ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>ಸಾಮಾನ್ಯ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>ಕ್ಷಣಿಕ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>ಅತ್ಯಂತ ಕ್ಷಣಿಕ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>ಅನುಕೂಲಿತ</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>ಅಮೂಲ್ಯ</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>ಪಿಡಿ: %1, ತಪ್ಪು: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>ಪ್ರಕ್ರಿಯೆಯ ಪ್ರಾಶಸ್ತ್ಯವನ್ನು ಬದಲಾಯಿಸಲಾಗಿಲ್ಲ</translation>
     </message>
@@ -986,32 +1029,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>ಪ್ರಕ್ರಿಯೆಯನ್ನು ನಿಲ್ಲಿಸಲಾಗಿಲ್ಲ</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>ಪ್ರಕ್ರಿಯೆಯನ್ನು ಮತ್ಯಾವರ್ಜಿಸಲಾಗಿಲ್ಲ</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>ಪ್ರಕ್ರಿಯೆಯನ್ನು ಕೊಲ್ಲಲಾಗಿಲ್ಲ</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>ಅಪರಿಚಿತ ತಪ್ಪು</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>ಪ್ರಕ್ರಿಯೆಗೆ ಸಂಕೇತ ಕಳುಹಿಸಲು ವಿಫಲವಾಯಿತು</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>ಪ್ರಕ್ರಿಯೆಯನ್ನು ಅಂತ್ಯಗೊಳಿಸಲಾಗಿಲ್ಲ</translation>
     </message>
@@ -1027,17 +1070,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>ಪ್ರತಿಕ್ರಿಯೆ ಇಲ್ಲ</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>ನಿಲ್ಲಿಸು</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>ಟ್ರೇ</translation>
     </message>
@@ -1045,37 +1090,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>ಕಮ್ಮಾಂಡ್ ಸ್ಥಳವನ್ನು ನೋಡು</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>ಸಾಮಗ್ರಿಗಳು</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>ಪ್ರಕ್ರಿಯೆಯನ್ನು ಅಂತ್ಯಗೊಳಿಸು</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>ಪ್ರಕ್ರಿಯೆಯನ್ನು ಮತ್ಯಾವರ್ಜಿಸು</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>ಪ್ರಕ್ರಿಯೆಯನ್ನು ಕೊಲ್ಲಿರಿ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>ಅವಧಿಯನ್ನು ಬದಲಾಯಿಸಿ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>ಪ್ರಕ್ರಿಯೆಯನ್ನು ನಿಲ್ಲಿಸಿ</translation>
     </message>
@@ -1083,18 +1133,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>ಅನುಕೂಲಿತ ಅವಧಿ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation type="unfinished">Change</translation>
@@ -1171,7 +1221,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>ಸ್ಪೋರ್ಟ್ ಆಗಿಲ್ಲ</translation>
     </message>
@@ -1214,12 +1264,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>ಸೇವಾ ಸ್ಟಾರ್ಟಪ್ ಟೈಪ್ ಸೆಟ್ ಮಾಡಲಾಗಿಲ್ಲ</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>ಪ್ರಮಾದ: ಸೇವಾ ಸ್ಟಾರ್ಟಪ್ ಟೈಪ್ ಸೆಟ್ ಮಾಡಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ ಏಕೆಂದರೆ ಸ್ವಲ್ಪ ಪ್ರಕ್ರಿಯೆಯು ಅನಾನುಕೂಲಿತ ಹಾನಿಗೊಂಡಿತು.</translation>
     </message>
@@ -1227,17 +1277,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>ಸೇವಾ ಅನುಕೂಲಿತ ಹೆಸರು</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -1245,37 +1297,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>ನವೀಕರಿಸಿ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>ಆರಂಭಿಸಿ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>ಸ್ಟಾಪ್</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>ರೀಸ್ಟಾರ್ಟ್</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>ಆಟೋಮೇಟಿಕ್</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>ಮ್ಯಾನುಯಲ್</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>ಸ್ಟಾರ್ಟಪ್ ಟೈಪ್</translation>
     </message>
@@ -1326,17 +1382,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>ಸೆಟ್ಟಿಂಗ್ಸ್</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>ಸುಧಾರಣೆ ಮಾಡಬಹುದು</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>ಸ್ಪೇಸ್: %1-%2</translation>
     </message>
@@ -1344,22 +1401,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>ಅನುಪಯೋಗವನ್ನು ಬಲವಾಗಿ ಅಂತ್ಯಗೊಳಿಸಿ</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>ವಿಸ್ತರಿಸಿ</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>ಕಮ್ಪಾಕ್ಟ್</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>ನೋಡಿ</translation>
     </message>
@@ -1367,7 +1425,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>ಹುಡುಕಿ</translation>
     </message>
@@ -1375,17 +1434,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>ಪ್ರಕ್ರಿಯೆಗಳು</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>ಸೇವ್</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>ವಿಷಯಗಳು</translation>
     </message>
@@ -1393,7 +1460,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>ಆಕ್ಯುಂಟ್ ಮಾಹಿತಿಯನ್ನು ಸುಧಾರಿಸಿ</translation>
     </message>
@@ -1401,12 +1468,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>ಆಡಿಮಿನಿಸ್ಟ್ರೇಟರ್</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>ಸ್ಟಾಂಡರ್ಡ್ ಬಳಕೆದಾರರು</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_ko.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_ko.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>시스템 모니터</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>시스템 실시간 시스템 부하를 모니터링하고 시스템에서 실행중인 프로세스 및 서비스를 보고 제어하는 도구입니다.</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>상세 정보 숨기기</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>전체 사용률</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>개별 사용률</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>읽기</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>쓰기</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60초</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1일 %2시간 %3분</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>현재 주파수</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>주파수</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">취소</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60초</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>검색 결과 없음</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>상세 정보</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>상세 정보</translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>사용 중</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>사용 가능</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>공유</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>캐시</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>버퍼</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>캐시 교환</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>활성</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>비활성</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>骯髒</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>매핑됨</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>총 교환</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>사용 가능한 교환</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>슬레브</translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>모델</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>읽기 속도</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>쓰기 속도</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>용량</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>읽은 섹터</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>읽기/초</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>읽은 섹터/초</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>병합된 읽기/초</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>작성된 섹터</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>작업 완료</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>병합된 쓰기</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>쓰기/초</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>작성된 섹터/초</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>병합된 쓰기/초</translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>확인</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>시스템</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>단축키 표시</translation>
     </message>
@@ -604,50 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>이 프로세스를 종료하면 데이터가 손실될 수 있습니다.
 계속하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>종료 프로세스</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>이 프로세스를 강제로 종료하면 데이터가 손실될 수 있습니다.
 계속하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>이 응용프로그램을 강제로 종료하면 데이터가 손실될 수 있습니다.
 계속하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>강제 종료</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>종료</translation>
@@ -656,7 +656,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>로그아웃</translation>
     </message>
@@ -664,7 +664,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>설정</translation>
     </message>
@@ -672,7 +672,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>크기</translation>
     </message>
@@ -819,17 +819,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>명령 줄</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>시작 시간</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>이름</translation>
     </message>
@@ -837,7 +837,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>종료하려는 응용프로그램을 클릭하십시오</translation>
     </message>
@@ -845,16 +845,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>메모리</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>수신</translation>
     </message>
@@ -862,85 +862,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>디스크 읽기</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>디스크 쓰기</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>메모리</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>스왑</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>사용할 수 없음</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>다운로드</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>업로드</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>네트워크</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>받은 총계</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>보낸 총계</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>전송</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>디스크</translation>
     </message>
@@ -956,54 +956,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>매우 높음</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>높음</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>보통</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>낮음</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>매우 낮음</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>사용자지정</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>잘못됨</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, 오류: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>프로세스 우선 순위를 변경하지 못했습니다</translation>
     </message>
@@ -1029,32 +1029,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>프로세스를 일시 중지하지 못했습니다</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>프로세스를 다시 시작하지 못했습니다</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>프로세스를 죽이지 못했습니다</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>알 수 없는 오류</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>처리시 신호를 보내는 데 실패했습니다</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>프로세스를 종료하지 못함</translation>
     </message>
@@ -1070,19 +1070,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>응답 없음</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>절전모드</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>트레이</translation>
     </message>
@@ -1090,42 +1090,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>명령 위치 보기</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>속성</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>종료 프로세스</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>재개 프로세스</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Kill 프로세스</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>우선 순위 변경</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>절전 프로세스</translation>
     </message>
@@ -1133,18 +1133,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>사용자지정 우선순위</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>변경</translation>
@@ -1221,7 +1221,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>지원하지 않음</translation>
     </message>
@@ -1264,12 +1264,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>서비스 시작 유형을 설정하지 못했습니다</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>오류: 충돌된 하위 프로세스로 인해 서비스 시작 프로그램 유형을 설정하지 못했습니다.</translation>
     </message>
@@ -1277,19 +1277,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>서비스 인스턴스 이름</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>확인</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
@@ -1297,41 +1297,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>새로 고침</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>시작</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>중지</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>재시작</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>자동</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>수동</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>시작 프로그램 유형</translation>
     </message>
@@ -1382,18 +1382,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>설정</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(수정 가능)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>범위: %1-%2</translation>
     </message>
@@ -1401,23 +1401,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>강제 종료 응용프로그램</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>확장</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>컴팩트</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>보기</translation>
     </message>
@@ -1425,8 +1425,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>검색</translation>
     </message>
@@ -1434,25 +1434,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>프로세스</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>서비스</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>사용자</translation>
     </message>
@@ -1460,7 +1460,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>계정 정보 수정</translation>
     </message>
@@ -1468,12 +1468,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>관리자</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>일반 사용자</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_ku.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_ku.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>ئەمەكى ئەنجامەن</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>ئەمەكى ئەنجامەن ھەرزەتىن ئەمەكى ئەنجامىنى نەزەرلىك، ھەرنەمە ئەنجامىنى كۆرۈش ۋە كۆرۈشتىن ھەرەكەتلىك ھەرنەمە ئەنجامىنى نەزەرلىك چېگىرەيدۇ.</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>تەسىرلىك ئېتىنى ئەچە</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>بىرەگە ھەرنەمە ئەچىلىكى</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>ئىندىيىلىك ئەچىلىكى</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>ئېتىنى ئوقۇش</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>ئېتىنى يېزىش</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 دىكى</translation>
     </message>
@@ -56,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 كۈن %2 ساچى %3 دىكى</translation>
     </message>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>ھەللىك ئېتىنى كۆرۈش</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>ئېتىنى كۆرۈش</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 دىكى</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>ئىزەرچىلىك نەتىجىسى بارمى</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>تەسىرلىك ئېتىنى</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>تەسىرلىك ئېتىنى</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>هەڵە</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>بەکارهێنراو</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>بەکارهێنرەوە ناکردن</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>بەشدار</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>کەشکردن</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>بەفرەوە</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>کەشکردن - سوپ</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation type="unfinished">Active</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>نەبەکارهێنراو</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>دەرکردن</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>مەپ کردن</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>کۆ سوپ</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>بەرکار نەکردن سوپ</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>سلاب</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>مۆدەل</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>سرعت بەکارهێنراو</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>سرعت نووسراو</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>کەمیتی</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>سیکتورەکان بەکارهێنراو</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>کەمەکان/س</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>سیکتورەکان کەمەکان/س</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>کەمەکان جووڵەکان/س</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>سیکتورەکان نووسرا</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>نووسراوەتەرە</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>نووسراوە جووڵەکان</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>نووسرا/س</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>سیکتورەکان نووسرا/س</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>نووسراوە جووڵەکان/س</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>سیستم</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>کوتاکەکان نمایش کردن</translation>
     </message>
@@ -598,45 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>پرۆسەسەکە بەکارهێنەر داتا بەکارهێنەر لاسەوە دەکات.
 ئەوە بەکارهێنەر دەبێت کە دەبێت بەکارهێنەر بەکارهێنەر دەبێت؟</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>پرۆسەسی بەکارهێنەر بەکارهێنەر</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>بەکارهێنەر بەکارهێنەر بەکارهێنەر بەکارهێنەر لاسەوە دەکات.
 ئەوە بەکارهێنەر دەبێت کە دەبێت بەکارهێنەر بەکارهێنەر دەبێت؟</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>بەکارهێنەر بەکارهێنەر بەکارهێنەر لاسەوە دەکات.
 ئەوە بەکارهێنەر دەبێت کە دەبێت بەکارهێنەر بەکارهێنەر دەبێت؟</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation type="unfinished">Force End</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation type="unfinished">End</translation>
@@ -645,7 +656,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>چاونەکردن</translation>
     </message>
@@ -653,7 +664,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>کۆنفیگ</translation>
     </message>
@@ -661,7 +672,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>بەش</translation>
     </message>
@@ -670,6 +681,7 @@ Are you sure you want to continue?</source>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>پی ئی ئەدەرس:</translation>
     </message>
@@ -788,11 +800,13 @@ Are you sure you want to continue?</source>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>IPv4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>IPv6</translation>
     </message>
@@ -805,17 +819,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>لەکەمەنی کۆمەند</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>زمانی شەڕکردن</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>نام</translation>
     </message>
@@ -823,7 +837,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>بەکارهێنەرەکە بەکارهێنەرەکە بەکارهێنەرەکە بەکارهێنەرەکە بەکارهێنەرەکە بەکارهێنەرە کە دەبێت بەکارهێنرە</translation>
     </message>
@@ -831,12 +845,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>هەمە</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>بەرکەوتن</translation>
     </message>
@@ -844,67 +862,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>پرۆسەسۆر</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>راکتەوتنەوە</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>نووسەوتنەوە</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>هەمە</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>سڤاپ</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>ناکەوتووە</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>داونلواد</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>یوپلواد</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>ناوەند</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>کۆکەرەوتن</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>ئەوە بەرھەم بەرھەم بەرھەم بەرھەم بەرھەم بەرھەم بەرھەم</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>بەرھەم بەرھەم</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>دیسكەکان</translation>
     </message>
@@ -920,47 +956,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>بەرھەم بەرھەم بەرھەم بەرھەم</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>بەرھەم بەرھەم</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>نۆرمال</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>بەرھەم بەرھەم</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>بەرھەم بەرھەم بەرھەم</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>کۆستم</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>بەرھەم بەرھەم</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1، خەرەک: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>بەرھەم بەرھەم بەرھەم بەرھەم بەرھەم بەرھەم بەرھەم</translation>
     </message>
@@ -986,32 +1029,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>بەرھەم بەرھەم بەرھەم بەرھەم بەرھەم</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>بەرھەم بەرھەم بەرھەم بەرھەم بەرھەم</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>بەرھەم بەرھەم بەرھەم بەرھەم بەرھەم</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>خەرەکی نەشنایان</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>بەرھەم بەرھەم بەرھەم بەرھەم بەرھەم</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>بەرھەم بەرھەم بەرھەم بەرھەم</translation>
     </message>
@@ -1027,17 +1070,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>جەڤە کەم</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>بەرھەم بەرھەم</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>بەرھەم بەرھەم</translation>
     </message>
@@ -1045,37 +1090,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>بەرھەم بەرھەم بەرھەم بەرھەم</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>ئەوە بەرھەم بەرھەم</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>بەرھەم بەرھەم</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>بەرھەم بەرھەم</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>کیل پروسەس</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>دەیایەت کۆمەڵە</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>بەکارهێنەری پروسەس</translation>
     </message>
@@ -1083,18 +1133,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>کۆمەڵە کۆمەڵە</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation type="unfinished">Change</translation>
@@ -1171,7 +1221,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>نەدەستکردن</translation>
     </message>
@@ -1214,12 +1264,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>بەکارهێنەری سێرڤیسی بەکارهێنەری گەڕاندنەوەی چاک کردن</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>کارەتە: بەکارهێنەری سێرڤیسی گەڕاندنەوەی چاک کردن لە نەخشکردنەوەی بەکارهێنەری ناچووە</translation>
     </message>
@@ -1227,17 +1277,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>ناڤی ناچووەی سێرڤیس</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -1245,37 +1297,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>بەرەکەت کردن</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>بەشێی چاک کردن</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>بەتەواو کردن</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>بەدەرەوە کردن</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>ئاوتۆ</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>مەنۇئەل</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>تۆپ ئەشەر تىپى</translation>
     </message>
@@ -1326,17 +1382,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>ئەگەر</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(ئەگەر كىرىنى)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>دەرىجە: %1-%2</translation>
     </message>
@@ -1344,22 +1401,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>پىرۆس ئەپلىكاسىيە ئەۋەردن</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>بەرەوە كىردن</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>بەرەوە كىردن</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>بەكىت</translation>
     </message>
@@ -1367,7 +1425,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>تىكار</translation>
     </message>
@@ -1375,17 +1434,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>پىرۆسەس</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>سېرڤىسەس</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>كىشىلەر</translation>
     </message>
@@ -1393,7 +1460,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>كىشى كىرىنى تەرجىمە كىردن</translation>
     </message>
@@ -1401,12 +1468,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>ئىمارەتىر</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>سەرڤىس كىشىسى</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_ku_IQ.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_ku_IQ.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>ئەمەکە سیستەم نەظەرکردن</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>ئەمەکە سیستەم نەظەرکردن ھەر واقت سیستەم باریت نەظەرکردن، سیستەمە ئەکەرە چالاکیت و کۆنترول کردن بۆ چالاکیتە و خەرچیتە کە دەکەنەن سیستەمە دەرەکەنەن کردن</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>دەtails نەدەرەن کردن</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>کۆتایی چالاکیت</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>ئەکەرە چالاکیت</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>ئەچوو</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>نووسین</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 دەن</translation>
     </message>
@@ -56,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 ڕۆژە %2 ھۆرە %3 دەن</translation>
     </message>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>کۆرەن فرەکوانسی</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>فرەکوانسی</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 دەن</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>ھەیچ نەتیجە نەدەرەن</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>دەtails</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>دەtails</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>ئەتنە</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>بەکارهێنرا</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>ئەمکە بەکارهێنرێ</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>ئەمکە چاکدرا</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>بەرکەوتوکردن</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>بەرکەوتوکردن</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>بەرکەوتوکردن (swap)</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation type="unfinished">Active</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>ئەمکە بەکار نەهێنرا</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>دەرەکە</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>ئەمکە دەرەکە</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>کۆکەن (swap)</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>بەکار نەهێنرا (swap)</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Slab</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>مۆدێل</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>دەرەکە سەرەکردن</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>دەرەکە نووسەردن</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>کۆپیتى</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>سەکتەرەکە دەرەکە</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>ئەتەک / ثانىە</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>سېکتورەک / ثانىە</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>ئەتەکەک / ثانىە</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>سېکتورەک نووسرا</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>نووسرا ئەتەک</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>نووسرا ئەتەکەک</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>نووسرا / ثانىە</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>سېکتورەک نووسرا / ثانىە</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>نووسرا ئەتەکەک / ثانىە</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>سیستەم</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>ئەتەکە ئەتەک بەکارهێنەر</translation>
     </message>
@@ -598,45 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>پرۆسەسەکە بەکارهێنەر بەکارهێنرەکە بەکارهێنەر دەتوانێت دەتايە لەسەر بکات.
 ئاگاڵ ئەتەکە بەکارهێنەر بەکارهێنرەکە بەکارهێنەر بەکارهێنەر بکات؟</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>پرۆسەسەکە بەکارهێنەر</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>بەرەوە گەڕاندنەوە بەکارهێنەر بەکارهێنرەکان بەکارهێنەر دەتوانێت دەتايە لەسەر بکات.
 ئاگاڵ ئەتەکە بەکارهێنەر بەکارهێنرەکان بەکارهێنەر بکات؟</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>بەرەوە گەڕاندنەوە بەکارهێنەر بەکارهێنرەکان بەکارهێنەر دەتوانێت دەتايە لەسەر بکات.
 ئاگاڵ ئەتەکە بەکارهێنەر بەکارهێنرەکان بەکارهێنەر بکات؟</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation type="unfinished">Force End</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation type="unfinished">End</translation>
@@ -645,7 +656,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>چاک کردن</translation>
     </message>
@@ -653,7 +664,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>تەمەمەت</translation>
     </message>
@@ -661,7 +672,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>بەش</translation>
     </message>
@@ -670,6 +681,7 @@ Are you sure you want to continue?</source>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>پى ئى پى ئەددىس:</translation>
     </message>
@@ -788,11 +800,13 @@ Are you sure you want to continue?</source>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>IPv4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>IPv6</translation>
     </message>
@@ -805,17 +819,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>لاینی کۆمەند</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>زمانی شەرو</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>نام</translation>
     </message>
@@ -823,7 +837,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>بەرەوە ئەپی کە دەرکەوتو دەبێت بەکاربێرەکە بەکاربێرە</translation>
     </message>
@@ -831,12 +845,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>مەموري</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>بەرەوە</translation>
     </message>
@@ -844,67 +862,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>دیسکی بارکردن</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>دیسکی نووسین</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>مەموري</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>سواپ</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>بەکارهێنەر نەکردن</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>دانلۆد</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>یوپلۆد</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>نیتواورک</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>کۆتایی بەرەوە</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>ئوتوئەڵ ھەجەم</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>پەشنە</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>دیسكە</translation>
     </message>
@@ -920,47 +956,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>بەرەم بەردنە</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>بەرەم بەردنە</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>نۆرمال</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>کۆتە</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>بەرەم کۆتە</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>کۆتە</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>بەرەم کۆتە</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1، خەط: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>بەرەم بەردنە دەگەڕات</translation>
     </message>
@@ -986,32 +1029,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>بەرەم بەردنە دەگەڕات</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>بەرەم بەردنە دەگەڕات</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>بەرەم بەردنە دەگەڕات</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>خەط نەشنوویە</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>سیگنال بەرەم بەردنە داگەڕات</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>بەرەم بەردنە دەگەڕات</translation>
     </message>
@@ -1027,17 +1070,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>چەکەرە</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>بەرەم بەردنە</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>تڕە</translation>
     </message>
@@ -1045,37 +1090,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>کۆمەندە کەمەندە بەردنەن ببینە</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>ئەیتەن</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>بەرەم بەردنە</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>بەرەم بەردنە</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>ئەمرەت کردن</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>پریۆریتی دەگەڕاندن</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>پرۆسەس بەرکەم کردن</translation>
     </message>
@@ -1083,18 +1133,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>پریۆریتی کۆشە</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation type="unfinished">Change</translation>
@@ -1171,7 +1221,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>نەدەستە</translation>
     </message>
@@ -1214,12 +1264,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>سرویس سەرەتی دەگەڕاندنەوە کەمکردنەوە</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>کەمکردنەوە: سرویس سەرەتی دەگەڕاندنەوە کەمکردنەوە لە ئەنجامی چاک کردنەوەی چەمە سرویس</translation>
     </message>
@@ -1227,17 +1277,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>سرویس ئینستانس ناو</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -1245,37 +1297,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>بەرکەم کردن</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>سەرەت کردن</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>بەندەکردن</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>دوبارە چالاک کردن</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>ئاوتۆ</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>ئەمەن</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>تایبەتی چالاککردن</translation>
     </message>
@@ -1326,17 +1382,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>ئەوەیە</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(بەهۆجەتی)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>بەرە: %1-%2</translation>
     </message>
@@ -1344,22 +1401,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>بەندەکردنەوەی ئەپ</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>بەردەوە</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>کۆمپاکت</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>بینا</translation>
     </message>
@@ -1367,7 +1425,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>ئەچىت</translation>
     </message>
@@ -1375,17 +1434,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>پرۆسەسەکان</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>سەرڤيسەکان</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>کاروان</translation>
     </message>
@@ -1393,7 +1460,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>تەمەمی کارگەری بەکارهێنەر</translation>
     </message>
@@ -1401,12 +1468,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>ئەمەنیستەر</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>کارگەری چەمەن</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_ky.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_ky.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Систем ҡаражыты</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Систем ҡаражыты сизге система үтәүҙән һыҙыҡлы үтәү, процесстар һәм хеҙмәттәрҙе ҡарау һәм башҡару өсөн ҡулланыла. Сизге система үтәүҙән һыҙыҡлы үтәү, процесстар һәм хеҙмәттәрҙе ҡарау һәм башҡару өсөн ҡулланыла.</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Мәғлүмәттәрҙе ҡулында</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Бөтә үтәү</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Индивидуаль үтәү</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Күрһәтеү</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Яҙыу</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 секунд</translation>
     </message>
@@ -56,9 +60,9 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
-        <translation>'%1 көн %2 сәғәт %3 минут'</translation>
+        <translation>&apos;%1 көн %2 сәғәт %3 минут&apos;</translation>
     </message>
 </context>
 <context>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Хәҙерге ҡуатын</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Ҡуатын</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 секунд</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Ҡыуыу нәтижәләре юҡ</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Мәғлүмәттәр</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Мәғлүмәттәр</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>Эскерту</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Колдонуу</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Мамлуга</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Бөлүү</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Кэш</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Буфер</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Кэштеги айырым</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation type="unfinished">Active</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Актив эмес</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Жылынган</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Маппинг</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Жалпы айырым</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Салтанат айырым</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Слаб</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Модель</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Окуу ылдамдығы</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Жазуу ылдамдығы</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Күлөө</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Секторлар окуу</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Оқу/с</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Секторлар оқу/с</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Оқу бірләшкән/с</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Секторлар жазылды</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Жазу түзәндән</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Жазу бірләшкән</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Жазу/с</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Секторлар жазу/с</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Жазу бірләшкән/с</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Система</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Тышқындарды көрсәт</translation>
     </message>
@@ -598,45 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Бул процессты төгәндеу мағынасыз мағлұматты үзіп қойуы мүмкін.
 Тағы да жалғыз үзіп қойыңыз ба?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Процессты төгәнде</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Бул процессты күшті төгәндеу мағынасыз мағлұматты үзіп қойуы мүмкін.
 Тағы да жалғыз үзіп қойыңыз ба?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Бул әмбебайынды күшті төгәндеу мағынасыз мағлұматты үзіп қойуы мүмкін.
 Тағы да жалғыз үзіп қойыңыз ба?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation type="unfinished">Force End</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation type="unfinished">End</translation>
@@ -645,7 +656,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Чыгыңыз</translation>
     </message>
@@ -653,7 +664,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Төзәмдер</translation>
     </message>
@@ -661,7 +672,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Көлбеүүл</translation>
     </message>
@@ -670,6 +681,7 @@ Are you sure you want to continue?</source>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>IP манзилы:</translation>
     </message>
@@ -788,11 +800,13 @@ Are you sure you want to continue?</source>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>IPv4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>IPv6</translation>
     </message>
@@ -805,17 +819,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Команда жолу</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Башланғыс уаҡыты</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Аты</translation>
     </message>
@@ -823,7 +837,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Тамамлау үчүн үзүнөн өйөнөткөн әмалдәрди тыштаң</translation>
     </message>
@@ -831,12 +845,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Мемория</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Қабылдаш</translation>
     </message>
@@ -844,67 +862,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Диск қырдаш</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Диск жазу</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Мемория</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Swap</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Активдә эмес</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Жүкляш</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Жөнөтүү</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Айырым</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Жалпы қабылдаш</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Жалпы жылыу</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Жылыу</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Диск</translation>
     </message>
@@ -920,47 +956,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Артыгыраа үс</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Үс</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Төгөн</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Төгөн</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Артыгыраа төгөн</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Кэсеп</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Жөнөкөй</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Қате: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Процес үс өзгөртүү үчүн үйлөө</translation>
     </message>
@@ -986,32 +1029,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Процес үйлөө үчүн үйлөө</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Процес үйлөө үчүн үйлөө</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Процес үйлөө үчүн үйлөө</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Белгилең қате</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Процес үйлөө үчүн үйлөө</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Процес үйлөө үчүн үйлөө</translation>
     </message>
@@ -1027,17 +1070,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Жауап жок</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Түшүрүү</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Трэй</translation>
     </message>
@@ -1045,37 +1090,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Команда жайлыгын көрсөт</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Сифаттар</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Процес үйлөө</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Процес үйлөө</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Процессни өлтөр</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Төрөнөөнөө өзгөртөр</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Процессни үзгәртөр</translation>
     </message>
@@ -1083,18 +1133,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Күп өлөштөн өзгөртөр</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation type="unfinished">Change</translation>
@@ -1171,7 +1221,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Мүнәсәбәтсіз</translation>
     </message>
@@ -1214,12 +1264,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Хызметті үзгәртөр үлгісін өзгәртіп өткөр</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Хатта: Хызметті үзгәртөр үлгісін өзгәртіп өткөр, өзгәртөр үзгәртіп өткөр үлгісі үзгәртілді</translation>
     </message>
@@ -1227,17 +1277,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Хызмет үлгісі аты</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -1245,37 +1297,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Тазарту</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Баштау</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Туп</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Таңдап қайта ішер</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Авт</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Күзәт</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Башқылыҡ түрү</translation>
     </message>
@@ -1326,17 +1382,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Төзүмдер</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Төҙөө</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Аралығы: %1-%2</translation>
     </message>
@@ -1344,22 +1401,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Берілгән әмәлдәрді үзінен үзір</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Күбейте</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Кыскара</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Көрү</translation>
     </message>
@@ -1367,7 +1425,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Қарастыр</translation>
     </message>
@@ -1375,17 +1434,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Процесстер</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Сервис</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Кешелер</translation>
     </message>
@@ -1393,7 +1460,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Аккаунт маълуматын өзгәрте</translation>
     </message>
@@ -1401,12 +1468,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Администратор</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Стандарттык Қызметкер</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_lt.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_lt.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Sistemos stebėjimas</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Sistemos stebėjimas yra įrankis, skirtas stebėti sistemos apkrovą, peržiūrėti ir valdyti procesus ir paslaugas, veikiančias jūsų sistemoje.</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Slėpti detalių informaciją</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Viso naudojimo</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Individinė naudojimo</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Skaityti</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Rašyti</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 sekundžių</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 dienos %2 valandos %3 minutes</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Dabartinė dažni</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Dažni</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="100"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Atsisakyti</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>ChartViewWidget</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Nėra paieškos rezultatų</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Detalės</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Detalės</translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Naudojama</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Prieinama</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Dalinama</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Cache</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Buferiai</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Cache swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Aktyvus</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Inaktyvus</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Kvaila</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Atsakomybė</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Visas swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Laisvas swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Slab</translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Modelis</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Skaitymo greitis</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Rašymo greitis</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Apimtis</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Sektorius nuskaitė</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Nuskaitomos/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Nuskaitomos sektoriai/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Sulietos nuskaitomos/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Sektorius parašė</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Parašyta</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Sulietos parašymo</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Parašyta/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Parašyta sektoriai/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Sulietos parašymo/s</translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Gerai</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Sistemos</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Rodyti trumpinės</translation>
     </message>
@@ -604,49 +604,49 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation type="unfinished">Šio proceso užbaigimas gali sukelti duomenų praradimą?
 Ar tikrai norite tęsti?</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Pabaigti</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation type="unfinished">Užbaigti procesą</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Atsisakyti</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Paskubinti pabaigti</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Priverstinis procesų pabaigimas gali sukelti duomenų praradimą.
 Ar tikrai norite tęsti?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Priverstinis programos pabaigimas gali sukelti duomenų praradimą.
@@ -656,7 +656,7 @@ Ar tikrai norite tęsti?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Atsijungti</translation>
     </message>
@@ -664,7 +664,7 @@ Ar tikrai norite tęsti?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Nustatymai</translation>
     </message>
@@ -672,7 +672,7 @@ Ar tikrai norite tęsti?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Dydis</translation>
     </message>
@@ -819,17 +819,17 @@ Ar tikrai norite tęsti?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation type="unfinished">Komandų eilutė</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation type="unfinished">Paleidimo laikas</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation type="unfinished">Pavadinimas</translation>
     </message>
@@ -837,7 +837,7 @@ Ar tikrai norite tęsti?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation type="unfinished">Spustelėkite ant programos, kurią norite sustabdyti</translation>
     </message>
@@ -845,16 +845,16 @@ Ar tikrai norite tęsti?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation type="unfinished">Atmintis</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Gauti</translation>
     </message>
@@ -862,85 +862,85 @@ Ar tikrai norite tęsti?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation type="unfinished">CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation type="unfinished">Disko skaitymas</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation type="unfinished">Disko rašymas</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation type="unfinished">Atmintis</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation type="unfinished">Sukeitimų skaidinys</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation type="unfinished">Neįjungta</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation type="unfinished">Atsiuntimas</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation type="unfinished">Išsiuntimas</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation type="unfinished">Tinklas</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Iš viso gauta</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Iš viso siųsta</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Diskai</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Siųsti</translation>
     </message>
@@ -956,54 +956,54 @@ Ar tikrai norite tęsti?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Labai aukšta</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Aukšta</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normali</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Žieta</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Labai žieta</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Parengta</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Neteisingas</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Klaidos: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Nepavyko pakeisti proceso prioritetų</translation>
     </message>
@@ -1029,32 +1029,32 @@ Ar tikrai norite tęsti?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Nepavyko sustabdyti proceso</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Nepavyko atsinaujinti proceso</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Nepavyko užbaigti proceso</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Nežinoma klaida</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Nepavyko išsiųsti signalo procesui</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Nepavyko užbaigti proceso</translation>
     </message>
@@ -1070,19 +1070,19 @@ Ar tikrai norite tęsti?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation type="unfinished">Nėra atsakymo</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation type="unfinished">Pristabdyti</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation type="unfinished">Dėklas</translation>
     </message>
@@ -1090,42 +1090,42 @@ Ar tikrai norite tęsti?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Peržiūrėti komandos vietą</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation type="unfinished">Savybės</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation type="unfinished">Užbaigti procesą</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Atsinaujinti procesą</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Užbaigti procesą</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Pakeisti prioritetą</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Sustabdyti procesą</translation>
     </message>
@@ -1133,18 +1133,18 @@ Ar tikrai norite tęsti?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Nepriklausomas Prioritetas</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Atsisakyti</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Keisti</translation>
@@ -1256,7 +1256,7 @@ Ar tikrai norite tęsti?</translation>
         <translation>Pranešimai</translation>
     </message>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Nepalaiko</translation>
     </message>
@@ -1264,12 +1264,12 @@ Ar tikrai norite tęsti?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Nepavyko nustatyti paslaugos paleidimo tipo</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Klaida: Nepavyko nustatyti paslaugos paleidimo tipo dėl užsibėgusiojo papildomo proceso</translation>
     </message>
@@ -1277,19 +1277,19 @@ Ar tikrai norite tęsti?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>GERAI</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Atsisakyti</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Paslaugos instancijos vardas</translation>
     </message>
@@ -1297,41 +1297,41 @@ Ar tikrai norite tęsti?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Atnaujinti</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Paleisti</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Stabdyti</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Paleisti iš naujo</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Automatinis</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Rankinis</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Paleidimo tipas</translation>
     </message>
@@ -1382,18 +1382,18 @@ Ar tikrai norite tęsti?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Nustatymai</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Redaguojamas)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Intervalas: %1-%2</translation>
     </message>
@@ -1401,23 +1401,23 @@ Ar tikrai norite tęsti?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Paskubinti užbaigti programą</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Plėsti</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Suskleisti</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Peržiūrėti</translation>
     </message>
@@ -1425,8 +1425,8 @@ Ar tikrai norite tęsti?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation type="unfinished">Paieška</translation>
     </message>
@@ -1434,25 +1434,25 @@ Ar tikrai norite tęsti?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Procesai</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Paslaugos</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Vartotojai</translation>
     </message>
@@ -1460,7 +1460,7 @@ Ar tikrai norite tęsti?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Redaguoti paskyros informaciją</translation>
     </message>
@@ -1468,12 +1468,12 @@ Ar tikrai norite tęsti?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Administratorius</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Standartinis vartotojas</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_ml.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_ml.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>ജനകീയ മോണിറ്റർ</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>സിസ്റ്റം മോണിറ്റർ ഒരു ടൂളാണ്, നിങ്ങളുടെ സിസ്റ്റത്തിൽ പ്രവർത്തിക്കുന്ന പ്രോസസ്സുകളും സേവിക്കുകളും കാണാനും നിയന്ത്രിക്കാനും കാലാവസാനം സിസ്റ്റം ലോഡ് പരിശോധിക്കാനും ഉപയോഗിക്കുന്നതാണ്.</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>ഡിറ്റേലുകൾ മറച്ചിടുക</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>ആകെ ഉപയോഗം</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>പ്രത്യക്ഷ ഉപയോഗം</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>പഠിക്കുക</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>എഴുതുക</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 സെക്കൻഡ്</translation>
     </message>
@@ -56,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 ദിവസം %2 മണിക്കൂർ %3 മിനിറ്റ്</translation>
     </message>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>ഇപ്പോൾ ഫ്രീക്വൻസി</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>ഫ്രീക്വൻസി</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 സെക്കൻഡ്</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>സെർച്ച് റഫറന്സുകൾ ഇല്ല</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>ഡിറ്റേലുകൾ</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>ഡിറ്റേലുകൾ</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>വിൽപ്പന</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>പ്രയോഗം</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>ഉപയോഗം ചെയ്യാനുള്ളത്</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>സാവധാനം</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>കേഷ്ഡ്</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>ബഫറുകൾ</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>കേഷ്ഡ് സ്വാപ്</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation type="unfinished">Active</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>പ്രവർത്തനരഹിതം</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>ഇടയ്ക്ക് ചെയ്യുക</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>മാപ്പ് ചെയ്യുക</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>ആകെ സ്വാപ്</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>സ്വാപ് വിട്ടുകളിച്ചിരിക്കുന്നു</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>സ്ലാബ്</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>മോഡൽ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>നിലവിലെ വേഗത</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>എഴുതൽ വേഗത</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>ക്ഷമത</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>സെക്ടർ വായിച്ചിരിക്കുന്നു</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>നായിക്കുന്നത്/സ്</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>സെക്ടറുകൾ നായിക്കുന്നത്/സ്</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>നായിക്കുന്നത് merged/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>സെക്ടറുകൾ എഴുതപ്പെടുന്നു</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>എഴുതൽ പൂർത്തിയായി</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>എഴുതൽ merged</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>എഴുതൽ/സ്</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>സെക്ടറുകൾ എഴുതപ്പെടുന്നത്/സ്</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>എഴുതൽ merged/s</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>സിസ്റ്റം</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>ശേഖരം പ്രദർശിപ്പിക്കുക</translation>
     </message>
@@ -598,45 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>ഈ പ്രോസസ്സ് അവസാനിപ്പിക്കുന്നത് ഡാറ്റ നഷ്ടപ്പെടുത്താം.
 നിങ്ങൾ തുടർന്ന് പോകാൻ തീരുമാനിച്ചിരിക്കുന്നു എന്ന് ഉറപ്പുവരുത്തിയാൽ മതിയാകുമോ?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>പ്രോസസ്സ് അവസാനിപ്പിക്കുക</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>പ്രോസസ്സ് പ്രബലമായി അവസാനിപ്പിക്കുന്നത് ഡാറ്റ നഷ്ടപ്പെടുത്താം.
 നിങ്ങൾ തുടർന്ന് പോകാൻ തീരുമാനിച്ചിരിക്കുന്നു എന്ന് ഉറപ്പുവരുത്തിയാൽ മതിയാകുമോ?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>പ്രോഗ്രാം പ്രബലമായി അവസാനിപ്പിക്കുന്നത് ഡാറ്റ നഷ്ടപ്പെടുത്താം.
 നിങ്ങൾ തുടർന്ന് പോകാൻ തീരുമാനിച്ചിരിക്കുന്നു എന്ന് ഉറപ്പുവരുത്തിയാൽ മതിയാകുമോ?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation type="unfinished">Force End</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation type="unfinished">End</translation>
@@ -645,7 +656,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>ലോഗ് ഔട്ട്</translation>
     </message>
@@ -653,7 +664,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>സെറ്റിംഗ്സ്</translation>
     </message>
@@ -661,7 +672,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>സൈസ്</translation>
     </message>
@@ -670,6 +681,7 @@ Are you sure you want to continue?</source>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>ഐ.പി. വിലാസം:</translation>
     </message>
@@ -788,11 +800,13 @@ Are you sure you want to continue?</source>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>ഐപിവി4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>ഐപിവി6</translation>
     </message>
@@ -805,17 +819,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>കമാൻഡ് ലൈൻ</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>ആരംഭ സമയം</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>പേര്</translation>
     </message>
@@ -823,7 +837,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>നിർത്താനാഗತ പ്രോഗ്രാമിനെ ക്ലിക്ക് ചെയ്യുക</translation>
     </message>
@@ -831,12 +845,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>മെമ്മറി</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>സ്ഥിരീകരിക്കുക</translation>
     </message>
@@ -844,67 +862,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>സീപിയു</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>ഡിസ്ക് റീഡ്</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>ഡിസ്ക് വൈറ്റ്</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>മെമ്മറി</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>സ്വാപ്</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>പ്രവർത്തനരഹിതം</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>ഡൗൺലോഡ്</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>യൂപ്ലോഡ്</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>നെറ്റ്വർക്ക്</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>ആകെ സ്ഥിരീകരിച്ചത്</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>ആകെ അയച്ചു</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>അയയിക്കു</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>ഡിസ്കുകൾ</translation>
     </message>
@@ -920,47 +956,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>ഉയരം കൂടാത്ത</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>ഉയരം</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>സാധാരണ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>നിരക്കിൽ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>ഉയരം കുറഞ്ഞ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>പ്രത്യേകം</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>അസാധുവായ</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>പിഡി: %1, പരിശോധന: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>പ്രോസസ്സ് പ്രിയോറിറ്റി മാറ്റാന്‍ കഴിഞ്ഞില്ല</translation>
     </message>
@@ -986,32 +1029,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>പ്രോസസ്സ് നിർത്താന്‍ കഴിഞ്ഞില്ല</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>പ്രോസസ്സ് തുടർന്നാന്‍ കഴിഞ്ഞില്ല</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>പ്രോസസ്സ് കില്ലാന്‍ കഴിഞ്ഞില്ല</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>അപരിചിത പരിശോധന</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>പ്രോസസ്സിലേക്ക് സിഗ്നല്‍ അയയി കഴിഞ്ഞില്ല</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>പ്രോസസ്സ് അവസാനിപ്പിക്കാന്‍ കഴിഞ്ഞില്ല</translation>
     </message>
@@ -1027,17 +1070,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>ആശയവിനിമയം ഇല്ല</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>നിർത്തു</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>ട്രെയി</translation>
     </message>
@@ -1045,37 +1090,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>കമാൻഡ് സ്ഥലം കാണു</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>സവിശേഷതകൾ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>പ്രോസസ്സ് അവസാനിപ്പിക്കു</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>പ്രോസസ്സ് തുടർന്നു</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>പ്രോസസ്സ് കില്ല്</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>പ്രോസസ്സ് പ്രിയോറിറ്റി മാറ്റുക</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>പ്രോസസ്സ് സസ്പെൻഡ് ചെയ്യുക</translation>
     </message>
@@ -1083,18 +1133,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>പ്രിയോറിറ്റി കസ്റ്റം</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation type="unfinished">Change</translation>
@@ -1171,7 +1221,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>നോട്ട് സപ്പോർട്ട്</translation>
     </message>
@@ -1214,12 +1264,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>സർവീസ് സ്റ്റാർട്ട് ടൈപ്പ് സെറ്റ് ചെയ്യാൻ കഴിയാത്തത്</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>പരാതി: സർവീസ് സ്റ്റാർട് ടൈപ്പ് സെറ്റ് ചെയ്യാൻ കഴിയാത്തത് കാരണം ക്രാഷ് ചെയ്ത സബ് പ്രോസസ്സ്</translation>
     </message>
@@ -1227,17 +1277,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>സർവീസ് ഇൻസ്റ്റൻസ് പേര്</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -1245,37 +1297,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>റഫ്രഷ്</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>സ്റ്റാർട്ട്</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>സ്റ്റോപ്പ്</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>റെസ്റ്റാർട്ട്</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>ആട്ടോ</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>മാനുവൽ</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>സ്റ്റാർട്ടപ് ടൈപ്പുകൾ</translation>
     </message>
@@ -1326,17 +1382,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>സെറ്റിംഗ്സ്</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(തിരുത്തൽ ചെയ്യാവുന്നത്)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>നിലവിലെ: %1-%2</translation>
     </message>
@@ -1344,22 +1401,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>പ്രവർത്തനം അവസാനിപ്പിക്കുക</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>ഉൾപ്പെടുത്തുക</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>കമ്പാക്ട്</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>നോക്കുക</translation>
     </message>
@@ -1367,7 +1425,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>തിരയുക</translation>
     </message>
@@ -1375,17 +1434,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>പ്രോസസസ്</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>സർവീസസ്</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>ഉപയോക്തർ</translation>
     </message>
@@ -1393,7 +1460,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>അക്കൌണ്ട് വിവരങ്ങൾ തിരുത്തുക</translation>
     </message>
@@ -1401,12 +1468,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>അഡ്മിനിസ്ട്രേറ്റർ</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>സ്റ്റാൻഡർഡ് ഉപയോക്തൻ</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_mn.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_mn.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Системын мэдээлэл</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Системын мэдээлэл нь таны систем дээр үйлдэл үргэлжилж байгаа үр ашиглалтыг, үйлдлийг үзэх болон дүүргэх боломжийг олгодог хэрэгсэл юм.</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Мэдээлэл хөхөрөх</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Бүх үр ашиглалт</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Хувь хүн бүр үр ашиглалт</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Унших</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Хэвлэх</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 секунд</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 өдөр %2 цаг %3 минут</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Хүчдэл</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Хүчдэл</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="100"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Цуцлах</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 секунд</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Хайлтанд олдсон байдал</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Мэдээлэл</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Дэлгэрэнгүй</translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Хэрэглэгдсэн</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Хэрэглэгдэхгүй</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Хуваагдсан</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Хадгалах</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Буфер</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Хадгалах swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Үйлдвэрлэгдсэн</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Үйлдвэрлэгдээгүй</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Хүчтэй</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Харуулах</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Бүтэн swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Босоо swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Слаб</translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Модель</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Хүснэгчийн хурд</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Зөвшөөрөгдсөн хурд</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Хэмжээ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Секторууд унших</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Унших хурд</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Унших секторууд хурд</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Хуваагдсан унших хурд</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Секторууд бичих</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Бичих эрхлэсэн</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Хуваагдсан бичих</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Бичих хурд</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Бичих секторууд хурд</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Хуваагдсан бичих хурд</translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Хүлээн зөвшөөрөх</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Систем</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Шинэчлэх товчныг харуулах</translation>
     </message>
@@ -604,47 +604,47 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Энэ үйлдлийг дуусгах нь үүнийгээ бүрэн ашиглаж байгаа үед мэдээлэлгүй байх боломжтой. Тийм болохыг хүсэж байгаа бол?</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Дуусгах</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation type="unfinished">Процесс зогсоох</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Цуцлах</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Хүчээр дуусгах</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Хүчээр энэ үйлдлийг дуусгах нь мэдээлэлгүй байх боломжтой. Тийм болохыг хүсэж байгаа бол?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Хүчээр энэ програмыг дуусгах нь мэдээлэлгүй байх боломжтой. Тийм болохыг хүсэж байгаа бол?</translation>
@@ -653,7 +653,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Гарах</translation>
     </message>
@@ -661,7 +661,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Төлөвлөгөө</translation>
     </message>
@@ -669,7 +669,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Хэмжээ</translation>
     </message>
@@ -816,17 +816,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation type="unfinished">Коммандын мөр</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation type="unfinished">Эхлэх цаг</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation type="unfinished">Нэр</translation>
     </message>
@@ -834,7 +834,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Хэвлэгдэх болгох програмыг дарна уу</translation>
     </message>
@@ -842,16 +842,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation type="unfinished">Санах ой</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Оролцоо</translation>
     </message>
@@ -859,85 +859,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation type="unfinished">Процессор</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation type="unfinished">Дискнээс унших</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation type="unfinished">Дискэнд бичих</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation type="unfinished">Санах ой</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation type="unfinished">Swap</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation type="unfinished">Идэвхжээгүй</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation type="unfinished">Татах</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Хүргэх</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation type="unfinished">Сүлжээ</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Хүчинчадал</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Хүргэсэн нийт</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Диск</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Хүргэх</translation>
     </message>
@@ -953,54 +953,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Үнэхээр их</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Их</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Хүндэтгэн</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Хур</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Үнэндээ хур</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Хөрөнгө</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Хүндрэлтэй</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Хүндрэл: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Процессын үнэ цэнгэл өөрчлөхөд алдаа гарлаа</translation>
     </message>
@@ -1026,32 +1026,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Процессыг тохирохдоо алдаа гарлаа</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Процессыг дааныг тохирохдоо алдаа гарлаа</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Процессыг устгахад алдаа гарлаа</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Хүндрэлтэй</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Процессын тэмдэг өгөхөд алдаа гарлаа</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Процессыг дуусгахад алдаа гарлаа</translation>
     </message>
@@ -1067,19 +1067,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation type="unfinished">Хариу ирээгүй</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation type="unfinished">Түр зогсоох</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Хавтгай</translation>
     </message>
@@ -1087,42 +1087,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Хүүхдийн командын байршил</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation type="unfinished">Шинж чанарууд</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation type="unfinished">Процесс зогсоох</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Процессыг дааныг</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Процессыг устгах</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Үнэ цэнгэл өөрчлөх</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Процессыг салгах</translation>
     </message>
@@ -1130,18 +1130,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Хөрөнгө үнэ цэнгэл</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Цуцлах</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Өөрчлөх</translation>
@@ -1253,7 +1253,7 @@ Are you sure you want to continue?</source>
         <translation>Мэдэгдлүүд</translation>
     </message>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Хүснэгтэл байхгүй</translation>
     </message>
@@ -1261,12 +1261,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Үйлчилгээний эхлэлд хэрэглэгчийн төрөл сонгохад амжилтгүй байсан</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Алдаа: Үйлчилгээний эхлэлд хэрэглэгчийн төрөл сонгохад амжилтгүй байсан, үйлдэлд хүрэх үед багаж нь үйлдэлд хүрэхгүй байсан</translation>
     </message>
@@ -1274,19 +1274,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>Хүүхэд</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Цуцлах</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Үйлчилгээний инстанцийн нэр</translation>
     </message>
@@ -1294,41 +1294,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Шинэчилэх</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Эхлүүлэх</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Дуусгах</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Алдартай эхлүүлэх</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Авт</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Хөгжмөн</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Эхлэлд хэрэглэгчийн төрөл</translation>
     </message>
@@ -1379,18 +1379,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Тохиргоо</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Өөрчлөгдөх боломжтой)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Хэрэгжүүлэх хүрээ: %1-%2</translation>
     </message>
@@ -1398,23 +1398,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Үйлчилгээг үргэлжлүүлэх</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Хөрвүүлэх</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Хөрвүүлэхгүй</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Харах</translation>
     </message>
@@ -1422,8 +1422,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation type="unfinished">Хайх</translation>
     </message>
@@ -1431,25 +1431,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Үйлчилгээ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Үйлчилгээ</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Хэрэглэгчид</translation>
     </message>
@@ -1457,7 +1457,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Хэрэглэгчийн мэдээллийг засах</translation>
     </message>
@@ -1465,12 +1465,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Админ</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Бүтээгч</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_mr.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_mr.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>सिस्टम मॉनिटर</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>सिस्टम मॉनिटर एक उपकरण आहे जे विविध प्रक्रियांचा आणि सेवांचा वास्तविक समय आधारावर नियंत्रण करतो, त्यांचे पहारा घेतो आणि ते तुमच्या सिस्टमवर चालत असलेल्या प्रक्रियांचा आणि सेवांचा पहारा घेतो आणि नियंत्रण करतो.</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>विस्तारित माहिती लपवा</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>सर्वात महत्वाची वापर</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>एका व्यक्तीची वापर</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>पठण</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>लिहिणे</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 सेकंद</translation>
     </message>
@@ -56,9 +60,9 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
-        <translation>'%1 दिवस %2 घंट्यां %3 मिनिटे'</translation>
+        <translation>&apos;%1 दिवस %2 घंट्यां %3 मिनिटे&apos;</translation>
     </message>
 </context>
 <context>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>वर्तमान आवृत्ती</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>आवृत्ती</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 सेकंद</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>कोणतेही शोध निकाल मिळाले नाही</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>विस्तारित माहिती</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>विस्तारित माहिती</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>चेतावणी</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>वापरलेले</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>उपलब्ध</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>स्पष्ट</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>कॅश केलेले</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>बफर्स</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>कॅश केलेले स्वॅप</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation type="unfinished">Active</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>अक्रिय</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>अपरिपूर्ण</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>मॅप केलेले</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>कुल स्वॅप</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>मुक्त स्वॅप</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>स्लॅब</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>मॉडेल</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>रीड स्पीड</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>वाइट स्पीड</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>क्षमता</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>सेक्टर्स रीड केले</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>સીધી સીધી / સી</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>સેક્ટર સીધી / સી</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>સીધી મર્જ / સી</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>સેક્ટર લખાયા</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>લખાયા પૂર્ણ થયા</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>લખાયા મર્જ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>લખાયા / સી</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>સેક્ટર લખાયા / સી</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>લખાયા મર્જ / સી</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>સિસ્ટમ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>શૉર્ટકટ દર્શાવો</translation>
     </message>
@@ -598,45 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>આ પ્રોસેસ સમાપ્ત કરવું માય ડેટા નું નુકસાન કારણ બની શકે.
 તમે ખરેખર આગળ વધવા માંગો છો?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>પ્રોસેસ સમાપ્ત કરો</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>બળથી આ પ્રોસેસ સમાપ્ત કરવું માય ડેટા નું નુકસાન કારણ બની શકે.
 તમે ખરેખર આગળ વધવા માંગો છો?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>બળથી આ એપ્લિકેશન સમાપ્ત કરવું માય ડેટા નું નુકસાન કારણ બની શકે.
 તમે ખરેખર આગળ વધવા માંગો છો?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation type="unfinished">Force End</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation type="unfinished">End</translation>
@@ -645,7 +656,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>લૉગઆઉટ</translation>
     </message>
@@ -653,7 +664,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>સેટિંગ્સ</translation>
     </message>
@@ -661,7 +672,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>સાઇઝ</translation>
     </message>
@@ -670,6 +681,7 @@ Are you sure you want to continue?</source>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>ઇપ એડ્રેસ:</translation>
     </message>
@@ -788,11 +800,13 @@ Are you sure you want to continue?</source>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>आईपीवी4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>आईपीवी6</translation>
     </message>
@@ -805,17 +819,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>कमांड लाइन</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>सुरु वेळ</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>नाव</translation>
     </message>
@@ -823,7 +837,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>तुमची थांबविण्यासाठी अनुकूल अॅप्लिकेशन वर क्लिक करा</translation>
     </message>
@@ -831,12 +845,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>मेमरी</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>मिळवा</translation>
     </message>
@@ -844,67 +862,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>सीपीयू</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>डिस्क रीड</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>डिस्क राइट</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>मेमरी</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>स्वॅप</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>अक्रिय</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>डाउनलोड</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>अपलोड</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>नेटवर्क</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>केंद्रित ग्राहक</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>कुल अपात</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>प्रेक्षण</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>डिस्क्स</translation>
     </message>
@@ -920,47 +956,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>मोठी</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>उच्च</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>सामान्य</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>निम्न</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>अत्यंत निम्न</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>कस्टम</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>अवैध</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, त्रुटी: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>प्रोसेस प्राथमिकता बदलणे विफल झाले</translation>
     </message>
@@ -986,32 +1029,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>प्रोसेस सुट्टी करणे विफल झाले</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>प्रोसेस पुन्हा सुरू करणे विफल झाले</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>प्रोसेस बंद करणे विफल झाले</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>अज्ञात त्रुटी</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>प्रोसेस मध्ये संकेत पाठविणे विफल झाले</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>प्रोसेस संपविणे विफल झाले</translation>
     </message>
@@ -1027,17 +1070,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>कोणताही उत्तर</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>सुट्टी करा</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>ट्रे</translation>
     </message>
@@ -1045,37 +1090,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>कमांड लोकेशन पहा</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>गुणधर्म</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>प्रोसेस संपवा</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>प्रोसेस पुन्हा सुरू करा</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>किल प्रोसेस</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>प्राथमिकता बदला</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>प्रोसेस सुस्पेंड करा</translation>
     </message>
@@ -1083,18 +1133,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>कस्टम प्राथमिकता</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation type="unfinished">Change</translation>
@@ -1171,7 +1221,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>नॉट सपॉर्ट</translation>
     </message>
@@ -1214,12 +1264,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>सर्विस स्टार्टअप टाइप सेट करता अ‍ॅकाउंट आले</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>त्रुटी: सर्विस स्टार्टअप टाइप सेट करता अ‍ॅकाउंट आले जेव्हा सब प्रोसेस ब्रेक झाले</translation>
     </message>
@@ -1227,17 +1277,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>सर्विस इंस्टॅन्स नाव</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -1245,37 +1297,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>रिफ्रेश</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>सुरु करा</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Stop</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Restart</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>स्वचालित</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>मॅन्युअल</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>स्टार्टअप प्रकार</translation>
     </message>
@@ -1326,17 +1382,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>सेटिंग्स</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(सुधारलेले)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>श्रेणी: %1-%2</translation>
     </message>
@@ -1344,22 +1401,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>अनुबंध अंत अनुप्रयोग</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>विस्तार</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>संकुचित</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>पहिला</translation>
     </message>
@@ -1367,7 +1425,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>शोध</translation>
     </message>
@@ -1375,17 +1434,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>प्रक्रिया</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>सेवा</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>उपयोगकर्ता</translation>
     </message>
@@ -1393,7 +1460,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>खाता माहिती सुधारा</translation>
     </message>
@@ -1401,12 +1468,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>अडमिनिस्ट्रेटर</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>स्टॅंडर्ड उपयोगकर्ता</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_ms.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_ms.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Pemantau Sistem</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Pemantau Sistem ialah sebuah alat yang memantau beban sistem masa nyata, lihat dan kawal proses-proses dan perkhidmatan-perkhidmatan dalam sistem anda.</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Sembunyi perincian</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Penggunaan keseluruhan</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Penggunaan individu</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Baca</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Tulis</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 saat</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 hari %2 jam %3 minit</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Frekuensi semasa</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Frekuensi</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Batal</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 saat</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Tiada keputusan gelintar</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Perincian</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Perincian</translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Digunakan</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Tersedia</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Dikongsi</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Dicache</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Penimbal</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Silih dicache</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Aktif</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Tidak aktif</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Kotor</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Dipeta</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Jumlah silih</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Silih bebas</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Slab</translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Kelajuan baca</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Kelajuan tulis</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Kapasiti</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Baca sektor</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Baca/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Baca sektor/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Gabung baca/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Sektor ditulis</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Tulis lengkap</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Tulis gabung</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Tulis/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Sektor ditulis/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Gabung tulis/s</translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Sistem</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Papar pintasan</translation>
     </message>
@@ -604,50 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Penamatan proses ini boleh mengakibatkan kehilangan data.
 Anda pasti mahu teruskannya?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Tamatkan proses</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Paksa penamatan proses ini boleh mengakibatkan kehilangan data.
 Anda pasti mahu teruskannya?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Paksa penamatan aplikasi ini boleh mengakibatkan kehilangan data.
 Anda pasti mahu teruskannya?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Paksa Penamatan</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Tamatkan</translation>
@@ -656,7 +656,7 @@ Anda pasti mahu teruskannya?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Log keluar</translation>
     </message>
@@ -664,7 +664,7 @@ Anda pasti mahu teruskannya?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Tetapan</translation>
     </message>
@@ -672,7 +672,7 @@ Anda pasti mahu teruskannya?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Saiz</translation>
     </message>
@@ -820,17 +820,17 @@ RX</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Baris perintah</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Masa mula</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Nama</translation>
     </message>
@@ -838,7 +838,7 @@ RX</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Klik aplikasi yang anda mahu tamatkan</translation>
     </message>
@@ -846,16 +846,16 @@ RX</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Ingatan</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Terima</translation>
     </message>
@@ -863,85 +863,85 @@ RX</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Baca cakera</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Tulis cakera</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Ingatan</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Silih</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Tidak dibenarkan</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Muat turun</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Muat naik</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Rangkaian</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Jumlah Terima</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Jumlah Hantar</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Hantar</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Cakera</translation>
     </message>
@@ -957,54 +957,54 @@ RX</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Sangat tinggi</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Tinggi</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Biasa</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Rendah</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Sangat rendah</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Suai</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Tidak sah</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Ralat: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Gagal mengubah prioriti proses</translation>
     </message>
@@ -1030,32 +1030,32 @@ RX</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Gagal menjeda proses</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Gagal menyambung semula proses</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Gagal membunuh proses</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Ralat tidak diketahui</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Gagal menghantar isyarat ke proses</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Gagal menamatkan proses</translation>
     </message>
@@ -1071,19 +1071,19 @@ RX</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Tiada respons</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Tangguh</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Talam</translation>
     </message>
@@ -1091,42 +1091,42 @@ RX</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Lihat lokasi perintah</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Sifat</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Tamatkan proses</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Sambung semula proses</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Bunuh proses</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Ubah prioriiti</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Tangguh proses</translation>
     </message>
@@ -1134,18 +1134,18 @@ RX</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Suai Prioriti</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Ubah</translation>
@@ -1222,7 +1222,7 @@ RX</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Tiada sokongan</translation>
     </message>
@@ -1265,12 +1265,12 @@ RX</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Gagal menetapkan jenis permulaan perkhidmatan</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Ralat: Gagal menetapkan jenis permulaan perkhidmatan yang disebabkan oleh kerosakan proses sub.</translation>
     </message>
@@ -1278,19 +1278,19 @@ RX</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Nama tika perkhidmatan</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>Batal</translation>
     </message>
@@ -1298,41 +1298,41 @@ RX</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Segar semula</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Mula</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Henti</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Mula semula</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Auto</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Manual</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Jenis permulaan</translation>
     </message>
@@ -1383,18 +1383,18 @@ RX</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Tetapan</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Boleh ubah suai)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Julat: %1-%2</translation>
     </message>
@@ -1402,23 +1402,23 @@ RX</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Paksa penamatan aplikasi</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Kembang</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Padat</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Lihat</translation>
     </message>
@@ -1426,8 +1426,8 @@ RX</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Gelintar</translation>
     </message>
@@ -1435,25 +1435,25 @@ RX</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Proses</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Perkhidmatan</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Pengguna</translation>
     </message>
@@ -1461,7 +1461,7 @@ RX</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Sunting maklumat akaun</translation>
     </message>
@@ -1469,12 +1469,12 @@ RX</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Pentadbir</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Pengguna Biasa</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_my.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_my.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>အခြေအနေကို စောင့က်ပါ</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>စနစ်ကို စောင့်ကြည့်ရန် အကူအညီပေးသည့် အက်ပလီကေးရှင်းတစ်ခုဖြစ်ပြီး စနစ်တွင် လည်ပတ်နေသည့် ပရောဂျက်များနှင့် ဝန်ဆောင်မှုများကို ကြည့်ရှုပြီး ထိန်းချုပ်နိုင်ပါသည်။</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>အချက်အလက်များကို ဖော်ပြမှုကို ဖျောက်ပါ</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>အားလုံးသုံးစွဲမှု</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>တစ်ဦးတစ်ယောက်ချင်းသုံးစွဲမှု</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>ဖတ်ရန်</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>ရေးရန်</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>၆၀ စုံ</translation>
     </message>
@@ -56,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 နေ့ %2 နာရီ %3 မိနစ်</translation>
     </message>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>စွမ်းဆောင်ရည်</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>နှုန်း</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>၆၀ စုံ</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>ရှာရှုရာတွင် ရလဒ်များ မရှိပါ</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>အချက်အလက်များ</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>အသေးစိတ်</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>အကွား</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>အသုံးပြုထားသည်</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>အသုံးပြုနိုင်သည်</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>ဝေမျှထားသည်</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>ကэ့်လ်ထားသည်</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>ဘူပ်လ်များ</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>ကြိုတင်ထားသည့် swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation type="unfinished">Active</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>အလုပ်မလုပ်သည်</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>မှန်းဆမှားသည်</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>ပို့စ်များ</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>အများအားဖြင့် swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>အသုံးမပြုသည့် swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>စာကြောင်း</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>မျိုးဆွေး</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>ဖတ်ရှုနှုန်း</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>ရေးနှုန်း</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>စွမ်းဆောင်ရည်</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>ဖတ်ရှုသည့် sectors</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>อ่าน/วินาที</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>จำนวนเซกเตอร์ที่อ่าน/วินาที</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>อ่านที่รวม/วินาที</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>จำนวนเซกเตอร์ที่เขียน</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>การเขียนเสร็จสิ้น</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>การเขียนที่รวม</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>เขียน/วินาที</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>จำนวนเซกเตอร์ที่เขียน/วินาที</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>เขียนที่รวม/วินาที</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>ระบบ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>แสดงคำสั่งลัด</translation>
     </message>
@@ -598,45 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>การสิ้นสุดกระบวนการนี้อาจทำให้สูญเสียข้อมูล
 dำเนินการต่อไปหรือไม่?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>สิ้นสุดกระบวนการ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>การสิ้นสุดกระบวนการนี้ด้วยการบังคับอาจทำให้สูญเสียข้อมูล
 dำเนินการต่อไปหรือไม่?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>การสิ้นสุดแอปพลิเคชันนี้ด้วยการบังคับอาจทำให้สูญเสียข้อมูล
 dำเนินการต่อไปหรือไม่?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation type="unfinished">Force End</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation type="unfinished">End</translation>
@@ -645,7 +656,7 @@ dำเนินการต่อไปหรือไม่?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>ออกจากระบบ</translation>
     </message>
@@ -653,7 +664,7 @@ dำเนินการต่อไปหรือไม่?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>ตั้งค่า</translation>
     </message>
@@ -661,7 +672,7 @@ dำเนินการต่อไปหรือไม่?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>ขนาด</translation>
     </message>
@@ -670,6 +681,7 @@ dำเนินการต่อไปหรือไม่?</translation>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>ที่อยู่ IP:</translation>
     </message>
@@ -788,11 +800,13 @@ dำเนินการต่อไปหรือไม่?</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>IPv4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>IPv6</translation>
     </message>
@@ -805,17 +819,17 @@ dำเนินการต่อไปหรือไม่?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>บรรทัดคำสั่ง</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>เวลาเริ่มต้น</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>ชื่อ</translation>
     </message>
@@ -823,7 +837,7 @@ dำเนินการต่อไปหรือไม่?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>คลิกแอปที่คุณต้องการปิด</translation>
     </message>
@@ -831,12 +845,16 @@ dำเนินการต่อไปหรือไม่?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>หน่วยความจำ</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>รับ</translation>
     </message>
@@ -844,67 +862,85 @@ dำเนินการต่อไปหรือไม่?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>ซีพียู</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>อ่านดิสก์</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>เขียนดิสก์</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>หน่วยความจำ</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>สเวป</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>ไม่ได้เปิดใช้งาน</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>ดาวน์โหลด</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>อัปโหลด</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>เครือข่าย</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>ทั้งหมดที่รับได้</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>รวมที่ส่ง</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>ส่ง</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>ฮาร์ดดิสก์</translation>
     </message>
@@ -920,47 +956,54 @@ dำเนินการต่อไปหรือไม่?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>สูงมาก</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>สูง</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>ปกติ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>ต่ำ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>ต่ำมาก</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>กำหนดเอง</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>ไม่ถูกต้อง</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, ข้อผิดพลาด: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>ไม่สามารถเปลี่ยนลำดับความสำคัญของกระบวนการได้</translation>
     </message>
@@ -986,32 +1029,32 @@ dำเนินการต่อไปหรือไม่?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>ไม่สามารถหยุดกระบวนการได้</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>ไม่สามารถเริ่มต้นกระบวนการได้</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>ไม่สามารถสังหารกระบวนการได้</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>ข้อผิดพลาดไม่ทราบ</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>ล้มเหลวในการส่งสัญญาณไปยังกระบวนการ</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>ไม่สามารถสิ้นสุดกระบวนการได้</translation>
     </message>
@@ -1027,17 +1070,19 @@ dำเนินการต่อไปหรือไม่?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>ไม่มีการตอบสนอง</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>หยุดชั่วคราว</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>ถาด</translation>
     </message>
@@ -1045,37 +1090,42 @@ dำเนินการต่อไปหรือไม่?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>ดูตำแหน่งคำสั่ง</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>คุณสมบัติ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>สิ้นสุดกระบวนการ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>เริ่มต้นกระบวนการ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>ฆ่ากระบวนการ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>เปลี่ยนความสำคัญ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>ระงับกระบวนการ</translation>
     </message>
@@ -1083,18 +1133,18 @@ dำเนินการต่อไปหรือไม่?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>ความสำคัญแบบกำหนดเอง</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation type="unfinished">Change</translation>
@@ -1171,7 +1221,7 @@ dำเนินการต่อไปหรือไม่?</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>ไม่รองรับ</translation>
     </message>
@@ -1214,12 +1264,12 @@ dำเนินการต่อไปหรือไม่?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>ไม่สามารถตั้งค่าประเภทการเริ่มต้นบริการได้</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>ข้อผิดพลาด: ไม่สามารถตั้งค่าประเภทการเริ่มต้นบริการได้เนื่องจากกระบวนการย่อยล้มเหลว</translation>
     </message>
@@ -1227,17 +1277,19 @@ dำเนินการต่อไปหรือไม่?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>ชื่อตัวอย่างบริการ</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -1245,37 +1297,41 @@ dำเนินการต่อไปหรือไม่?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>อัปเดต</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>เริ่มต้น</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>หยุด</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>เริ่มต้นใหม่</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>อัตโนมัติ</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>ด้วยมือ</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>ประเภทการเริ่มต้น</translation>
     </message>
@@ -1326,17 +1382,18 @@ dำเนินการต่อไปหรือไม่?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>การตั้งค่า</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(สามารถปรับเปลี่ยนได้)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>ช่วง: %1-%2</translation>
     </message>
@@ -1344,22 +1401,23 @@ dำเนินการต่อไปหรือไม่?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>สั่งให้ปิดแอปพลิเคชัน</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>ขยาย</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>กระชับ</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>แสดง</translation>
     </message>
@@ -1367,7 +1425,8 @@ dำเนินการต่อไปหรือไม่?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>ค้นหา</translation>
     </message>
@@ -1375,17 +1434,25 @@ dำเนินการต่อไปหรือไม่?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>กระบวนการ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>บริการ</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>ผู้ใช้</translation>
     </message>
@@ -1393,7 +1460,7 @@ dำเนินการต่อไปหรือไม่?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>แก้ไขข้อมูลบัญชี</translation>
     </message>
@@ -1401,12 +1468,12 @@ dำเนินการต่อไปหรือไม่?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>ผู้ดูแลระบบ</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>ผู้ใช้ทั่วไป</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_nb.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_nb.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>System Monitor</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>System Monitor er et verktøy for å overvåke systembelastning i realtid, se og styre prosesser og tjenester som kjører på systemet ditt.</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Skjul detaljer</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Total bruk</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Individuell bruk</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Les</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Skriv</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 sekunder</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 dager %2 timer %3 minutter</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Aktuell frekvens</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Frekvens</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="100"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Avbryt</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 sekunder</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Ingen søkeresulter</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Detaljer</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Detaljer</translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Brukt</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Tilgjengelig</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Delte</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Kachet</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Buffer</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Kachet swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Aktiv</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Inaktiv</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Sørv</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Kartlagt</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Total swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Ledig swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Slab</translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Modell</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Les hastighet</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Skrivhastighet</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Kapasitet</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Sektorer leste</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Lest/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Sektorer lest/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Lest sammenslått/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Sektorer skrevet</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Skrevet fullført </translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Skrevet sammenslått</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Skrevet/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Sektorer skrevet/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Skrevet sammenslått/s</translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>System</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Vis hurtigtaster</translation>
     </message>
@@ -604,49 +604,49 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Avslutning av denne prosessen kan føre til tap av data.
 Er du sikker på at du vil fortsette?</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Avslutt</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation type="unfinished">Avslutt oppgave</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Avbryt</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Tving avslutning</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Tving avslutning av denne prosessen kan føre til tap av data.
 Er du sikker på at du vil fortsette?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Tving avslutning av denne applikasjonen kan føre til tap av data.
@@ -656,7 +656,7 @@ Er du sikker på at du vil fortsette?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Logg ut</translation>
     </message>
@@ -664,7 +664,7 @@ Er du sikker på at du vil fortsette?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Innstillinger</translation>
     </message>
@@ -672,7 +672,7 @@ Er du sikker på at du vil fortsette?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Størrelse</translation>
     </message>
@@ -819,17 +819,17 @@ Er du sikker på at du vil fortsette?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation type="unfinished">Kommandolinje</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation type="unfinished">Starttidspunkt</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Navn</translation>
     </message>
@@ -837,7 +837,7 @@ Er du sikker på at du vil fortsette?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Klikk på programmet du vil slå av</translation>
     </message>
@@ -845,16 +845,16 @@ Er du sikker på at du vil fortsette?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation type="unfinished">Minne</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Mottatt</translation>
     </message>
@@ -862,85 +862,85 @@ Er du sikker på at du vil fortsette?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation type="unfinished">CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation type="unfinished">Disk les</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation type="unfinished">Disk skriv</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation type="unfinished">Minne</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation type="unfinished">Mellomlager</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation type="unfinished">Ikke aktivert</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation type="unfinished">Nedlasting</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation type="unfinished">Opplasting</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation type="unfinished">Nettverk</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Total mottatt</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Total sendt</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Disker</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Sendt</translation>
     </message>
@@ -956,54 +956,54 @@ Er du sikker på at du vil fortsette?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Veldig høy</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Høy</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Lav</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Veldig lav</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Tilpasset</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Ugyldig</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Feil: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Kunne ikke endre prosessprioritet</translation>
     </message>
@@ -1029,32 +1029,32 @@ Er du sikker på at du vil fortsette?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Kunne ikke pause prosess</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Kunne ikke gjenopprekke prosess</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Kunne ikke slå av prosess</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Ukjent feil</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Feil ved sending av signal til prosess</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Kunne ikke avslutte prosess</translation>
     </message>
@@ -1070,19 +1070,19 @@ Er du sikker på at du vil fortsette?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation type="unfinished">Ingen respons</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation type="unfinished">Stopp midlertidig</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Skål</translation>
     </message>
@@ -1090,42 +1090,42 @@ Er du sikker på at du vil fortsette?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Vis kommandoets plassering</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Egenskaper</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation type="unfinished">Avslutt oppgave</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Gjenopprekke prosess</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Slå av prosess</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Endre prioritet</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Pause prosess</translation>
     </message>
@@ -1133,18 +1133,18 @@ Er du sikker på at du vil fortsette?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Tilpasset prioritet</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Avbryt</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Endre</translation>
@@ -1256,7 +1256,7 @@ Er du sikker på at du vil fortsette?</translation>
         <translation>Varsel</translation>
     </message>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Ikke støttet</translation>
     </message>
@@ -1264,12 +1264,12 @@ Er du sikker på at du vil fortsette?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Kunne ikke sette tjenesteoppstartstype</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Feil: Kunne ikke sette tjenesteoppstartstype på grunn av krasj i underliggende prosess.</translation>
     </message>
@@ -1277,19 +1277,19 @@ Er du sikker på at du vil fortsette?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Avbryt</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Tjenestenavn</translation>
     </message>
@@ -1297,41 +1297,41 @@ Er du sikker på at du vil fortsette?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Oppfrisk</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Stopp</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Gjenstart</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Automatisk</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Manuell</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Oppstartstype</translation>
     </message>
@@ -1382,18 +1382,18 @@ Er du sikker på at du vil fortsette?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Instillinger</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Redigerbar)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Interval: %1-%2</translation>
     </message>
@@ -1401,23 +1401,23 @@ Er du sikker på at du vil fortsette?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Tving slutt på applikasjon</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Utvide</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Komprimert</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Vis</translation>
     </message>
@@ -1425,8 +1425,8 @@ Er du sikker på at du vil fortsette?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Søk</translation>
     </message>
@@ -1434,25 +1434,25 @@ Er du sikker på at du vil fortsette?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Prosesser</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Tjenester</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Brukere</translation>
     </message>
@@ -1460,7 +1460,7 @@ Er du sikker på at du vil fortsette?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Rediger kontoinformasjon</translation>
     </message>
@@ -1468,12 +1468,12 @@ Er du sikker på at du vil fortsette?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Administrator</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Standardbruker</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_ne.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_ne.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>सिस्टम मनिटर</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>सिस्टम मनिटर एक उपकरण हो जु आपको व्यवस्थापन र नियंत्रण गर्न र आपको सिस्टममा सञ्चालन भूक्त प्रक्रियाहरू र सेवाहरू देख्न अनुमति दिन्छ।</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>विवरण छुपाउ</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>सार्वभूक्त प्रयोग</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>व्यक्तिगत प्रयोग</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>पढ्नु</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>लेख्नु</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>६० सेकेण्ड</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 दिन %2 घण्टा %3 मिनेट</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>वर्तमान आवृत्ति</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>आवृत्ति</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="100"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation>रद्द गर्नु</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>६० सेकेण्ड</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>कुनै खोज फलाम</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation> विवरण </translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation> विवरण </translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>उपयोग गरिएको</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>उपलब्ध</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>साझा</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>केच गरिएको</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>बफर्स</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>केच गरिएको स्वैप</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>सक्रिय</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>असक्रिय</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>गर्म</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>म्याप गरिएको</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>कुल स्वैप</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>मुक्त स्वैप</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>स्लेब</translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>मॉडल</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>पढ़ने की गति</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>लेखन गति</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>क्षमता</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>सेक्टर पढ़े</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>पढ़ने/स</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>पढ़े सेक्टर/स</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>मर्ज किए गए पढ़ने/स</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>लिखे गए सेक्टर</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>लेखन पूर्ण</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>मर्ज किए गए लेखन</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>लेखन/स</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>लिखे गए सेक्टर/स</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>मर्ज किए गए लेखन/स</translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>ठीक</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>सिस्टम</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>शॉर्टकट दिखाएं</translation>
     </message>
@@ -604,49 +604,49 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>यह प्रोसेस खत्म करने से डेटा खो जाने की संभावना है।
 आप वास्तव में आगे बढ़ना चाहते हैं कि आप निश्चित हैं?</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>अंत</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>प्रोसेस खत्म करें</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>रद्द करें</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>बलपूर्वक अंत</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>यह प्रोसेस बलपूर्वक खत्म करने से डेटा खो जाने की संभावना है।
 आप वास्तव में आगे बढ़ना चाहते हैं कि आप निश्चित हैं?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>यह एप्लिकेशन बलपूर्वक खत्म करने से डेटा खो जाने की संभावना है।
@@ -656,7 +656,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>लॉगआउट</translation>
     </message>
@@ -664,7 +664,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>सेटिंग्स</translation>
     </message>
@@ -672,7 +672,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>आकार</translation>
     </message>
@@ -819,17 +819,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation type="unfinished">कमांड लाइन</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation type="unfinished">सुरु समय</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>नाम</translation>
     </message>
@@ -837,7 +837,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>तपाईँ अ छोड्न चाहानु भएको एप्लिकेशनलाई क्लिक गर्नुहोस्</translation>
     </message>
@@ -845,16 +845,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation type="unfinished">मेमोरी</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>प्राप्त</translation>
     </message>
@@ -862,85 +862,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation type="unfinished">सि.पी. यु</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation type="unfinished">डिस्क रिड</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation type="unfinished">डिस्क राइट</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation type="unfinished">मेमोरी</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>स्वैप</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>अनलाइस छ</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>डाउनलोड</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>अपलोड</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>नेटवर्क</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>कुल प्राप्त</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>कुल भेजेको</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>डिस्कहरू</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>भेज्नु</translation>
     </message>
@@ -956,54 +956,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>अत्याधिक उच्च</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>उच्च</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>सामान्य</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>कम</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>अत्याधिक कम</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>कस्टम</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>अमान्य</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, त्रुटि: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>प्रक्रिया प्राथमिकता परिवर्तन असफल</translation>
     </message>
@@ -1029,32 +1029,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>प्रक्रिया स्थगित गर्न असफल</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>प्रक्रिया फेरि सुरु गर्न असफल</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>प्रक्रिया मार्न असफल</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>अज्ञात त्रुटि</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>प्रक्रिया मा संकेत पठाउँदा असफल</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>प्रक्रिया समाप्त गर्न असफल</translation>
     </message>
@@ -1070,19 +1070,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>कुनै प्रतिक्रिया</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>स्थगित गर्नु</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>ट्रे</translation>
     </message>
@@ -1090,42 +1090,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>कमाण्ड स्थान देख्नु</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>गुणस्व</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>प्रक्रिया समाप्त गर्नु</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>प्रक्रिया फिर से शुरू करे</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>प्रक्रिया खत्म करे</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>प्राथमिकता बदले</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>प्रक्रिया रोके</translation>
     </message>
@@ -1133,18 +1133,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>अनुकूलित प्राथमिकता</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>रद्द करे</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>बदले</translation>
@@ -1256,7 +1256,7 @@ Are you sure you want to continue?</source>
         <translation>अधिसूचनाएं</translation>
     </message>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>समर्थन नहीं करता</translation>
     </message>
@@ -1264,12 +1264,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>सेवा स्टार्टअप प्रकार सेट करने में असफल</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>त्रुटि: सेवा स्टार्टअप प्रकार सेट करने में असफल कारण उप-प्रक्रिया के डिस्क के कारण</translation>
     </message>
@@ -1277,19 +1277,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>ठीक</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>रद्द करे</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>सेवा उदाहरण नाम</translation>
     </message>
@@ -1297,41 +1297,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>अपडेट करे</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>सुरु गर्नु</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>थप गर्नु</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>पुनः सुरु गर्नु</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>स्वचालित</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>हात बाट</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>सुरु गर्ने प्रकार</translation>
     </message>
@@ -1382,18 +1382,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>सेटिंग्स</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(परिवर्तनीय)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>क्षेत्र: %1-%2</translation>
     </message>
@@ -1401,23 +1401,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>अनुप्रयोग बलपूर्वक समाप्त गर्नु</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>विस्तार गर्नु</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>संकुचित गर्नु</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>देख्नु</translation>
     </message>
@@ -1425,8 +1425,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>खोज्नु</translation>
     </message>
@@ -1434,25 +1434,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>प्रक्रियाहरू</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>सेवाहरू</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>युजरहरू</translation>
     </message>
@@ -1460,7 +1460,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>खाता जानकारी समाप्त गर्नु</translation>
     </message>
@@ -1468,12 +1468,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>अडमिनिस्ट्रेटर</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>स्टान्डर्ड युजर</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_nl.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_nl.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Systeemmonitor</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Systeemmonitor is een hulpprogramma voor het monitoren van systeembelasting en het bekijken en beheren van processen en achtergronddiensten.</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Informatie verbergen</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Algeheel gebruik</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Individueel gebruik</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Uitgelezen</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Weggeschreven</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 seconden</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 dagen, %2 uur, %3 minuten</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Huidige snelheid</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Snelheid</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Annuleren</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 seconden</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Geen zoekresultaat</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Informatie</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Informatie</translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Gebruikt</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Beschikbaar</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Gedeeld</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Gecachet</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Buffers</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Gecachet wisselgeheugen</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Actief</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Inactief</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Dirty</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Toegewezen</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Totaal wisselgeheugen</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Vrij wisselgeheugen</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Model</translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Leessnelheid</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Schrijfsnelheid</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Capaciteit</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Uitgelezen sectoren</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Uitgelezen/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Uitgelezen sectoren/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Uitgelezen+samengevoegd/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Weggeschreven sectoren</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Voltooide wegschrijvingen</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Samengevoegde wegschrijvingen</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Weggeschreven/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Weggeschreven sectoren/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Samengevoegde wegschrijvingen/s</translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Oké</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Systeem</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Sneltoetsen tonen</translation>
     </message>
@@ -604,50 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Het beëindigen van dit proces kan gegevensverlies veroorzaken.
 Weet je zeker dat je wilt doorgaan?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Proces beëindigen</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Het beëindigen van dit proces kan gegevensverlies veroorzaken.
 Weet je zeker dat je wilt doorgaan?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Het beëindigen van dit programma kan gegevensverlies veroorzaken.
 Weet je zeker dat je door wilt gaan?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Geforceerd afsluiten</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Beëindigen</translation>
@@ -656,7 +656,7 @@ Weet je zeker dat je door wilt gaan?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Uitloggen</translation>
     </message>
@@ -664,7 +664,7 @@ Weet je zeker dat je door wilt gaan?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Instellingen</translation>
     </message>
@@ -672,7 +672,7 @@ Weet je zeker dat je door wilt gaan?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Grootte</translation>
     </message>
@@ -819,17 +819,17 @@ Weet je zeker dat je door wilt gaan?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Opdrachtregel</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Starttijd</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
@@ -837,7 +837,7 @@ Weet je zeker dat je door wilt gaan?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Klik op het programma dat je wilt beëindigen</translation>
     </message>
@@ -845,16 +845,16 @@ Weet je zeker dat je door wilt gaan?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Geheugen</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Ontvangen</translation>
     </message>
@@ -862,85 +862,85 @@ Weet je zeker dat je door wilt gaan?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>Processor</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Schijfuitlezing</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Schijfwegschrijving</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Geheugen</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Wisselgeheugen</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Niet ingeschakeld</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Downloaden</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Uploaden</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Netwerk</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Totaal ontvangen</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Totaal verstuurd</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Verstuurd</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Schijven</translation>
     </message>
@@ -956,54 +956,54 @@ Weet je zeker dat je door wilt gaan?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Erg hoog</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Hoog</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normaal</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Laag</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Erg laag</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Aangepast</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Ongeldig</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Foutmelding: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Het aanpassen van de procesprioriteit is mislukt</translation>
     </message>
@@ -1029,32 +1029,32 @@ Weet je zeker dat je door wilt gaan?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Het proces kan niet worden onderbroken</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Het proces kan niet worden hervat</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Het proces kan niet worden vernietigd</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Onbekende fout</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Er kan geen signaal worden verstuurd naar het proces</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Het proces kan niet worden beëindigd</translation>
     </message>
@@ -1070,19 +1070,19 @@ Weet je zeker dat je door wilt gaan?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Geen antwoord</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Onderbreken</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Systeemvak</translation>
     </message>
@@ -1090,42 +1090,42 @@ Weet je zeker dat je door wilt gaan?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Opdrachtlocatie tonen</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Eigenschappen</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Proces beëindigen</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Proces hervatten</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Geforceerd beëindigen</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Prioriteit aanpassen</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Proces onderbreken</translation>
     </message>
@@ -1133,18 +1133,18 @@ Weet je zeker dat je door wilt gaan?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Aangepaste prioriteit</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Aanpassen</translation>
@@ -1221,7 +1221,7 @@ Weet je zeker dat je door wilt gaan?</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Niet ondersteund</translation>
     </message>
@@ -1264,12 +1264,12 @@ Weet je zeker dat je door wilt gaan?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Kan het soort opstart niet instellen</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Foutmelding: kan het soort opstart niet instellen wegens een gecrasht onderliggend proces.</translation>
     </message>
@@ -1277,19 +1277,19 @@ Weet je zeker dat je door wilt gaan?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Naam van dienstproces</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>Oké</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
@@ -1297,41 +1297,41 @@ Weet je zeker dat je door wilt gaan?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Verversen</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Starten</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Stoppen</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Herstarten</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Automatisch</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Handmatig</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Soort opstart</translation>
     </message>
@@ -1382,18 +1382,18 @@ Weet je zeker dat je door wilt gaan?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Instellingen</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(aanpasbaar)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Tussen de %1-%2</translation>
     </message>
@@ -1401,23 +1401,23 @@ Weet je zeker dat je door wilt gaan?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Programma geforceerd beëindigen</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Uitklappen</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Compact</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Weergave</translation>
     </message>
@@ -1425,8 +1425,8 @@ Weet je zeker dat je door wilt gaan?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Zoeken</translation>
     </message>
@@ -1434,25 +1434,25 @@ Weet je zeker dat je door wilt gaan?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Processen</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Diensten</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Gebruikers</translation>
     </message>
@@ -1460,7 +1460,7 @@ Weet je zeker dat je door wilt gaan?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Accountinformatie bewerken</translation>
     </message>
@@ -1468,12 +1468,12 @@ Weet je zeker dat je door wilt gaan?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Beheerder</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Standaardgebruiker</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_pa.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_pa.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>سیسٹم مانیٹر</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>سیسٹم مانیٹر ایک ادا دار ہے جو سیسٹم کی ہار ہار چارج، پروسسز اور سروسز کا نگرانی کرے، اور آپ کے سیسٹم پر چل رہے پروسسز اور سروسز کو دیکھنے اور کنٹرول کرنے کے لیے استعمال کیا جاتا ہے۔</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>تفصیلات چھپا دو</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>کل استعمال</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>افرادی استعمال</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>پڑھنے</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>لکھنے</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 سیکنڈ</translation>
     </message>
@@ -56,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 دن %2 گھنٹے %3 منٹ</translation>
     </message>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>ہار ہار فریکوئنسی</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>فریکوئنسی</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="100"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">ਰੱਦ ਕਰੋ</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 سیکنڈ</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>کوئی تلاش نتائج نہیں ملا</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>تفصیلات</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>تفصیلات</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>تحذیر</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>آواز</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>دستیاب</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>شیئر</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>کیش</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>بفرس</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>کیش چینج</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>اکتیو</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>اکتیو نہیں</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>ڈرائی</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>میپ</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>کل چینج</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>فري چینج</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>سلاب</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>میڈل</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>ریڈ سپیڈ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>تیزیت نوشت</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>ساختار</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>سیکتور ریڈ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>ریڈز / ثانیہ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>سیکتور ریڈز / ثانیہ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>ریڈز مرجد / ثانیہ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>سیکتور نوشت</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>نوشت کمپلیٹ </translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>نوشت مرجد</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>نوشتز / ثانیہ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>سیکتور نوشتز / ثانیہ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>نوشت مرجد / ثانیہ</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>سیسٹم</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>کلچر نمایش کریں</translation>
     </message>
@@ -598,44 +604,49 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>این پروسس ختم کرݨ ڈیٹا گم کرݨ کی وجہ سے ہو سکدی ہے۔
 آپ کیا کرݨ چاہیے کہ ایہ جاری رکھیے؟</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>ختم کرݨ</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>پروسس ختم کرݨ</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">ਰੱਦ ਕਰੋ</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>فورس ختم کرݨ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>این پروسس فورس ختم کرݨ ڈیٹا گم کرݨ کی وجہ سے ہو سکدی ہے۔
 آپ کیا کرݨ چاہیے کہ ایہ جاری رکھیے؟</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>این ایپلیکیشن فورس ختم کرݨ ڈیٹا گم کرݨ کی وجہ سے ہو سکدی ہے۔
@@ -645,7 +656,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>لوج آؤٹ</translation>
     </message>
@@ -653,7 +664,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>سیٹنگز</translation>
     </message>
@@ -661,7 +672,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>سائز</translation>
     </message>
@@ -670,6 +681,7 @@ Are you sure you want to continue?</source>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>ای پی ایڈریس:</translation>
     </message>
@@ -698,11 +710,13 @@ Are you sure you want to continue?</source>
     <name>NetInfoModel</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>ای پی وی ایچ 4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>ای پی وی 6</translation>
     </message>
@@ -805,17 +819,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation type="unfinished">ਕਮਾਂਡ ਲਾਈਨ</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation type="unfinished">ਸ਼ੁਰੂ ਸਮਾਂ</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation type="unfinished">ਨਾਂ</translation>
     </message>
@@ -823,7 +837,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>کلیک کنید که برنامه مورد نظر را تمام کنید</translation>
     </message>
@@ -831,12 +845,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation type="unfinished">ਮੈਮੋਰੀ</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>دریافت</translation>
     </message>
@@ -844,67 +862,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation type="unfinished">CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>خواندن دیسک</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>نوشتن دیسک</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation type="unfinished">ਮੈਮੋਰੀ</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>سوپ</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation type="unfinished">ਸਮਰੱਥ ਨਹੀਂ</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation type="unfinished">ਡਾਊਨਲੋਡ</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>آپلواد</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation type="unfinished">ਨੈੱਟਵਰਕ</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>کل دریافت شده</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>کل ارسال شده</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>دیسک ها</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>ارسال</translation>
     </message>
@@ -920,47 +956,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>ਬਹੁਤ ਉੱਚ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>ਉੱਚ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>ਆਮ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>ਨੀਂਧ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>ਬਹੁਤ ਨੀਂਧ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>ਪ੍ਰਸ਼ੰਸ਼</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>ਅਮਲੀ</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, ਤਿਰੋਗਾਹ: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>ਪ੍ਰੋਸੈਸ ਪ੍ਰਾਇੰਸੀ ਬਦਲਣ ਵਿੱਚ ਅਸਫਲ</translation>
     </message>
@@ -986,32 +1029,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>ਪ੍ਰੋਸੈਸ ਨੂੰ ਰੋਕਣ ਵਿੱਚ ਅਸਫਲ</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>ਪ੍ਰੋਸੈਸ ਨੂੰ ਚਾਲੂ ਕਰਨ ਵਿੱਚ ਅਸਫਲ</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>ਪ੍ਰੋਸੈਸ ਨੂੰ ਮਾਰਨ ਵਿੱਚ ਅਸਫਲ</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>ਅਪਰਿਚਿਤ ਤਿਰੋਗਾਹ</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>ਪ੍ਰੋਸੈਸ ਵੱਲ ਸੈਗਲ ਭੇਜਣ ਵਿੱਚ ਅਸਫਲ</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>ਪ੍ਰੋਸੈਸ ਖਤਮ ਕਰਨ ਵਿੱਚ ਅਸਫਲ</translation>
     </message>
@@ -1027,17 +1070,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>ਕੋਈ ਜਵਾਬ ਨਹੀਂ</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>ਸੁਪੰਡ</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>ਟਰੇ</translation>
     </message>
@@ -1045,37 +1090,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>ਕਮੈਂਡ ਸਥਾਨ ਦੇਖੋ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>ਸੰਪਤੀਆਂ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>ਪ੍ਰੋਸੈਸ ਖਤਮ ਕਰੋ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>ਪ੍ਰੋਸੈਸ ਚਾਲੂ ਕਰੋ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>ਪ੍ਰੋਸੈਸ ਮਾਰੋ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>ਪ੍ਰਾਇੰਸੀ ਬਦਲੋ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>ਪ੍ਰੋਸੈਸ ਸੁਪੰਡ ਕਰੋ</translation>
     </message>
@@ -1083,18 +1133,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>ਪ੍ਰਸ਼ੰਸ਼ ਪ੍ਰਾਇੰਸੀ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">ਰੱਦ ਕਰੋ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>ਬਦਲੋ</translation>
@@ -1206,7 +1256,7 @@ Are you sure you want to continue?</source>
         <translation>Notifications</translation>
     </message>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Not support</translation>
     </message>
@@ -1214,12 +1264,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Failed to set service startup type</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Error: Failed to set service startup type due to the crashed sub process.</translation>
     </message>
@@ -1227,17 +1277,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">ਰੱਦ ਕਰੋ</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Service instance name</translation>
     </message>
@@ -1245,37 +1297,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Refresh</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Stop</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Restart</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Auto</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Manual</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Startup type</translation>
     </message>
@@ -1326,17 +1382,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>ਸੈੱਟਿੰਗਜ਼</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(ਸੋਧਿਆ ਜਾ ਸਕਦਾ ਹੈ)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>ਰੇਂਜ: %1-%2</translation>
     </message>
@@ -1344,22 +1401,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>ਐਪਲੀਕੇਸ਼ਨ ਖ਼ਤਮ ਕਰੋ</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>ਵਿਸਥਾਰ</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>ਛੋਟਾ ਕਰੋ</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>ਦੇਖੋ</translation>
     </message>
@@ -1367,7 +1425,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation type="unfinished">ਖੋਜੋ</translation>
     </message>
@@ -1375,17 +1434,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>ਪ੍ਰੋਸੈਸਜ਼</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>ਸਰਵਿਸਜ਼</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>ਯੂਜ਼ਰਜ਼</translation>
     </message>
@@ -1393,7 +1460,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>ਐਕਾਊਂਟ ਜਾਣਕਾਰੀ ਸੋਧੋ</translation>
     </message>
@@ -1401,12 +1468,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>ਐਡਮਿਨ</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>ਸਟੈਂਡਰਡ ਯੂਜ਼ਰ</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_pl.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_pl.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Monitor systemu</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>System Monitor to narzędzie do monitorowania obciążenia systemu w czasie rzeczywistym, przeglądania i kontrolowania procesów i usług działających w systemie.</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Ukryj szczegóły</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Generalne użycie</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Pojedyncze użycie</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Odczyt</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Zapis</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 sekund</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 dni %2 godzin %3 minut</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Aktualna częstotliwość</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Częstotliwość</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Anuluj</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 sekund</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Brak wyników wyszukiwania</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Szczegóły</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Szczegóły</translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>W użyciu</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Dostępne</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Współdzielone</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>W pamięci podręcznej</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Buforów</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Pamięć swap w cache</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Aktywne</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Nieaktywne</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Brudne</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Mapowane</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Cały swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Wolny swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Slab</translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Prędkość odczytu</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Prędkość zapisu</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Pojemność</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Sektorów odczytanych</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Odczytów/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Sektorów odczytanych/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Odczytów scalonych/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Sektorów zapisanych</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Zapisów ukończonych</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Zapisów scalonych</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Zapisów/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Sektorów zapisanych/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Zapisów scalonych/s</translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>System</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Wyświetl skróty</translation>
     </message>
@@ -604,50 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Zakończenie tego procesu może spowodować utratę danych.
 Czy na pewno chcesz kontynuować?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Zakończ proces</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Wymuszenie zakończenia tego procesu może spowodować utratę danych.
 Czy na pewno chcesz kontynuować?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Wymuszenie zakończenia tej aplikacji może spowodować utratę danych.
 Czy na pewno chcesz kontynuować?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Wymuś zakończenie</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Zakończ</translation>
@@ -656,7 +656,7 @@ Czy na pewno chcesz kontynuować?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Wyloguj</translation>
     </message>
@@ -664,7 +664,7 @@ Czy na pewno chcesz kontynuować?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Ustawienia</translation>
     </message>
@@ -672,7 +672,7 @@ Czy na pewno chcesz kontynuować?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Rozmiar</translation>
     </message>
@@ -819,17 +819,17 @@ Czy na pewno chcesz kontynuować?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Wiersz poleceń</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Data rozpoczęcia</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Nazwa</translation>
     </message>
@@ -837,7 +837,7 @@ Czy na pewno chcesz kontynuować?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Kliknij aplikację, którą chcesz zabić</translation>
     </message>
@@ -845,16 +845,16 @@ Czy na pewno chcesz kontynuować?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Pamięć</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Pobieranie</translation>
     </message>
@@ -862,85 +862,85 @@ Czy na pewno chcesz kontynuować?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>Procesor</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Prędkość odczytu dysku</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Prędkość zapisu dysku</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Pamięć</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Swap</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Nie włączone</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Pobieranie</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Wysyłanie</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Sieć</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Łącznie otrzymano</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Łącznie wysłano</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Wysyłanie</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Dyski</translation>
     </message>
@@ -956,54 +956,54 @@ Czy na pewno chcesz kontynuować?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Bardzo wysoki</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Wysoki</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normalny</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Niski</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Bardzo niski</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Niestandardowy</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Nieprawidłowy</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Błąd: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Nie udało się zmienić priorytetu procesu</translation>
     </message>
@@ -1029,32 +1029,32 @@ Czy na pewno chcesz kontynuować?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Nie udało się wstrzymać procesu</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Nie udało się wznowić procesu</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Nie udało się zabić procesu</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Nieznany błąd</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Nie udało się wysłać sygnału do przetworzenia</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Nie udało się zakończyć procesu</translation>
     </message>
@@ -1070,19 +1070,19 @@ Czy na pewno chcesz kontynuować?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Brak odpowiedzi</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Wstrzymany</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Zasobnik systemowy</translation>
     </message>
@@ -1090,42 +1090,42 @@ Czy na pewno chcesz kontynuować?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Zobacz lokalizację polecenia</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Właściwości</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Zakończ proces</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Wznów</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Zabij</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Zmień priorytet</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Wstrzymaj</translation>
     </message>
@@ -1133,18 +1133,18 @@ Czy na pewno chcesz kontynuować?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Priorytet niestandardowy</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Zmień</translation>
@@ -1221,7 +1221,7 @@ Czy na pewno chcesz kontynuować?</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Brak wsparcia</translation>
     </message>
@@ -1264,12 +1264,12 @@ Czy na pewno chcesz kontynuować?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Nie udało się ustawić typu uruchomienia usługi</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Błąd: Nie można ustawić typu uruchomienia usługi z powodu awarii pod-procesu.</translation>
     </message>
@@ -1277,19 +1277,19 @@ Czy na pewno chcesz kontynuować?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Nazwa instancji usługi</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>
@@ -1297,41 +1297,41 @@ Czy na pewno chcesz kontynuować?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Odśwież</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Uruchom</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Zatrzymaj</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Restartuj</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Automatycznie</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Ręcznie</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Typ uruchomienia</translation>
     </message>
@@ -1382,18 +1382,18 @@ Czy na pewno chcesz kontynuować?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Ustawienia</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Modyfikowalny)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Zakres: %1-%2</translation>
     </message>
@@ -1401,23 +1401,23 @@ Czy na pewno chcesz kontynuować?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Wymuś zakończenie aplikacji</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Rozszerzony</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Kompaktowy</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Widok</translation>
     </message>
@@ -1425,8 +1425,8 @@ Czy na pewno chcesz kontynuować?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Szukaj</translation>
     </message>
@@ -1434,25 +1434,25 @@ Czy na pewno chcesz kontynuować?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Procesy</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Usługi</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Użytkownicy</translation>
     </message>
@@ -1460,7 +1460,7 @@ Czy na pewno chcesz kontynuować?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Edytuj informacje konta</translation>
     </message>
@@ -1468,12 +1468,12 @@ Czy na pewno chcesz kontynuować?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Administrator</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Standardowy użytkownik</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_pt.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_pt.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Monitor do Sistema</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>O Monitor do Sistema é uma ferramenta para monitorizar a carga do sistema em tempo real, visualizar e controlar os processos e serviços em execução no seu sistema.</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Ocultar detalhes</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Utilização geral</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Utilização individual</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Leitura</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Gravação</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 segundos</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 dias %2 horas %3 minutos</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Frequência atual</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Frequência</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 segundos</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Pesquisa sem resultados</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Detalhes</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Detalhes</translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Utilizado</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Disponível</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Partilhado</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Em cache</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Buffers</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Swap em cache</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Ativo</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Inativo</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Corrupto</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Mapeado</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Swap total</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Swap livre</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Slab</translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Velocidade de leitura</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Velocidade de gravação</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Capacidade</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Leitura de sectores</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Leituras/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Leitura/s de sectores</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Leituras unidas/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Sectores gravados</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Gravações concluídas</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Gravações unidas</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Gravações/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Sectores gravados/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Gravações unidas/s</translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceitar</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Mostrar atalhos</translation>
     </message>
@@ -604,50 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>O fim deste processo pode causar perda de dados.
 Tem a certeza de que deseja continuar?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Terminar processo</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>O término forçado deste processo pode causar perda de dados.
 Tem a certeza de que deseja continuar?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Forçar o término desta aplicação pode causar perda de dados.
 Tem a certeza de que deseja continuar?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Forçar o terminar</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Terminar</translation>
@@ -656,7 +656,7 @@ Tem a certeza de que deseja continuar?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Sair</translation>
     </message>
@@ -664,7 +664,7 @@ Tem a certeza de que deseja continuar?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Definições</translation>
     </message>
@@ -672,7 +672,7 @@ Tem a certeza de que deseja continuar?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Tamanho</translation>
     </message>
@@ -819,17 +819,17 @@ Tem a certeza de que deseja continuar?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Linha de comando</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Hora de início</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
@@ -837,7 +837,7 @@ Tem a certeza de que deseja continuar?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Clicar na aplicação que deseja terminar</translation>
     </message>
@@ -845,16 +845,16 @@ Tem a certeza de que deseja continuar?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>RAM</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Receber</translation>
     </message>
@@ -862,85 +862,85 @@ Tem a certeza de que deseja continuar?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Leitura do disco</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Gravação do disco</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>RAM</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Swap</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Não ativado</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Transferir</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Enviar</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Rede</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Total transferido</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Total enviado</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Enviar</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Discos</translation>
     </message>
@@ -956,54 +956,54 @@ Tem a certeza de que deseja continuar?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Muito alto</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Alto</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Baixo</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Muito baixo</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Personalizado</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Inválido</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Erro: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Falha ao alterar a prioridade do processo</translation>
     </message>
@@ -1029,32 +1029,32 @@ Tem a certeza de que deseja continuar?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Falha ao colocar processo em pausa</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Falha ao retomar processo</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Falha ao matar processo</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Erro desconhecido</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Falha ao enviar sinal para processar</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Falha ao terminar processo</translation>
     </message>
@@ -1070,19 +1070,19 @@ Tem a certeza de que deseja continuar?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Sem resposta</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Suspender</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Área de notificação</translation>
     </message>
@@ -1090,42 +1090,42 @@ Tem a certeza de que deseja continuar?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Ver localização do comando</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Propriedades</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Terminar processo</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Retomar processo</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Matar processo</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Mudar prioridade</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Suspender processo</translation>
     </message>
@@ -1133,18 +1133,18 @@ Tem a certeza de que deseja continuar?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Prioridade personalizada</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Mudar</translation>
@@ -1221,7 +1221,7 @@ Tem a certeza de que deseja continuar?</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Não suportado</translation>
     </message>
@@ -1264,12 +1264,12 @@ Tem a certeza de que deseja continuar?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Falha em definir o tipo de arranque do serviço</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Erro: Falha em definir o tipo de arranque do serviço devido ao sub-processo falhado.</translation>
     </message>
@@ -1277,19 +1277,19 @@ Tem a certeza de que deseja continuar?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Nome da instância do serviço</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>Aceitar</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -1297,41 +1297,41 @@ Tem a certeza de que deseja continuar?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Atualizar</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Iniciar</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Parar</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Reiniciar</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Auto</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Manual</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Tipo de arranque</translation>
     </message>
@@ -1382,18 +1382,18 @@ Tem a certeza de que deseja continuar?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Definições</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Modificável)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Intervalo: %1-%2</translation>
     </message>
@@ -1401,23 +1401,23 @@ Tem a certeza de que deseja continuar?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Forçar o término da aplicação</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Expandir</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Compacto</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Ver</translation>
     </message>
@@ -1425,8 +1425,8 @@ Tem a certeza de que deseja continuar?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Pesquisar</translation>
     </message>
@@ -1434,25 +1434,25 @@ Tem a certeza de que deseja continuar?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Processos</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Serviços</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Utilizadores</translation>
     </message>
@@ -1460,7 +1460,7 @@ Tem a certeza de que deseja continuar?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Editar informações da conta</translation>
     </message>
@@ -1468,12 +1468,12 @@ Tem a certeza de que deseja continuar?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Administrador</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Usuário Padrão</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_pt_BR.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_pt_BR.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Monitor de Sistema</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>O Monitor de Sistema é uma ferramenta para monitorar a carga do sistema em tempo real, exibir e controlar processos e serviços em execução no sistema.</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Ocultar detalhes</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Utilização geral</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Utilização individual</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Ler</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Gravar</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 segundos</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 dias %2 horas %3 minutos</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Frequência atual</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Frequência</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 segundos</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Nenhum resultado encontrado</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Detalhes</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Detalhes</translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Utilizado</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Disponível</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Compartilhada</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Em cache</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Buffers</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>SWAP em cache</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Ativo</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Inativo</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Sujo</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Mapeado</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>SWAP total</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>SWAP livre</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Placa</translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Velocidade de leitura</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Velocidade de gravação</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Capacidade</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Setores lidos</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Leituras / s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Setores lidos / s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Leituras mescladas / s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Setores gravados</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Gravações concluídas</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Gravações mescladas</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Gravações / s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Setores gravados / s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Gravações mescladas / s</translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Ok</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Exibir atalhos</translation>
     </message>
@@ -604,50 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Encerrar este processo poderá causar a perda de dados.
 Continuar?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Encerrar processo</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Forçar o encerramento deste processo, poderá causar a perda de dados.
 Continuar?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Forçar o encerramento deste aplicativo, poderá causar a perda de dados.
 Continuar?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Forçar encerrar</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Encerrar</translation>
@@ -656,7 +656,7 @@ Continuar?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation type="unfinished"></translation>
     </message>
@@ -664,7 +664,7 @@ Continuar?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Configurações</translation>
     </message>
@@ -672,7 +672,7 @@ Continuar?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Tamanho</translation>
     </message>
@@ -819,17 +819,17 @@ Continuar?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Linha de comando</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Hora de início</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
@@ -837,7 +837,7 @@ Continuar?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Clique no aplicativo que deseja encerrar</translation>
     </message>
@@ -845,16 +845,16 @@ Continuar?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Memória</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Receber</translation>
     </message>
@@ -862,85 +862,85 @@ Continuar?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Leitura de disco</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Escrita de disco</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Memória</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>SWAP</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Inativa</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Download</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Upload</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Rede</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Total Baixado</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Total Enviado</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Enviar</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Discos</translation>
     </message>
@@ -956,54 +956,54 @@ Continuar?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Muito alta</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Alta</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Baixa</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Muito baixa</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Personalizada</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Inválido</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Erro: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Falha ao alterar a prioridade do processo</translation>
     </message>
@@ -1029,32 +1029,32 @@ Continuar?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Falha ao pausar o processo</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Falha ao retomar o processo</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Falha ao interromper o processo</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Erro desconhecido</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Falha no envio do sinal para o processo</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Falha ao finalizar o processo</translation>
     </message>
@@ -1070,19 +1070,19 @@ Continuar?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Sem resposta</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Suspender</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Bandeja</translation>
     </message>
@@ -1090,42 +1090,42 @@ Continuar?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Visualizar o local do comando</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Propriedades</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Encerrar processo</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Retomar processo</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Interromper processo</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Alterar prioridade</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Suspender processo</translation>
     </message>
@@ -1133,18 +1133,18 @@ Continuar?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Prioridade Personalizada</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Alterar</translation>
@@ -1221,7 +1221,7 @@ Continuar?</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Sem suporte</translation>
     </message>
@@ -1264,12 +1264,12 @@ Continuar?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Falha ao definir o tipo de inicialização do serviço</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Erro: falha ao definir o tipo de inicialização do serviço devido ao subprocesso com falha.</translation>
     </message>
@@ -1277,19 +1277,19 @@ Continuar?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Nome de instância do serviço</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>Ok</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -1297,41 +1297,41 @@ Continuar?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Atualizar</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Iniciar</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Parado</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Reiniciar</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Automático</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Manual</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Tipo de inicialização</translation>
     </message>
@@ -1382,18 +1382,18 @@ Continuar?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Configurações</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Modificável)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Intervalo: %1-%2</translation>
     </message>
@@ -1401,23 +1401,23 @@ Continuar?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Forçar encerramento de aplicativo</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Expandida</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Compacta</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Visualização</translation>
     </message>
@@ -1425,8 +1425,8 @@ Continuar?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Pesquisar</translation>
     </message>
@@ -1434,25 +1434,25 @@ Continuar?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Processos</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Serviços</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Usuários</translation>
     </message>
@@ -1460,7 +1460,7 @@ Continuar?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Editar informações da conta</translation>
     </message>
@@ -1468,12 +1468,12 @@ Continuar?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Administrador</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Usuário padrão</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_ro.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_ro.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Monitorul Sistemului</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Monitorul Sistemului este un instrument pentru monitorizarea încărcării sistemului în timp real, afișarea și controlul proceselor și serviciilor care rulează pe sistemul tău.</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Ascunde detaliile</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Utilizarea generală</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Utilizarea individuală</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Citește</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Scrie</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 de secunde</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>&apos;%1 zile %2 ore %3 minute&apos;</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Frecvența curentă</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Frecvență</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="100"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Anulare</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 de secunde</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Niciun rezultat de căutare</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Detalii</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Detalii</translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Utilizat</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Disponibil</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Împărțit</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Cached</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Buffer</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Swap cached</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Activ</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Inactiv</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Măcelărit</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Mapat</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Swap total</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Swap liber</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Slab</translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Viteza de citire</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Viteza de scriere</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Capacitate</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Secțiuni citite</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Citiri/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Secțiuni citite/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Citiri fuzionate/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Secțiuni scrise</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Scrisori completate </translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Scrisori fuzionate</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Scrisori/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Secțiuni scrise/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Scrisori fuzionate/s</translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Sistem</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Afisează scurtături</translation>
     </message>
@@ -604,49 +604,49 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Încheierea acestui proces poate cauza pierderi de date.
 Sigur dorești să continui?</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Încheiere</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation type="unfinished">Închidere proces</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Anulare</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Forțare încheiere</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Forțarea încheierii acestui proces poate cauza pierderi de date.
 Sigur dorești să continui?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Forțarea încheierii acestui program poate cauza pierderi de date.
@@ -656,7 +656,7 @@ Sigur dorești să continui?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Deconectare</translation>
     </message>
@@ -664,7 +664,7 @@ Sigur dorești să continui?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Setări</translation>
     </message>
@@ -672,7 +672,7 @@ Sigur dorești să continui?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Dimensiune</translation>
     </message>
@@ -819,17 +819,17 @@ Sigur dorești să continui?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation type="unfinished">Comandă</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation type="unfinished">Timpul de start</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation type="unfinished">Nume</translation>
     </message>
@@ -837,7 +837,7 @@ Sigur dorești să continui?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation type="unfinished">Faceți click pe aplicația care doriți să o închideți</translation>
     </message>
@@ -845,16 +845,16 @@ Sigur dorești să continui?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation type="unfinished">Memorie</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Recepție</translation>
     </message>
@@ -862,85 +862,85 @@ Sigur dorești să continui?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation type="unfinished">CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation type="unfinished">Citire de pe disk</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation type="unfinished">Scriere pe disk</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation type="unfinished">Memorie</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation type="unfinished">Swap</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation type="unfinished">Inactiv</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation type="unfinished">Descărcare</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation type="unfinished">Încărcare</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation type="unfinished">Rețea</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Total primit</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Total trimis</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Discuri</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Trimitere</translation>
     </message>
@@ -956,54 +956,54 @@ Sigur dorești să continui?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Foarte ridicată</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Ridicată</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normală</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Scăzută</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Foarte scăzută</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Personalizat</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Invalide</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Eroare: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Eșecul modificării priorității procesului</translation>
     </message>
@@ -1029,32 +1029,32 @@ Sigur dorești să continui?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Eșecul pauzării procesului</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Eșecul reanumării procesului</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Eșecul terminării procesului</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Eroare necunoscută</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Eșecul trimiterea semnalului către proces</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Eșecul încheierea procesului</translation>
     </message>
@@ -1070,19 +1070,19 @@ Sigur dorești să continui?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation type="unfinished">Nici un răspuns</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation type="unfinished">Suspendare</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Tray</translation>
     </message>
@@ -1090,42 +1090,42 @@ Sigur dorești să continui?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Vizualizează locul comenzii</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation type="unfinished">Proprietăți</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation type="unfinished">Închidere proces</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Reanume procesul</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Termine procesul</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Modifică prioritatea</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Pauzează procesul</translation>
     </message>
@@ -1133,18 +1133,18 @@ Sigur dorești să continui?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Prioritate personalizată</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Anulare</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Modifică</translation>
@@ -1256,7 +1256,7 @@ Sigur dorești să continui?</translation>
         <translation>Notificări</translation>
     </message>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Nu este susținut</translation>
     </message>
@@ -1264,12 +1264,12 @@ Sigur dorești să continui?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Eșec în setarea tipului de pornire al serviciului</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Eroare: Eșec în setarea tipului de pornire al serviciului din cauza procesului secundar crash</translation>
     </message>
@@ -1277,19 +1277,19 @@ Sigur dorești să continui?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Anulare</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Numele instanței de serviciu</translation>
     </message>
@@ -1297,41 +1297,41 @@ Sigur dorești să continui?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Rescrie</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Porneste</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Oprește</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Redemare</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Automat</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Manual</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Tipul de pornire</translation>
     </message>
@@ -1382,18 +1382,18 @@ Sigur dorești să continui?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Setări</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Modificabil)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Interval: %1-%2</translation>
     </message>
@@ -1401,23 +1401,23 @@ Sigur dorești să continui?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Forțează încheierea aplicației</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Extinde</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Compactează</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Vizualizare</translation>
     </message>
@@ -1425,8 +1425,8 @@ Sigur dorești să continui?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation type="unfinished">Căutare</translation>
     </message>
@@ -1434,25 +1434,25 @@ Sigur dorești să continui?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Procese</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Servicii</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Utilizatori</translation>
     </message>
@@ -1460,7 +1460,7 @@ Sigur dorești să continui?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Editează informații cont</translation>
     </message>
@@ -1468,12 +1468,12 @@ Sigur dorești să continui?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Administrator</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Utilizator Standard</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_ru.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_ru.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Системный Монитор</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Системный монитор - это инструмент для мониторинга загрузки системы в реальном времени, а также просмотра и управления запущенными процессами и службами.</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Скрыть подробности</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Общее потребление</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Индивидуальное потребление</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Чтение</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Запись</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 секунд</translation>
     </message>
@@ -56,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 дней %2 часов %3 минут</translation>
     </message>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Текущая частота</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Частота</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Отмена</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 секунд</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Поиск не дал результатов</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Подробности</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Подробности</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>Внимание</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Использовано</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Доступно</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Общий</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Кэш</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Буферы</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Кэшированный своп</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Активный</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Неактивно</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Грязный</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Отображено</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Итого своп</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Бесплатный обмен</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Плита</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Модель</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Скорость чтения</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Скорость записи</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Ёмкость</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Прочитано секторов</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Чтение/с</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Чтение секторов/с</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Считывает объединенные/-ы</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Записано секторов</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Записи завершены </translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Записи объединены</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Записи/с</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Секторы записаны/с</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Writes merged/s</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Система</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Показать ярлыки</translation>
     </message>
@@ -598,44 +604,49 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Завершение этого процесса может привести к потере данных.
 Вы уверены, что хотите продолжить?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Завершить процесс</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Принудительное завершение этого процесса может привести к потере данных.
 Вы уверены что хотите продолжить?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Принудительное завершение работы этого приложения может привести к потере данных. Вы уверены, что хотите продолжить?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Принудительное закрытие</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Завершение</translation>
@@ -644,7 +655,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Выход</translation>
     </message>
@@ -652,7 +663,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Настройки</translation>
     </message>
@@ -660,7 +671,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Размер</translation>
     </message>
@@ -669,6 +680,7 @@ Are you sure you want to continue?</source>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>IP-адрес:</translation>
     </message>
@@ -787,11 +799,13 @@ Are you sure you want to continue?</source>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>IPv4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>IPv6</translation>
     </message>
@@ -804,17 +818,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Командная строка</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Время запуска</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Имя</translation>
     </message>
@@ -822,7 +836,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Нажмите на приложение, которое хотите завершить</translation>
     </message>
@@ -830,12 +844,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Память</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Прием</translation>
     </message>
@@ -843,67 +861,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>Процессор</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Чтение диска</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Запись диска</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Память</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Раздел подкачки</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Не подключен</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Загрузка</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Отправка</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Сеть</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Всего Получено</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Всего Отправлено</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Передача</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Диски</translation>
     </message>
@@ -919,47 +955,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Очень высокий</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Высокий</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Нормальный</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Низкий</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Очень низкий</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Пользовательский</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Недействительный</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Ошибка: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Не удалось изменить приоритет процесса</translation>
     </message>
@@ -985,32 +1028,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Не удалось приостановить процесс</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Не удалось возобновить процесс</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Не удалось убить процесс</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Неизвестная ошибка</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Ошибка при отправке сигнала процессу</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Не удалось завершить процесс</translation>
     </message>
@@ -1026,17 +1069,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Не отвечает</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Приостановить</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Панель</translation>
     </message>
@@ -1044,37 +1089,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Посмотреть расположение команды</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Завершить процесс</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Возобновить процесс</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Убить процесс</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Изменить приоритет</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Приостановить процесс</translation>
     </message>
@@ -1082,18 +1132,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Пользовательский Приоритет</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Изменить</translation>
@@ -1170,7 +1220,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Не поддерживается</translation>
     </message>
@@ -1213,12 +1263,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Не удалось установить тип запуска службы</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Ошибка: не удалось установить тип запуска службы из-за сбоя вспомогательного процесса.</translation>
     </message>
@@ -1226,17 +1276,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Наименование  службы</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
@@ -1244,37 +1296,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Обновить</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Запустить</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Остановить</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Перезапустить</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Авто</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Вручную</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Тип запуска</translation>
     </message>
@@ -1325,17 +1381,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation type="unfinished">Настройки</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Изменяемый)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Диапазон: %1-%2</translation>
     </message>
@@ -1343,22 +1400,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Принудительное завершение приложения</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Расширенный</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Компактный</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Вид</translation>
     </message>
@@ -1366,7 +1424,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Поиск</translation>
     </message>
@@ -1374,17 +1433,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Процессы</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Службы</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Пользователи</translation>
     </message>
@@ -1392,7 +1459,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Редактировать информацию о учетной записи</translation>
     </message>
@@ -1400,12 +1467,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Администратор</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Стандартный пользователь</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_si.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_si.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>ස්යැස්මාන් පරීක්ෂක</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>ස්යැස්මාන් පරීක්ෂක ඔබේ අවස්ථාවෙහි පවතින ප්‍රශ්නාත්මක සේවා සහ ප්‍රොසෙස් ප්‍රමාණය පරීක්ෂා කරන සම්පූර්ණ පරීක්ෂක වේ, ඔබේ අවස්ථාවෙහි පවතින ප්‍රොසෙස් සහ සේවා පරීක්ෂා කරන සම්පූර්ණ පරීක්ෂක වේ</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>විස්තාරය අපසන් කරන්න</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>සම්පූර්ණ ප්‍රමාණය</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>සේවාවක් ප්‍රමාණය</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>සියලුම ප්‍රමාණය</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>ලිවිය හැකි</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 වින්‍දු</translation>
     </message>
@@ -56,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 දින %2 විභාග %3 මිනිත්තු</translation>
     </message>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>වර්තමාන ස්වර්ගය</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>ස්වර්ගය</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 වින්‍දු</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>සේවා අවලංගු නොවේ</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>විස්තාරය</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>විස්තාරය</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>අවසන් කරන්න</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>ඇති</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>ලබාගත්</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>සම්ප්‍රාප්ත</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>කාච්ඩ්</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>බුෆර්ස්</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>කාච්ඩ් ස්වාප්</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation type="unfinished">Active</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>සක්‍රීය නොවූ</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>අපහසු</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>මාප් කරන්න</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>සියලුම ස්වාප්</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>මිලියන් ස්වාප්</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>ස්ලාබ්</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>මෝඩල්</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>ඇසිරිය වේගය</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>ලියුම් වේගය</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>කාබ්ලිතිය</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>ස්ෙක්ටර්ස් ඇසිරිය</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>ඇසි/ස</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>සෙක්ටර් ඇසි/ස</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>ඇසි වැළඳි/ස</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>සෙක්ටර් ඇසි</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>ඇසි අවසන් කළ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>ඇසි වැළඳි</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>ඇසි/ස</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>සෙක්ටර් ඇසි/ස</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>ඇසි වැළඳි/ස</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>ස්යුස්ටම්</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>ස්කොට් කුල් පෙන්වා ගැනීම</translation>
     </message>
@@ -598,45 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>මෙම ක්‍රමය අවසන් කරන්නේ දත්ත අවම වීමට ඉඩ ඇත.
 ඇතුළත් කරන්නේ දැනටමත් ද? </translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>ක්‍රමය අවසන් කරන්න</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>මෙම ක්‍රමය අවසන් කරන්නේ දත්ත අවම වීමට ඉඩ ඇත.
 ඇතුළත් කරන්නේ දැනටමත් ද? </translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>මෙම ප්‍රොග්‍රාමය අවසන් කරන්නේ දත්ත අවම වීමට ඉඩ ඇත.
 ඇතුළත් කරන්නේ දැනටමත් ද? </translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation type="unfinished">Force End</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation type="unfinished">End</translation>
@@ -645,7 +656,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>ඇතුළත් කිරීම</translation>
     </message>
@@ -653,7 +664,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>සැකසීම්</translation>
     </message>
@@ -661,7 +672,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>ප්‍රමාණය</translation>
     </message>
@@ -670,6 +681,7 @@ Are you sure you want to continue?</source>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>අංශුප්‍රමාණය:</translation>
     </message>
@@ -788,11 +800,13 @@ Are you sure you want to continue?</source>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>ඉන්ප්‍රාන්ස් 4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>ඉන්ප්‍රාන්ස් 6</translation>
     </message>
@@ -805,17 +819,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>ප්‍රවර්ගීකරණ පිරිස්</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>ආරම්භ කිරීමේ කාලය</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>නම</translation>
     </message>
@@ -823,7 +837,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>අවසන් කිරීමට අවශ්‍ය ප්‍රශ්‍ණය අවශ්‍ය නම් එය අවශ්‍ය කරන්න</translation>
     </message>
@@ -831,12 +845,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>ස්ථානය</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>ආ ගැනීම</translation>
     </message>
@@ -844,67 +862,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>ස්වාච්චිය</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>ඩිස්ක් අධිකරණය</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>ඩිස්ක් අවශ්‍ය කරන්න</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>සම්පූර්ණ ප්‍රමාණය</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>ස්වාප්</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>සක්‍රිය කරන්නේ නැත</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>ඇතුළුවන්න</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>පිටුවන්න</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>විද්‍යුත් ප්‍රමාණය</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>සම්පූර්ණ ගැනීම</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>සියලුම අවසන් කළා</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>අවසන් කරන්න</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>ඩිස්ක්ස්</translation>
     </message>
@@ -920,47 +956,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>අතිශය අධික</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>අධික</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>සාමාන්‍ය</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>අඩු</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>අතිශය අඩු</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>ක්‍රමාনුකූල</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>අවලඟ</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, අඩුව: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>ප්‍රෝසෙස් ප්‍රයෝග් අභිමානය වෙනස් කරන්න නොහැක</translation>
     </message>
@@ -986,32 +1029,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>ප්‍රෝසෙස් ප්‍රතිඵලය නොකළ හැක</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>ප්‍රෝසෙස් ප්‍රතිඵලය නොවෙනස් කරන්න හැක</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>ප්‍රෝසෙස් ප්‍රතිඵලය නොසමාපන්න හැක</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>විශේෂ අඩුව</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>ප්‍රෝසෙස් දිගුව නොවෙනස් කරන්න හැක</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>ප්‍රෝසෙස් ප්‍රතිඵලය නොසමාපන්න හැක</translation>
     </message>
@@ -1027,17 +1070,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>ප්‍රතිඵලය නොමැත</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>සමාපනය</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>ට්‍රේ</translation>
     </message>
@@ -1045,37 +1090,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>ප්‍රාරම්භය ලෝක් පෙන්වන්න</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>සාධකයන්</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>ප්‍රෝසෙස් ප්‍රතිඵලය සමාපනය කරන්න</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>ප්‍රෝසෙස් ප්‍රතිඵලය ප්‍රතිඵලය නොවෙනස් කරන්න</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>प्रोसेस को मार्ने</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>प्राथमिकता बदल्ने</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>प्रोसेस को अवकाश दिने</translation>
     </message>
@@ -1083,18 +1133,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>अनुकूल प्राथमिकता</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation type="unfinished">Change</translation>
@@ -1171,7 +1221,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>समर्थन नाही</translation>
     </message>
@@ -1214,12 +1264,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>सेवा स्टार्टअप प्रकार सेट गर्न सकिएन</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>त्रुटि: सेवा स्टार्टअप प्रकार सेट गर्न सकिएन किनकि उपस्थित प्रक्रिया विफल भयो।</translation>
     </message>
@@ -1227,17 +1277,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>सेवा उदाहरण नाम</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -1245,37 +1297,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>पुन: चलाउ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>प्रारम्भ गर्ने</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>අවසනය කරන්න</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>නව ආරම්භ කරන්න</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>ඇයිටෝ</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>මානුවල්</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>ආරම්භ ගේදරා ප්‍රකාරය</translation>
     </message>
@@ -1326,17 +1382,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>සැකසීම්</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(සංස්කරණය විය හැකි)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>රාංග්: %1-%2</translation>
     </message>
@@ -1344,22 +1401,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>අඩු අයිතිය දෙන ලෙස ප්‍රවේශනය</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>වැළඳා ගැනීම</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>අඩු කිරීම</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>සැලසුම</translation>
     </message>
@@ -1367,7 +1425,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>සොයන්න</translation>
     </message>
@@ -1375,17 +1434,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>ප්‍රොස්සෙස්</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>සේවා</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>උෂ්ණා</translation>
     </message>
@@ -1393,7 +1460,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>උෂ්ණා නිර්මාණ අවස්ථාව සංස්කරණය කරන්න</translation>
     </message>
@@ -1401,12 +1468,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>අධිපති</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>ස්ටාන්ඩාර්ඩ් උෂ්ණා</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_sk.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_sk.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Systémový monitor</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>System Monitor je nástroj na monitorovanie reálneho systémového zatíženia, zobrazenie a ovládanie procesov a služieb, ktoré sa spúšťajú na vašom systéme.</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Skryť detaily</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Celkovo využitie</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Individuálne využitie</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Čítanie</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Zápis</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 sekúnd</translation>
     </message>
@@ -56,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 deň %2 hodiny %3 minúty</translation>
     </message>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Aktuálna frekvencia</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Frekvencia</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="100"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Zrušiť</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 sekúnd</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Žiadne výsledky vyhľadávania</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Detaily</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Podrobnosti</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>Varovanie</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Použitá</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Dostupná</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Zdieľaná</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Vyrobená</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Buffer</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Vyrobená výmena</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Aktívna</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Inaktívna</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Znečistená</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Zobrazená</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Celkovo výmena</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Voľná výmena</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Slab</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Rýchlosť čítania</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Rýchlosť zápisu</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Kapacita</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Sektorov prečítaných</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Prečítané/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Prečítané sektory/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Zlúčené prečítané/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Sektorov napísaných</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Napísané dokončené </translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Zlúčené napísané</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Napísané/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Napísané sektory/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Zlúčené napísané/s</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Systém</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Zobrazit skratky</translation>
     </message>
@@ -598,44 +604,49 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation type="unfinished">Ukončenie tohto procesu môže spôsobiť stratu údajov.
 Naozaj chcete pokračovať?</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Koniec</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation type="unfinished">Ukončiť proces</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Zrušiť</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Silne ukončenie</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Sila ukončenie tohto procesu môže spôsobiť stratu dátum.
 Ste si istí, že chcete pokračovať?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Sila ukončenie tohto programu môže spôsobiť stratu dátum.
@@ -645,7 +656,7 @@ Ste si istí, že chcete pokračovať?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Odhlásiť sa</translation>
     </message>
@@ -653,7 +664,7 @@ Ste si istí, že chcete pokračovať?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Nastavenia</translation>
     </message>
@@ -661,7 +672,7 @@ Ste si istí, že chcete pokračovať?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Veľkosť</translation>
     </message>
@@ -670,6 +681,7 @@ Ste si istí, že chcete pokračovať?</translation>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>IP adresa:</translation>
     </message>
@@ -698,11 +710,13 @@ Ste si istí, že chcete pokračovať?</translation>
     <name>NetInfoModel</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>IPv4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>IPv6</translation>
     </message>
@@ -805,17 +819,17 @@ Ste si istí, že chcete pokračovať?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation type="unfinished">Príkazový riadok</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation type="unfinished">Doba spustenia</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation type="unfinished">Názov</translation>
     </message>
@@ -823,7 +837,7 @@ Ste si istí, že chcete pokračovať?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation type="unfinished">Kliknite na aplikáciu, ktorú chcete ukončiť</translation>
     </message>
@@ -831,12 +845,16 @@ Ste si istí, že chcete pokračovať?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation type="unfinished">Pamäť</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Prijatie</translation>
     </message>
@@ -844,67 +862,85 @@ Ste si istí, že chcete pokračovať?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation type="unfinished">CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation type="unfinished">Čítanie disku</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation type="unfinished">Zápis disku</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation type="unfinished">Pamäť</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation type="unfinished">Swap</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation type="unfinished">Nie je povolené</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation type="unfinished">Sťahovanie</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation type="unfinished">Odosielanie</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation type="unfinished">Sieť</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Celkovo prijaté</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Celkovo odoslané</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Disky</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Odoslanie</translation>
     </message>
@@ -920,47 +956,54 @@ Ste si istí, že chcete pokračovať?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Veľmi vysoký</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Vysoký</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normálny</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Nízky</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Veľmi nízky</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Vlastný</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Neplatný</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Chyba: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Nie bolo možné zmeniť prioritu procesu</translation>
     </message>
@@ -986,32 +1029,32 @@ Ste si istí, že chcete pokračovať?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Nie bolo možné pozastaviť proces</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Nie bolo možné obnoviť proces</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Nie bolo možné ukončiť proces</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Neznáma chyba</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Nie bolo možné odoslať signál procesu</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Nie bolo možné ukončiť proces</translation>
     </message>
@@ -1027,17 +1070,19 @@ Ste si istí, že chcete pokračovať?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation type="unfinished">Žiadna odpoveď</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation type="unfinished">Pozastaviť</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation type="unfinished">Zásobník</translation>
     </message>
@@ -1045,37 +1090,42 @@ Ste si istí, že chcete pokračovať?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Zobraziť umiestnenie príkazu</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation type="unfinished">Vlastnosti</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation type="unfinished">Ukončiť proces</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Obnoviť proces</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Ukončiť proces</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Zmeniť prioritu</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Pozastaviť proces</translation>
     </message>
@@ -1083,18 +1133,18 @@ Ste si istí, že chcete pokračovať?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Vlastná priorita</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Zrušiť</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Zmeniť</translation>
@@ -1206,7 +1256,7 @@ Ste si istí, že chcete pokračovať?</translation>
         <translation>Oznámenia</translation>
     </message>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Nepodporované</translation>
     </message>
@@ -1214,12 +1264,12 @@ Ste si istí, že chcete pokračovať?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Nepodarilo sa nastaviť typ spustenia služby</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Chyba: Nepodarilo sa nastaviť typ spustenia služby kvôli zlyhaniu podprocesu.</translation>
     </message>
@@ -1227,17 +1277,19 @@ Ste si istí, že chcete pokračovať?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Zrušiť</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Názov inštancie služby</translation>
     </message>
@@ -1245,37 +1297,41 @@ Ste si istí, že chcete pokračovať?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Obnoviť</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Spustiť</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Zastaviť</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Znovu spustiť</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Automaticky</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Ručne</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Typ spustenia</translation>
     </message>
@@ -1326,17 +1382,18 @@ Ste si istí, že chcete pokračovať?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Nastavenia</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Zmeniteľné)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Rozsah: %1-%2</translation>
     </message>
@@ -1344,22 +1401,23 @@ Ste si istí, že chcete pokračovať?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Vynútiť ukončenie aplikácie</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Rozšíriť</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Zúžiť</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Zobraziť</translation>
     </message>
@@ -1367,7 +1425,8 @@ Ste si istí, že chcete pokračovať?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation type="unfinished">Vyhľadávanie</translation>
     </message>
@@ -1375,17 +1434,25 @@ Ste si istí, že chcete pokračovať?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Procesy</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Služby</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Používatelia</translation>
     </message>
@@ -1393,7 +1460,7 @@ Ste si istí, že chcete pokračovať?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Upraviť informácie o účte</translation>
     </message>
@@ -1401,12 +1468,12 @@ Ste si istí, že chcete pokračovať?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Administrátor</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Štandardný používateľ</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_sl.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_sl.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Monitor za sistem</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Monitor za sistem je alat za nadzorovanje vremenskega zahtevka sistema, prikaz in upravljanje procesov in storitev, ki se izvajajo na vašem sistemu.</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Skriti podrobnosti</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Celkova uporaba</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Individuálna uporaba</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Branje</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Pisanje</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 sekund</translation>
     </message>
@@ -56,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 dnevi %2 ure %3 minute</translation>
     </message>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Trenutna frekvencija</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Frekvencija</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Prekliči</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 sekund</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Ni rezultatov pretraživanja</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Podrobnosti</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Podrobnosti</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>Opozorilo</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Uporabljen</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Na voljo</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Deljen</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>V kah</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Povzetki</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Začasno shranjeno v kah</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation type="unfinished">Aktivno</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Neaktivno</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>غير نظيف</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>تم التعيين</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>التبديل الكلي</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>التبديل الحر</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>صفيحة</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>النموذج</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>سرعة القراءة</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>سرعة الكتابة</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>السعة</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>القطاعات التي تم قرائتها</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>القراءات/ثانية</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>القطاعات التي تم قرائتها/ثانية</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>القراءات المدمجة/ثانية</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>القطاعات التي تم كتابتها</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>الكتابات/ثانية</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>القطاعات التي تم كتابتها/ثانية</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>الكتابات المدمجة/ثانية</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>إنهاء قسري</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>إنهاء</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">V redu</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Sistem</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Pokaž poteze</translation>
     </message>
@@ -598,7 +604,7 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Zaključevanje ta proces lahko povzroči izgubo podatkov.
@@ -606,12 +612,14 @@ Ste сигурни, da želite nadaljevati?
 </translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Končaj proces</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Zaključevanje ta proces z naprem lahko povzroči izgubo podatkov.
@@ -619,7 +627,7 @@ Ste сигурни, da želite nadaljevati?
 </translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Zaključevanje ta aplikacije z naprem lahko povzroči izgubo podatkov.
@@ -627,19 +635,22 @@ Ste сигурни, da želite nadaljevati?
 </translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Prekliči</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>تسجيل الخروج</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>الإعدادات</translation>
@@ -648,7 +659,7 @@ Ste сигурни, da želite nadaljevati?
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>الحجم</translation>
     </message>
@@ -656,7 +667,7 @@ Ste сигурни, da želite nadaljevati?
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>عنوان IP:</translation>
     </message>
@@ -664,7 +675,7 @@ Ste сигурни, da želite nadaljevati?
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>قناع الشبكة:</translation>
     </message>
@@ -673,6 +684,7 @@ Ste сигурни, da želite nadaljevati?
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>البث:</translation>
     </message>
@@ -791,11 +803,13 @@ Ste сигурни, da želite nadaljevati?
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>IPv4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>IPv6</translation>
     </message>
@@ -808,17 +822,17 @@ Ste сигурни, da želite nadaljevati?
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Ukazna vrstica</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Zagonski čas</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Ime</translation>
     </message>
@@ -826,7 +840,7 @@ Ste сигурни, da želite nadaljevati?
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Kliknite na program, ki bi ga radi zaprli</translation>
     </message>
@@ -834,12 +848,16 @@ Ste сигурни, da želite nadaljevati?
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Spomin</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Prejemanje</translation>
     </message>
@@ -847,67 +865,85 @@ Ste сигурни, da želite nadaljevati?
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Branje z diska</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Pisanje na disk</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Spomin</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Swap</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Ni omogočeno</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Prenos</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Nalaganje</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Omrežje</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Celotno prejeto</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Celotno oddano</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Pošiljanje</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Diski</translation>
     </message>
@@ -923,47 +959,54 @@ Ste сигурни, da želite nadaljevati?
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Naprej</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Visoko</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normalno</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Nizko</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Preprično nizko</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Svoje</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Neveljavno</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Napaka: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Napaka pri spremembi prioryteza procesa</translation>
     </message>
@@ -989,32 +1032,32 @@ Ste сигурни, da želite nadaljevati?
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Napaka pri zastopanju procesa</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Napaka pri nadaljevanju procesa</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Napaka pri izbijanju procesa</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Neznana napaka</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Napaka pri pošiljanju signala procesu</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Napaka pri zaključevanju procesa</translation>
     </message>
@@ -1030,17 +1073,19 @@ Ste сигурни, da želite nadaljevati?
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Ni odziva</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Prekini</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Sistemska vrstica</translation>
     </message>
@@ -1048,37 +1093,42 @@ Ste сигурни, da želite nadaljevati?
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Pokaži lokacijo ukaza</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Lastnosti</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Končaj proces</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Obnovi proces</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Ukinej proces</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Spremeni prioritet</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Pogrej proces</translation>
     </message>
@@ -1086,18 +1136,18 @@ Ste сигурни, da želite nadaljevati?
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Ustavitev prioritet</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Prekliči</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Spremeni</translation>
@@ -1174,7 +1224,7 @@ Ste сигурни, da želite nadaljevati?
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Ne podpiram</translation>
     </message>
@@ -1217,12 +1267,12 @@ Ste сигурни, da želite nadaljevati?
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Napaka: Ni mogoče nastaviti začetne vrste storitve</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Napaka: Ni mogoče nastaviti začetne vrste storitve zaradi pregrajenega podprocesa.</translation>
     </message>
@@ -1230,17 +1280,19 @@ Ste сигурни, da želite nadaljevati?
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Ime primerka storitve</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>V redu</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>Prekliči</translation>
     </message>
@@ -1248,37 +1300,41 @@ Ste сигурни, da želite nadaljevati?
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Osveži</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Začni</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Zaustavi</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Ponovno začni</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Samodejno</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Rdeč</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Vrsta začetka</translation>
     </message>
@@ -1329,17 +1385,18 @@ Ste сигурни, da želite nadaljevati?
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Nastavitve</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Spremljivo)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Obseg: %1-%2</translation>
     </message>
@@ -1347,22 +1404,23 @@ Ste сигурни, da želite nadaljevati?
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Zavrnite aplikacijo</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Razširitev</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Skicovni prikaz</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Pogled</translation>
     </message>
@@ -1370,7 +1428,8 @@ Ste сигурни, da želite nadaljevati?
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Išči</translation>
     </message>
@@ -1378,17 +1437,25 @@ Ste сигурни, da želite nadaljevati?
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Postopki</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Uslugi</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Uporabniki</translation>
     </message>
@@ -1396,7 +1463,7 @@ Ste сигурни, da želite nadaljevati?
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Uredi podatke o računu</translation>
     </message>
@@ -1404,12 +1471,12 @@ Ste сигурни, da želite nadaljevati?
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Upravnik</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Standardni uporabnik</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_sq.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_sq.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Mbikëqyrës Sistemi</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Mbikëqyrësi i Sistemit është një mjet për të mbikëqyrur në kohë reale ngarkesën e sistemit, për të parë dhe kontrolluar procese dhe shërbime që xhirojnë në sistemin tuaj.</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Fshihi hollësitë</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Përdorim i përgjithshëm</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Përdorim individual</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Lexim</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Shkrim</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 sekonda</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 ditë %2 orë %3 minuta</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Frekuenca e tanishme</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Frekuencë</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Anuloje</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 sekonda</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>S’ka përfundime kërkimi</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Hollësi</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Hollësi</translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Të përdorura</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Të lira</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Jukshtuar</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Shpenzuar</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Buffëra</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Shpenzim shpenzuar</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Aktiv</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Jo aktiv</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Zëra</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Mapuar</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Swap gjithsej</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Swap i lirë</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Slab</translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Shpejtësi leximesh</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Shpejtësi shkrimesh</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Kapacitet</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Sektorë të lexuar</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Lexime/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Sektorë të lexuar/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Lidhjejë e kuptuar/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Sektorë të shkruar</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Shkruar i përfunduar</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Shkrimet lidhura</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Shkrime/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Sektorë të shkruar/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Shkrimet lidhura/s</translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Sistem</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Shfaq shkurtore</translation>
     </message>
@@ -604,50 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Përfundimi i këtij procesi mund të shkaktojë humbje të dhënash.
 Jeni i sigurt se doni të vazhdohet?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Përfundoje procesin</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Përfundimi me zor i këtij procesi mund të shkaktojë humbje të dhënash.
 Jeni i sigurt se doni të vazhdohet?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Përfundimi me zor i këtij aplikacioni mund të shkaktojë humbje të dhënash.
 Jeni i sigurt se doni të vazhdohet?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Detyro Përfundim</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Përfundoje</translation>
@@ -656,7 +656,7 @@ Jeni i sigurt se doni të vazhdohet?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation type="unfinished"></translation>
     </message>
@@ -664,7 +664,7 @@ Jeni i sigurt se doni të vazhdohet?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Rregullime</translation>
     </message>
@@ -672,7 +672,7 @@ Jeni i sigurt se doni të vazhdohet?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Madhësi</translation>
     </message>
@@ -819,17 +819,17 @@ Jeni i sigurt se doni të vazhdohet?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Rresht urdhrash</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Kohë fillimi</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Emër</translation>
     </message>
@@ -837,7 +837,7 @@ Jeni i sigurt se doni të vazhdohet?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Klikoni mbi aplikacionin që doni të përfundohet</translation>
     </message>
@@ -845,16 +845,16 @@ Jeni i sigurt se doni të vazhdohet?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Kujtesë</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Marrje</translation>
     </message>
@@ -862,85 +862,85 @@ Jeni i sigurt se doni të vazhdohet?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Lexim në disk</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Shkrim në disk</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Kujtesë</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Swap</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>I paaktivizuar</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Shkarkim</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Ngarkim</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Rrjet</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Të marrë gjithsej</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Të dërguar gjithsej</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Dërgim</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Disqe</translation>
     </message>
@@ -956,54 +956,54 @@ Jeni i sigurt se doni të vazhdohet?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Shumë e lartë</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>E lartë</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normale</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>E ulët</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Shumë e ulët</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Vetjake</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>E pavlefshme</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Gabim: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>S’u arrit të ndryshohet përparësi procesi</translation>
     </message>
@@ -1029,32 +1029,32 @@ Jeni i sigurt se doni të vazhdohet?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>S’u arrit të pushohej procesi</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>S’u arrit të rimerrej procesi</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>S’u arrit të asgjësohej procesi</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Gabim i panjohur</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>S’u arrit t’i dërgohej sinjal procesit</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>S’u arrit të përfundohej procesi</translation>
     </message>
@@ -1070,19 +1070,19 @@ Jeni i sigurt se doni të vazhdohet?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>S’ka përgjigje</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Pezulloje</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Panel</translation>
     </message>
@@ -1090,42 +1090,42 @@ Jeni i sigurt se doni të vazhdohet?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Shihni vendndodhje urdhri</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Veti</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Përfundoje procesin</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Rimerre procesin</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Asgjësoje procesin</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Ndryshojini përparësinë</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Pezulloje procesin</translation>
     </message>
@@ -1133,18 +1133,18 @@ Jeni i sigurt se doni të vazhdohet?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Përparësi Vetjake</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Ndryshoje</translation>
@@ -1221,7 +1221,7 @@ Jeni i sigurt se doni të vazhdohet?</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Pa mbulim</translation>
     </message>
@@ -1264,12 +1264,12 @@ Jeni i sigurt se doni të vazhdohet?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>S’u arrit të caktohej lloj nisjeje shërbimi</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Gabim: S’u arrit të caktohej lloj nisjeje shërbimi, për shkak të një nënprocesi të vithisur.</translation>
     </message>
@@ -1277,19 +1277,19 @@ Jeni i sigurt se doni të vazhdohet?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Emër instance shërbimi</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>Anuloje</translation>
     </message>
@@ -1297,41 +1297,41 @@ Jeni i sigurt se doni të vazhdohet?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Rifreskoje</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Nise</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Ndale</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Rinise</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Auto</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Dorazi</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Lloj nisjeje</translation>
     </message>
@@ -1382,18 +1382,18 @@ Jeni i sigurt se doni të vazhdohet?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Rregullime</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(I ndryshueshëm)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Interval: %1-%2</translation>
     </message>
@@ -1401,23 +1401,23 @@ Jeni i sigurt se doni të vazhdohet?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Detyro përfundim aplikacioni</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Zgjeroje</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Mblidhe</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Shihni</translation>
     </message>
@@ -1425,8 +1425,8 @@ Jeni i sigurt se doni të vazhdohet?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Kërko</translation>
     </message>
@@ -1434,25 +1434,25 @@ Jeni i sigurt se doni të vazhdohet?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Procese</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Shërbime</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Përdorues</translation>
     </message>
@@ -1460,7 +1460,7 @@ Jeni i sigurt se doni të vazhdohet?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Përpunoni hollësi llogarie</translation>
     </message>
@@ -1468,12 +1468,12 @@ Jeni i sigurt se doni të vazhdohet?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Përgjegjës</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Përdorues Standard</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_sr.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_sr.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Праћење Система</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Праћење Система је алат за надзирање оптерећења система у реалном времену и управљање системским процесима и услугама.</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Сакриј детаље</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Укупна употреба</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Индивидуална употреба</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Читање</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Уписивање</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 секунди</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 дана %2 сат. %3 мин.</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Тренутни радни такт</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Радни такт</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Откажи</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 секунди</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Нема резултата претраге</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Детаљи</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Детаљи</translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Заузето</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Слободно</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Дељено</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Кеширано</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Попуне</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Кеширана помоћна мем.</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Активност</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Неактивно</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Прљаво</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Пресликано</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Укупна помоћна мем.</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Слободна помоћна мем.</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Плоча</translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Модел</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Брзина читања</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Брзина уписивања</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Капацитет</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Читања сектора</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Читања/сек</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Читања сектора/сек</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Читања спојено/сек</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Уписаних сектора</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Завршених уписивања </translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Уписивања спојено </translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Уписивања/сек</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Уписаних сектора/сек</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Читања спојено/сек</translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>У реду</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Систем</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Прикажи пречице</translation>
     </message>
@@ -604,50 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Окончање овог процеса може изазвати губитак података.
 Заиста желите да наставите?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Окончај процес</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Принудно окончање овог процеса може изазвати губитак података.
 Заиста желите да наставите?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Принудно окончање овог програма може изазвати губитак података.
 Заиста желите да наставите?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Откажи</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Принудно окончај</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Окончај</translation>
@@ -656,7 +656,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Одјави се</translation>
     </message>
@@ -664,7 +664,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Подешавање</translation>
     </message>
@@ -672,7 +672,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Величина</translation>
     </message>
@@ -819,17 +819,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Командна линија</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Почетно време</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Име</translation>
     </message>
@@ -837,7 +837,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Кликните на програм који желите да окончате</translation>
     </message>
@@ -845,16 +845,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Меморија</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Примање</translation>
     </message>
@@ -862,85 +862,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>ЦПЈ</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Читање диска</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Уписивање диска</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Меморија</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Помоћна</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Није омогућено</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Преузимање</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Отпремање</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Мрежа</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Преузето</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Отпремљено</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Слање</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Дискови</translation>
     </message>
@@ -956,54 +956,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Веома висок</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Висок</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Нормалан</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Низак</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Веома низак</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Прилагођен</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Неважеће</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>ПИД: %1, Грешка: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Неуспешна промена приоритета процеса</translation>
     </message>
@@ -1029,32 +1029,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Неуспешно паузирање процеса</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Неуспешно настављање процеса</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Убијање процеса није успело</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Непозната грешка</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Неуспешно слање сигнала ка процесу</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Окончавање процеса није успело</translation>
     </message>
@@ -1070,19 +1070,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Нема одговора</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Обустављено</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Касета</translation>
     </message>
@@ -1090,42 +1090,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Прикажи локацију команде</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Својства</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Окончај процес</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Настави процес</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Убиј процес</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Промени приоритет</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Обустави процес</translation>
     </message>
@@ -1133,18 +1133,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Прилагођени приоритет</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Откажи</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Промени</translation>
@@ -1221,7 +1221,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Неподржано</translation>
     </message>
@@ -1264,12 +1264,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Неуспешна поставка режима покретања услуге</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Грешка: Неуспешна поставка режима покретања услуге због отказа под-процеса</translation>
     </message>
@@ -1277,19 +1277,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Назив инстанце услуге</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>У реду</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>Откажи</translation>
     </message>
@@ -1297,41 +1297,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Освежи</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Покрени</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Заустави</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Поново покрени</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Ауто.</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Ручно</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Режим покретања</translation>
     </message>
@@ -1382,18 +1382,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Подешавање</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Модификујући)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Обим: %1-%2</translation>
     </message>
@@ -1401,23 +1401,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Принудно окончај програм</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Проширено</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Збијено</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Приказ</translation>
     </message>
@@ -1425,8 +1425,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Претражи</translation>
     </message>
@@ -1434,25 +1434,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Процеси</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Услуге</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Корисници</translation>
     </message>
@@ -1460,7 +1460,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Уреди информације о налогу</translation>
     </message>
@@ -1468,12 +1468,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Администратор</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Стандардни корисник</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_sv.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_sv.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>System Monitor</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>System Monitor är ett verktyg för att övervaka systembelastning i realtid, visa och kontrollera processer och tjänster som körs på ditt system.</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Dölj detaljer</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Total användning</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Individuell användning</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Läs</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Skriv</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 sekunder</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 dagar %2 timmar %3 minuter</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Aktuell frekvens</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Frekvens</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="100"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Avbryt</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 sekunder</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Inga sökresultat</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Detaljer</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Detaljer</translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Använd</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Tillgänglig</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Delad</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Cache</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Buffer</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Cache swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Aktiv</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Inaktiv</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Fet</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Kartlagd</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Totalt swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Ledigt swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Slab</translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Modell</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Läs hastighet</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Skrivhastighet</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Kapacitet</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Sektorer lästa</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Läsningar/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Sektorer lästa/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Sammanslagna läsningar/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Sektorer skrivna</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Skrivningar slutförda </translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Sammanslagna skrivningar</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Skrivningar/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Sektorer skrivna/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Sammanslagna skrivningar/s</translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>System</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Visa genombrott</translation>
     </message>
@@ -604,49 +604,49 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Avsluta denna process kan orsaka förlust av data.
 Är du säker på att du vill fortsätta?</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Avsluta</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation type="unfinished">Avsluta process</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Avbryt</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Tvinga avslut</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Tvinga avslutande denna process kan orsaka förlust av data.
 Är du säker på att du vill fortsätta?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Tvinga avslutande denna applikation kan orsaka förlust av data.
@@ -656,7 +656,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Logga ut</translation>
     </message>
@@ -664,7 +664,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Inställningar</translation>
     </message>
@@ -672,7 +672,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Storlek</translation>
     </message>
@@ -819,17 +819,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation type="unfinished">Kommandorad</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation type="unfinished">Starttid</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation type="unfinished">Namn</translation>
     </message>
@@ -837,7 +837,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation type="unfinished">Klicka på programmet som du vill avsluta</translation>
     </message>
@@ -845,16 +845,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation type="unfinished">Minne</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Mottagning</translation>
     </message>
@@ -862,85 +862,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation type="unfinished">CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation type="unfinished">Diskläsning</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation type="unfinished">Diskskrivning</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation type="unfinished">Minne</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation type="unfinished">Swap</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation type="unfinished">Ej aktiverad</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation type="unfinished">Nedladdning</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation type="unfinished">Uppladdning</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation type="unfinished">Nätverk</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Total mottagen</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Total skickad</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Diskar</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Skicka</translation>
     </message>
@@ -956,54 +956,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Väldigt hög</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Hög</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Låg</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Väldigt låg</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Anpassad</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Ogiltig</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Fel: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Misslyckades med att ändra processprioritet</translation>
     </message>
@@ -1029,32 +1029,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Misslyckades med att pausa process</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Misslyckades med att återuppta process</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Misslyckades med att avsluta process</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Okänd fel</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Misslyckades med att skicka signal till process</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Misslyckades med att avsluta process</translation>
     </message>
@@ -1070,19 +1070,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation type="unfinished">Inget svar</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Pausa</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Skärm</translation>
     </message>
@@ -1090,42 +1090,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Visa kommandoläge</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation type="unfinished">Egenskaper</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation type="unfinished">Avsluta process</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Återuppta process</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Avsluta process</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Ändra prioritet</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Pausa process</translation>
     </message>
@@ -1133,18 +1133,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Anpassad prioritet</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Avbryt</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Ändra</translation>
@@ -1256,7 +1256,7 @@ Are you sure you want to continue?</source>
         <translation>Meddelanden</translation>
     </message>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Ej stöd</translation>
     </message>
@@ -1264,12 +1264,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Misslyckades med att ange tjänstens starttyp</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Fel: Misslyckades med att ange tjänstens starttyp på grund av att underliggande underprocess kraschade.</translation>
     </message>
@@ -1277,19 +1277,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Avbryt</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Tjänstens instansnamn</translation>
     </message>
@@ -1297,41 +1297,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Uppdatera</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Starta</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Stoppa</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Starta om</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Automatisk</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Manuell</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Starttyp</translation>
     </message>
@@ -1382,18 +1382,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Inställningar</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Ändrabart)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Intervallet: %1-%2</translation>
     </message>
@@ -1401,23 +1401,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Tvinga avsluta program</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Utöka</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Kompakt</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Visa</translation>
     </message>
@@ -1425,8 +1425,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation type="unfinished">Sök</translation>
     </message>
@@ -1434,25 +1434,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Processer</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Tjänster</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Användare</translation>
     </message>
@@ -1460,7 +1460,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Redigera kontoinformation</translation>
     </message>
@@ -1468,12 +1468,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Administratör</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Standardanvändare</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_sw.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_sw.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Sisitem Monitor</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Sisitem Monitor ni programu ambayo inatumia kuchapisha mabadiliko ya mabadiliko ya system, kushirikisha na kuchapa mabadiliko ya mabadiliko ya system inayotumia kwenye system wako.</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Kubadilisha mabadiliko</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Mabadiliko ya kawaida</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Mabadiliko ya kati</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Kuondoa</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Kuondoa</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>Sani 60</translation>
     </message>
@@ -56,9 +60,9 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
-        <translation>'%1 loko %2 muda %3 muda'</translation>
+        <translation>&apos;%1 loko %2 muda %3 muda&apos;</translation>
     </message>
 </context>
 <context>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Frequensi ya kati</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Frequensi</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>Sani 60</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Hakuna matokeo ya kuchapisha</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Mabadiliko</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Mabadiliko</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>Ripoti</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Iliyochapwa</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Iliyotolewa</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Iliyolipwa</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Iliyokompyuta</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Buffers</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Swap ya kompyuta</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation type="unfinished">Active</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Inactive</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Dirty</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Mapped</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Swap ya kubadilika</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Swap ya kubadilika</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Slab</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Modeli</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Ukubadilika wa kubadilika</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Ukubadilika wa kutolewa</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Kapaiti</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Sectors ya kubadilika</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Mwaka/m</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Mwaka ya sektoris/m</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Mwaka ya sektoris ya kizungumzwa/m</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Sektori ya kizungumzwa</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Mwaka ya kizungumzwa ya kifungwa </translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Mwaka ya sektoris ya kizungumzwa</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Mwaka ya kizungumzwa/m</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Mwaka ya sektoris ya kizungumzwa/m</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Mwaka ya sektoris ya kizungumzwa/m</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Mifumo</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Ongeza mchimbuzi</translation>
     </message>
@@ -598,45 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Kufungua mifumo hii inaweza kusababisha kufungua data.
 Uko mwenye kujitambua kufungua?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Kufungua mifumo</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Kufungua mifumo hii kwa kifungua inaweza kusababisha kufungua data.
 Uko mwenye kujitambua kufungua?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Kufungua mifumo hii kwa kifungua inaweza kusababisha kufungua data.
 Uko mwenye kujitambua kufungua?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation type="unfinished">Force End</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation type="unfinished">End</translation>
@@ -645,7 +656,7 @@ Uko mwenye kujitambua kufungua?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Kutoka</translation>
     </message>
@@ -653,7 +664,7 @@ Uko mwenye kujitambua kufungua?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Mipango</translation>
     </message>
@@ -661,7 +672,7 @@ Uko mwenye kujitambua kufungua?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Uwezo</translation>
     </message>
@@ -670,6 +681,7 @@ Uko mwenye kujitambua kufungua?</translation>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>IP address:</translation>
     </message>
@@ -788,11 +800,13 @@ Uko mwenye kujitambua kufungua?</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>IPv4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>IPv6</translation>
     </message>
@@ -805,17 +819,17 @@ Uko mwenye kujitambua kufungua?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Sukuma ya njia</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Wakati wa kuanza</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Jina</translation>
     </message>
@@ -823,7 +837,7 @@ Uko mwenye kujitambua kufungua?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Chukua programu unayochukua kufungua</translation>
     </message>
@@ -831,12 +845,16 @@ Uko mwenye kujitambua kufungua?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Moyo</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Kutumia</translation>
     </message>
@@ -844,67 +862,85 @@ Uko mwenye kujitambua kufungua?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Kutumia disk</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Kutumia disk</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Moyo</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Swap</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Hakuna inayotumika</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Kutumia</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Kutumia</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Moyo</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Jumla ya kutumia</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Jumla ya kujitokeza</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Kujitokeza</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Dish</translation>
     </message>
@@ -920,47 +956,54 @@ Uko mwenye kujitambua kufungua?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Moyo wa kikubwa</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Moyo wa kubwa</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Moyo wa kati</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Moyo wa kisasa</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Moyo wa kisasa</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Kusimamisha</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Lile</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Sasa: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Hakikamata kusimamisha moyo wa kazi</translation>
     </message>
@@ -986,32 +1029,32 @@ Uko mwenye kujitambua kufungua?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Hakikamata kusikiliza kazi</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Hakikamata kusahiliza kazi</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Hakikamata kusukilisha kazi</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Sasa ya kizina</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Hakikamata kusikilisha matokeo kwa kazi</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Hakikamata kusikilisha kazi</translation>
     </message>
@@ -1027,17 +1070,19 @@ Uko mwenye kujitambua kufungua?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Hakikamata jibu</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Kusikiliza</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Kati ya kazi</translation>
     </message>
@@ -1045,37 +1090,42 @@ Uko mwenye kujitambua kufungua?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Tazama jina la kuzalisha</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Maelezo</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Kusikilisha kazi</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Kusahilisha kazi</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Kule procesi</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Ongeze priority</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Kule procesi</translation>
     </message>
@@ -1083,18 +1133,18 @@ Uko mwenye kujitambua kufungua?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Priority ya Kifalasi</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation type="unfinished">Change</translation>
@@ -1171,7 +1221,7 @@ Uko mwenye kujitambua kufungua?</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Hapofaulu</translation>
     </message>
@@ -1214,12 +1264,12 @@ Uko mwenye kujitambua kufungua?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Hapofaulu kuzalishwa matokeo ya kuanza uservice</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Error: Hapofaulu kuzalishwa matokeo ya kuanza uservice kwa sababu ya sub process ya kipasavyo.</translation>
     </message>
@@ -1227,17 +1277,19 @@ Uko mwenye kujitambua kufungua?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Jina ya instance ya uservice</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -1245,37 +1297,41 @@ Uko mwenye kujitambua kufungua?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Refreshe</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Kuanza</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Kukata</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Tumia</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Automatiki</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Mandhari</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Mipaka ya kipasikia</translation>
     </message>
@@ -1326,17 +1382,18 @@ Uko mwenye kujitambua kufungua?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Mipaka</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Mipaka)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Kipengele: %1-%2</translation>
     </message>
@@ -1344,22 +1401,23 @@ Uko mwenye kujitambua kufungua?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Tumia kufungua kifaa</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Kuzalisha</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Kupakia</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Ona</translation>
     </message>
@@ -1367,7 +1425,8 @@ Uko mwenye kujitambua kufungua?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Tazama</translation>
     </message>
@@ -1375,17 +1434,25 @@ Uko mwenye kujitambua kufungua?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Mipaka</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Mipaka</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Wateja</translation>
     </message>
@@ -1393,7 +1460,7 @@ Uko mwenye kujitambua kufungua?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Tumia maelezo ya akunti</translation>
     </message>
@@ -1401,12 +1468,12 @@ Uko mwenye kujitambua kufungua?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Mudhania</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Mteja wa kifaa</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_ta.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_ta.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>மின்னணி கண்காட்சி</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>மின்னணி கண்காட்சி என்பது உங்கள் மின்னணியில் இயங்கும் பொருட்கள் மற்றும் சேவைகளைக் காண்பி மற்றும் கட்டுப்பாட்டு செய்யக்கூடிய ஒரு கருவியாகும், மின்னணி ஆட்சி பொருளை காண்பி மற்றும் கட்டுப்பாட்டு செய்யக்கூடிய ஒரு கருவியாகும்</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>விவரங்களை அகற்று</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>தொடர்ச்சியாக பயன்பாடு</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>தனிப்பட்ட பயன்பாடு</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>தொடர்பு</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>எழுது</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 வினாடி</translation>
     </message>
@@ -56,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 நாள் %2 மணி %3 நிமிடம்</translation>
     </message>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>தற்போதைய ஆமை</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>ஆமை</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 வினாடி</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>தேடல் விளைவுகள் இல்லை</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>விவரங்கள்</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>விவரங்கள்</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>செய்திருக்கிறேன்</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>பயன்பாட்டு</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>கிடைக்கிறது</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>பகிர்ந்து</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>கைவிடப்பட்டது</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>பேன்ர்ஸ்</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>கைவிடப்பட்ட சேர்க்கை</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation type="unfinished">Active</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>முடங்கிய</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>கசாய்</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>மாப்பட்</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>மொத்த சேர்க்கை</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>தேடும் சேர்க்கை</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>சலப்</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>மாடல்</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>கேட்பதற்கான வேகம்</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>எழுதுவதற்கான வேகம்</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>கைமைப்பு</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>செக்டர்கள் கேட்பது</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>ஒரு நிமிடத்திற்கு படிக்கப்பட்டது</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>ஒரு நிமிடத்திற்கு படிக்கப்பட்ட பகுதிகள்</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>ஒரு நிமிடத்திற்கு இணைக்கப்பட்ட படிக்கப்பட்டது</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>படிக்கப்பட்ட பகுதிகள்</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>உருவாக்கப்பட்ட காப்பிகள் முடிந்தது</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>உருவாக்கப்பட்ட காப்பிகள் இணைக்கப்பட்டது</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>ஒரு நிமிடத்திற்கு உருவாக்கப்பட்ட காப்பிகள்</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>ஒரு நிமிடத்திற்கு உருவாக்கப்பட்ட பகுதிகள்</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>ஒரு நிமிடத்திற்கு உருவாக்கப்பட்ட காப்பிகள் இணைக்கப்பட்டது</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>முறைமை</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>துரிதங்களை காட்டு</translation>
     </message>
@@ -598,45 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>இந்த பெயரை அழிக்கும் போது தரவு இழப்பு ஏற்படலாம்.
 தொடர விரும்புகிறீர்களா?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>பெயரை அழிக்கவும்</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>இந்த பெயரை வலுவாக அழிக்கும் போது தரவு இழப்பு ஏற்படலாம்.
 தொடர விரும்புகிறீர்களா?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>இந்த பயன்பாட்டை வலுவாக அழிக்கும் போது தரவு இழப்பு ஏற்படலாம்.
 தொடர விரும்புகிறீர்களா?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation type="unfinished">Force End</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation type="unfinished">End</translation>
@@ -645,7 +656,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>விலக்கி</translation>
     </message>
@@ -653,7 +664,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>அமைப்புகள்</translation>
     </message>
@@ -661,7 +672,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>அளவு</translation>
     </message>
@@ -670,6 +681,7 @@ Are you sure you want to continue?</source>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>IP முகவை:</translation>
     </message>
@@ -788,11 +800,13 @@ Are you sure you want to continue?</source>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>ஐ.பி.4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>ஐ.பி.6</translation>
     </message>
@@ -805,17 +819,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>கமாண்ட் லைன்</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>தொடங்கு நேரம்</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>பெயர்</translation>
     </message>
@@ -823,7 +837,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>முடிக்க விரும்பிய ஆப்பிளிகேஷனை கிளிக் செய்யவும்</translation>
     </message>
@@ -831,12 +845,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>குறிப்பிட்ட இடத்தில்</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>பெறு</translation>
     </message>
@@ -844,67 +862,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>சிபி</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>டிஸ்க் படிக்க</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>டிஸ்க் எழுது</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>மெமரி</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>சுவாப்</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>முடிவுக்கு வந்துள்ளது</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>மின்னல் கொண்டாடு</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>மின்னல் பெறு</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>நெட்வொர்க்</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>மொத்தம் பெற்றது</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>மொத்தம் அனுப்பப்பட்டது</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>அனுப்பு</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>டிஸ்க்ஸ்</translation>
     </message>
@@ -920,47 +956,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>தீவிரமான</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>மிக அதிக</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>நிலைமை</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>குறைந்த</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>மிகவும் குறைந்த</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>தனிப்பயன்</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>தவறான</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, தவறு: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>திருவாய்வு பெறுமானத்தை மாற்ற வேண்டாம்</translation>
     </message>
@@ -986,32 +1029,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>பெறுமானத்தை நிறுத்த வேண்டாம்</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>பெறுமானத்தை மீண்டும் தொடங்க வேண்டாம்</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>பெறுமானத்தை முடித்த வேண்டாம்</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>தெரியாத தவறு</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>பெறுமானத்திற்கு தகவலை அனுப்ப வேண்டாம்</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>பெறுமானத்தை முடித்த வேண்டாம்</translation>
     </message>
@@ -1027,17 +1070,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>தகவல் இல்லை</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>நிறுத்து</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>டிரே</translation>
     </message>
@@ -1045,37 +1090,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>முகவை கமாண்ட் இடத்தை பார்க்க</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>முகவை பண்புகள்</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>பெறுமானத்தை முடித்து</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>பெறுமானத்தை மீண்டும் தொடங்கு</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>தொடர்பு கொண்ட பெயர்</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>உயர்வு மாற்று</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>தொடர்பு கொண்ட பெயர் நிறுத்து</translation>
     </message>
@@ -1083,18 +1133,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>தனிப்பட்ட உயர்வு</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation type="unfinished">Change</translation>
@@ -1171,7 +1221,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>அங்கீகரிக்கப்படவில்லை</translation>
     </message>
@@ -1214,12 +1264,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>சேவிகள் தொடர்பு கொண்ட தொடக்க வகையை அமைக்க தவறியது</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>தவறு: சேவிகள் தொடர்பு கொண்ட தொடக்க வகையை அமைக்க தவறியது ஏனெனின் செயல்பாட்டின் உட்பகுதி மோதிரம் வெளியேறியது</translation>
     </message>
@@ -1227,17 +1277,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>சேவி தொடர்பு கொண்ட பெயர்</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -1245,37 +1297,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>புதுப்பிக்க</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>தொடங்கு</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>நிறுத்து</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>மீண்டும் தொடங்கு</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>தாவரம்</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>மேலோட்டம்</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>துவக்க வகை</translation>
     </message>
@@ -1326,17 +1382,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>அமைப்புகள்</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(திருத்தும் திறன்)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>வரம்பு: %1-%2</translation>
     </message>
@@ -1344,22 +1401,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>அமலியை வலுவாக முடிக்கவும்</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>நீட்டிக்க</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>சுருக்கு</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>காண</translation>
     </message>
@@ -1367,7 +1425,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>தேடு</translation>
     </message>
@@ -1375,17 +1434,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>முறைகள்</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>சேவிகள்</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>பயனாளிகள்</translation>
     </message>
@@ -1393,7 +1460,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>கணக்கு தகவலை திருத்து</translation>
     </message>
@@ -1401,12 +1468,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>அதிகாரி</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>முறையான பயனாளி</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_th.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_th.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>ติดตามระบบ</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>System Monitor เป็นเครื่องมือสำหรับติดตามภาระระบบแบบเรียลไทม์ ดูและควบคุมกระบวนการและบริการที่ทำงานอยู่บนระบบของคุณ</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>ซ่อนรายละเอียด</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>การใช้งานทั้งหมด</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>การใช้งานรายบุคคล</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>อ่าน</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>เขียน</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 วินาที</translation>
     </message>
@@ -56,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 วัน %2 ชั่วโมง %3 นาที</translation>
     </message>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>ความถี่ปัจจุบัน</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>ความถี่</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 วินาที</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>ไม่มีผลการค้นหา</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>รายละเอียด</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>รายละเอียด</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>เตือน</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>ใช้แล้ว</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>มีอยู่</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>แบ่งปัน</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>ถูกเก็บไว้</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>บัฟเฟอร์</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>ถูกเก็บไว้ swap</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation type="unfinished">Active</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>ไม่ใช้งาน</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>สกปรก</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>จับคู่</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Swap ทั้งหมด</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Swap ว่างเปล่า</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>ซลอบ</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>แบบจำลอง</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>ความเร็วการอ่าน</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>ความเร็วการเขียน</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>ความจุ</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>จำนวนเซกเตอร์ที่อ่าน</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>การอ่าน/วินาที</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>จำนวนเซกเตอร์ที่อ่าน/วินาที</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>การอ่านที่รวม/วินาที</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>จำนวนเซกเตอร์ที่เขียน</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>การเขียนเสร็จสิ้น</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>การเขียนที่รวม</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>การเขียน/วินาที</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>จำนวนเซกเตอร์ที่เขียน/วินาที</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>การเขียนที่รวม/วินาที</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>ระบบ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>แสดงคำสั่งลัด</translation>
     </message>
@@ -598,45 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>การสิ้นสุดกระบวนการนี้อาจทำให้สูญเสียข้อมูล
 do you want to continue?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>สิ้นสุดกระบวนการ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>การสิ้นสุดกระบวนการนี้ด้วยแรงบังคับอาจทำให้สูญเสียข้อมูล
 do you want to continue?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>การสิ้นสุดแอปพลิเคชันนี้ด้วยแรงบังคับอาจทำให้สูญเสียข้อมูล
 do you want to continue?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation type="unfinished">Force End</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation type="unfinished">End</translation>
@@ -645,7 +656,7 @@ do you want to continue?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>ออกจากระบบ</translation>
     </message>
@@ -653,7 +664,7 @@ do you want to continue?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>ตั้งค่า</translation>
     </message>
@@ -661,7 +672,7 @@ do you want to continue?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>ขนาด</translation>
     </message>
@@ -670,6 +681,7 @@ do you want to continue?</translation>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>ที่อยู่ IP:</translation>
     </message>
@@ -788,11 +800,13 @@ do you want to continue?</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>IPv4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>IPv6</translation>
     </message>
@@ -805,17 +819,17 @@ do you want to continue?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>บรรทัดคำสั่ง</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>เวลาเริ่มต้น</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>ชื่อ</translation>
     </message>
@@ -823,7 +837,7 @@ do you want to continue?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>คลิกแอปพลิเคชันที่คุณต้องการปิด</translation>
     </message>
@@ -831,12 +845,16 @@ do you want to continue?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>ความจำ</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>รับ</translation>
     </message>
@@ -844,67 +862,85 @@ do you want to continue?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>อ่านดิสก์</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>เขียนดิสก์</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>ความจำ</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>เปลี่ยน</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>ไม่ได้เปิดใช้งาน</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>ดาวน์โหลด</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>อัปโหลด</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>เครือข่าย</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>ทั้งหมดที่ได้รับ</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>จำนวนที่ส่งแล้ว</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>ส่ง</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>ดิสก์</translation>
     </message>
@@ -920,47 +956,54 @@ do you want to continue?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>สูงมาก</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>สูง</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>ปกติ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>ต่ำ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>ต่ำมาก</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>กำหนดเอง</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>ไม่ถูกต้อง</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, ข้อผิดพลาด: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>เปลี่ยนความสำคัญของกระบวนการล้มเหลว</translation>
     </message>
@@ -986,32 +1029,32 @@ do you want to continue?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>การหยุดกระบวนการล้มเหลว</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>การเริ่มต่อกระบวนการล้มเหลว</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>การสังหารกระบวนการล้มเหลว</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>ข้อผิดพลาดไม่ทราบ</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>การส่งสัญญาณไปยังกระบวนการล้มเหลว</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>การสิ้นสุดกระบวนการล้มเหลว</translation>
     </message>
@@ -1027,17 +1070,19 @@ do you want to continue?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>ไม่มีการตอบสนอง</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>ระงับ</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>ถาด</translation>
     </message>
@@ -1045,37 +1090,42 @@ do you want to continue?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>ดูตำแหน่งคำสั่ง</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>คุณสมบัติ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>สิ้นสุดกระบวนการ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>เริ่มต่อกระบวนการ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>สังหารกระบวนการ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>เปลี่ยนลำดับความสำคัญ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>ระงับกระบวนการ</translation>
     </message>
@@ -1083,18 +1133,18 @@ do you want to continue?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>ลำดับความสำคัญแบบกำหนดเอง</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation type="unfinished">Change</translation>
@@ -1171,7 +1221,7 @@ do you want to continue?</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>ไม่รองรับ</translation>
     </message>
@@ -1214,12 +1264,12 @@ do you want to continue?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>ไม่สามารถตั้งค่าประเภทการเริ่มต้นของบริการได้</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>ข้อผิดพลาด: ไม่สามารถตั้งค่าประเภทการเริ่มต้นของบริการได้เนื่องจากกระบวนการย่อยล้มเหลว</translation>
     </message>
@@ -1227,17 +1277,19 @@ do you want to continue?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>ชื่อตัวอย่างบริการ</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -1245,37 +1297,41 @@ do you want to continue?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>อัปเดต</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>เริ่มต้น</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>หยุด</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>เริ่มต้นใหม่</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>อัตโนมัติ</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>มือ</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>ประเภทการเริ่มต้น</translation>
     </message>
@@ -1326,17 +1382,18 @@ do you want to continue?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>ตั้งค่า</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(สามารถแก้ไขได้)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>ช่วง: %1-%2</translation>
     </message>
@@ -1344,22 +1401,23 @@ do you want to continue?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>สิ้นสุดแอปพลิเคชันโดยบังคับ</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>ขยาย</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>กระชับ</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>ดู</translation>
     </message>
@@ -1367,7 +1425,8 @@ do you want to continue?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>ค้นหา</translation>
     </message>
@@ -1375,17 +1434,25 @@ do you want to continue?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>กระบวนการ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>บริการ</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>ผู้ใช้</translation>
     </message>
@@ -1393,7 +1460,7 @@ do you want to continue?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>แก้ไขข้อมูลบัญชี</translation>
     </message>
@@ -1401,12 +1468,12 @@ do you want to continue?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>ผู้ดูแลระบบ</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>ผู้ใช้มาตรฐาน</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_tr.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_tr.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Sistem İzleyici</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Sistem İzleyici, sisteminizde çalışan gerçek zamanlı sistem yükünü izlemek, görüntülemek ve kontrol etmek için kullanılan bir araçtır.</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Ayrıntıları gizle</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Genel kullanım</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Bireysel kullanım</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Oku</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Yaz</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 saniye</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 gün %2 saat %3 dakika</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Şuanki frekans</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Frekans</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">İptal</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 saniye</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Arama sonucu bulunamadı</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Ayrıntılar</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Ayrıntılar</translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Kullanıldı</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Mevcut</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Paylaşıldı</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Önbelleklendi</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Arabellekler</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Önbelleklenen takas</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Aktif</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Pasif</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Kirli</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Haritalandı</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Toplam takas </translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Boş takas</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Levha</translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Okuma hızı</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Yazma hızı</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Kapasite</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Bölgeler okundu</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Okur/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Bölgeler okundu/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Okumalar birleştirildi/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Bölgeler yazıldı</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Yazılar tamamlandı</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Yazılar birleştirildi</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Yazar/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Bölgeler yazıldı/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Yazılar birleştirildi/s</translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Tamam</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Sistem</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Kısayolları görüntüle</translation>
     </message>
@@ -604,50 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Bu işlemi sonlandırmak veri kaybına neden olabilir.
 Devam etmek istediğinize emin misiniz?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>İşlemi sonlandır</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Bu işlemi zorla sonlandırmak veri kaybına neden olabilir.
 Devam etmek istediğinize emin misiniz?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Bu uygulamayı sonlandırmaya zorlamak veri kaybına neden olabilir.
 Devam etmek istediğine emin misin?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Zorla Sonlandır</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Sonlandır</translation>
@@ -656,7 +656,7 @@ Devam etmek istediğine emin misin?</translation>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Çıkış Yap</translation>
     </message>
@@ -664,7 +664,7 @@ Devam etmek istediğine emin misin?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Ayarlar</translation>
     </message>
@@ -672,7 +672,7 @@ Devam etmek istediğine emin misin?</translation>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Boyut</translation>
     </message>
@@ -819,17 +819,17 @@ Devam etmek istediğine emin misin?</translation>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Komut satırı</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Başlama zamanı</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Ad</translation>
     </message>
@@ -837,7 +837,7 @@ Devam etmek istediğine emin misin?</translation>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Sonlandırmak istediğiniz uygulamayı tıklayın</translation>
     </message>
@@ -845,16 +845,16 @@ Devam etmek istediğine emin misin?</translation>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Bellek</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Alınan</translation>
     </message>
@@ -862,85 +862,85 @@ Devam etmek istediğine emin misin?</translation>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Disk okuma</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Disk yazma</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Bellek</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Takas</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Etkin değil</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>İndirme</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Yükleme</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Ağ</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Toplam Alınan</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Toplam Gönderilen</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Gönderilen</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Diskler</translation>
     </message>
@@ -956,54 +956,54 @@ Devam etmek istediğine emin misin?</translation>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Çok yüksek</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Yüksek</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Düşük</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Çok düşük</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Özel</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Geçersiz</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Hata: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>İşlem önceliği değiştirilemedi</translation>
     </message>
@@ -1029,32 +1029,32 @@ Devam etmek istediğine emin misin?</translation>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>İşlem duraklatılamadı</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>İşlem sürdürülemedi</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>İşlem öldürülemedi</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Bilinmeyen hata</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>İşleme alınacak sinyal gönderilemedi</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>İşlem sona erdirilemedi</translation>
     </message>
@@ -1070,19 +1070,19 @@ Devam etmek istediğine emin misin?</translation>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Yanıt yok</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Askıya al</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Tepsi</translation>
     </message>
@@ -1090,42 +1090,42 @@ Devam etmek istediğine emin misin?</translation>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Komut konumunu görüntüle</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Özellikler</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>İşlemi sonlandır</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>İşlemi sürdür</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Süreçleri öldür</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Önceliği değiştir</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>İşlemi askıya al</translation>
     </message>
@@ -1133,18 +1133,18 @@ Devam etmek istediğine emin misin?</translation>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Özel Öncelik</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Değiştir</translation>
@@ -1221,7 +1221,7 @@ Devam etmek istediğine emin misin?</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Desteklenmiyor</translation>
     </message>
@@ -1264,12 +1264,12 @@ Devam etmek istediğine emin misin?</translation>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Hizmet başlangıç türü ayarlanamadı</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Hata: Alt işlem çöktüğü için hizmet başlatma türü ayarlanamadı.</translation>
     </message>
@@ -1277,19 +1277,19 @@ Devam etmek istediğine emin misin?</translation>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Hizmet örneği adı</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>Tamam</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>İptal</translation>
     </message>
@@ -1297,41 +1297,41 @@ Devam etmek istediğine emin misin?</translation>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Yenile</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Başlat</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Durdur</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Yeniden başlat</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Otomatik</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Elle</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Başlangıç türü</translation>
     </message>
@@ -1382,18 +1382,18 @@ Devam etmek istediğine emin misin?</translation>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Ayarlar</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Değiştirilebilir)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Aralık: %1-%2</translation>
     </message>
@@ -1401,23 +1401,23 @@ Devam etmek istediğine emin misin?</translation>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Uygulamayı zorla sonlandır</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Genişlet</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Sade</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Görünüm</translation>
     </message>
@@ -1425,8 +1425,8 @@ Devam etmek istediğine emin misin?</translation>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Ara</translation>
     </message>
@@ -1434,25 +1434,25 @@ Devam etmek istediğine emin misin?</translation>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>İşlemler</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Hizmetler</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Kullanıcılar</translation>
     </message>
@@ -1460,7 +1460,7 @@ Devam etmek istediğine emin misin?</translation>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Kullanıcı bilgisini düzenle</translation>
     </message>
@@ -1468,12 +1468,12 @@ Devam etmek istediğine emin misin?</translation>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Yönetici</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Standart kullanıcı</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_ug.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_ug.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>سىستېما نازارەتچىسى</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>سىستېما نازارەتچىسى سىستېمىڭىزدا ئىجرا بولۇۋاتقان سىستېمىنىڭ يۈكىنى نازارەت قىلىش ، كۆرۈش ۋە كونترول قىلىش جەريانى ۋە مۇلازىمەتلىرىنى نازارەت قىلىدىغان قورال.</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>تەپسىلاتىنى يوشۇرۇش</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>ئومۇمىي پايدىلىنىش نىسبىتى</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>شەخسىي پايدىلىنىش نىسبىتى</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>ئوقۇش</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>يېزىش</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 سېكونت</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 كۈن %2 سائەت %3 مىنۇت</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>ھازىرقى چاستوتا</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>چاستوتا</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">بىكار قىلىش</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 سېكونت</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>ئىزدەش نەتىجىسى يوق</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>تەپسىلىي ئۇچۇر</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>تەپسىلىي ئۇچۇر</translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>ئىشلەتكىنى</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>ئىشلەتكىلى بولىدىغىنى</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>ئىچكى ساقلىغۇچ ھەمبەھرىلىنىش</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>يۇقىرى سۈرئەتلىك غەملەك</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>سانلىق مەلۇمات غەملىكى</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>غەملەك ئالماشتۇرۇش رايونى</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>ئاكتىپ</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>پاسسىپ غەملەك ھۆججىتى</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>مەينەت بەت</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>ئەكس ئەتتۈرۈش چوڭلۇقى</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>بوشلۇق ئالماشتۇرۇش سىغىمى</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>ئالماشتۇرۇشقا بولىدىغان بوشلۇق</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>ئىچكى يادرو سانلىق مەلۇمات قۇرۇلمىسى ساقلىغۇچى</translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>تىپى</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>ئوقۇش سۈرئىتى</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>يېزىش سۈرئىتى</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>سىغىمى</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>بۇ سېكتورنىڭ قېتىم سانى</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>ھەر سېكونتتىكى مەشغۇلات سانى</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>بۇ سېكتورنى ھەر سېكونتتا ئوقۇش سانى</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>ھەر سېكونتتىكى قوشۇپ مەشغۇلات قىلىش سانى</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>بۇ سېكتورغا يېزىش قېتىم سانى</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>يېزىپ تاماملانغان سانى</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>قوشۇپ يېزىش تاماملانغان سانى</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>ھەر سېكونتتىكى يېزىش سۈرئىتى</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>بۇ سېكتورغا ھەر سېكونتتا يېزىش سانى</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>ھەر سېكونتتىكى قوشۇپ يېزىش سانى</translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>ماقۇل</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>سىستېما</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>تېزلەتمە كۆرسەت</translation>
     </message>
@@ -604,50 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>بۇ جەرياننى ئاخىرلاشتۇرۇش سانلىق مەلۇماتلارنىڭ يوقىلىشىنى كەلتۈرۈپ چىقىرىشى مۇمكىن.
 داۋاملاشتۇرۇشنى خالامسىز؟</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>جەرياننى ئاخىرلاشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>بۇ جەرياننى ئاخىرلاشتۇرىدىغان كۈچ سانلىق مەلۇماتلارنىڭ يوقىلىشىنى كەلتۈرۈپ چىقىرىشى مۇمكىن.
 داۋاملاشتۇرۇشنى خالامسىز؟</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>بۇ پروگراممىنى ئاخىرلاشتۇرىدىغان كۈچ سانلىق مەلۇماتلارنىڭ يوقىلىشىنى كەلتۈرۈپ چىقىرىشى مۇمكىن.
 داۋاملاشتۇرۇشنى خالامسىز؟</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>بىكار قىلىش</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>مەجبۇرى ئاخرلاشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>ئاخىرلاشتۇرۇش</translation>
@@ -656,7 +656,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>چېكىتىش</translation>
     </message>
@@ -664,7 +664,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>تەڭشەك</translation>
     </message>
@@ -672,7 +672,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>سىغىمى</translation>
     </message>
@@ -819,17 +819,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>بۇيرۇق قۇرى</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>باشلىنىش ۋاقتى</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>ئىسمى</translation>
     </message>
@@ -837,7 +837,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>ئاخىرلاشتۇرماقچى بولغان پروگراممىنى چېكىڭ</translation>
     </message>
@@ -845,16 +845,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>ساقلىغۇ</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>قوبۇللاش</translation>
     </message>
@@ -862,85 +862,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>بىر تەرەپ قىلغۇچ</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>دىسكا ئوقۇش</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>دىسكا يېزىش</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>ساقلىغۇ</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>ئالماشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>قوزغىتىلمىدى</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>چۈشۈرۈش</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>يۈكلەش</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>تور</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>ئومۇمىي قوبۇل قىلىنغان</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>ئومۇمىي ئەۋەتىلگەن</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>يوللاش</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>دىسكا</translation>
     </message>
@@ -956,54 +956,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>بەك ئېگىز</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>ئېگىز</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>نورمال</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>تۆۋەن</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>بەك تۆۋەن</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>بەلگىلەش</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>ئىناۋەتسىز</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID:%1 ، خاتالىق: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>جەرياننىڭ تەرتىپىنى ئۆزگەرتەلمىدى</translation>
     </message>
@@ -1029,32 +1029,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>جەرياننى توختىتالمىدى</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>جەرياننى ئەسلىگە كەلتۈرەلمىدى</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>جەرياننى ئۆلتۈرەلمىدى</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>نامەلۇم خاتالىق</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>بىر تەرەپ قىلىش سىگنالى ئەۋەتىش مەغلۇب بولدى</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>جەرياننى ئاخىرلاشتۇرمىدى</translation>
     </message>
@@ -1070,19 +1070,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>ھېچقانداق جاۋاب يوق</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>توختىتىش</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>تەخسە</translation>
     </message>
@@ -1090,42 +1090,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>بۇيرۇق ئورنىنى كۆرۈش</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>خاسلىقى</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>جەرياننى ئاخىرلاشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>جەرياننى ئەسلىگە كەلتۈرۈش</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>جەرياننى ئۆلتۈرۈش</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>تەرتىپنى ئۆزگەرتىش</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>جەرياننى توختىتىش</translation>
     </message>
@@ -1133,18 +1133,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>ئالدىنلىق دەرىجىسىنى بەلگىلەش</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>بىكار قىلىش</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>ئۆزگەرتىش</translation>
@@ -1221,7 +1221,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>قوللىمايدۇ</translation>
     </message>
@@ -1264,12 +1264,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>مۇلازىمەت باشلاش تىپىنى بەلگىلىمىدى</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>خاتالىق: تارماق جەريان چۈشۈپ كەتكەنلىكتىن مۇلازىمەت باشلاش تۈرىنى بەلگىلىمىدى.</translation>
     </message>
@@ -1277,19 +1277,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>مۇلازىمەت ئۈلگە ئىسمى</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>ماقۇل</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>بىكار قىلىش</translation>
     </message>
@@ -1297,41 +1297,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>يېڭىلاش</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>باشلاش</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>توختاڭ</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>قايتا قوزغىتىڭ</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>ئاپتوماتىك</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>قولدا</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>باشلاش تىپى</translation>
     </message>
@@ -1382,18 +1382,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>تەڭشەك</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(چەك قىممەتنى ئۆزگەرتىشكە بولىدۇ)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>قىممەت دائىرىسى: %1-%2</translation>
     </message>
@@ -1401,23 +1401,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>قوللىنىشچان پروگراممىنى كۈچلەندۈرۈش</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>كېڭەيتىش</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>ئىخچام</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>كۆرۈش</translation>
     </message>
@@ -1425,8 +1425,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>ئىزدەش</translation>
     </message>
@@ -1434,25 +1434,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>جەريانلار</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>مۇلازىمەتلەر</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>كىشىلەر</translation>
     </message>
@@ -1460,7 +1460,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>ھەققىدە ئىشلەپ چىقۇر</translation>
     </message>
@@ -1468,12 +1468,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>مۇھىتىنىڭ ئەھۋالى</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>تىرە قىلغۇچى</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_uk.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_uk.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Нагляд за системою</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Монітор системи — інструмент для спостереження за навантаженням на систему у режимі реального часу, перегляду списку процесів та керування процесами та службами, які запущено у вашій системі.</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Приховати подробиці</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Загальне використання</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Окреме використання</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Читання</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Запис</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 секунд</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 днів %2 годин %3 хвилин</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Поточна частота</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Частота</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Скасувати</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 секунд</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Нічого не знайдено</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Подробиці</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Подробиці</translation>
     </message>
@@ -441,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Використано</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Доступно</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Спільно</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Кешовано</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Буфери</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Кешований резерв</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Активний</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Неактивний</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Змінено</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Пов&apos;язано</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Загальний резерв</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Вільний резерв</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Частина</translation>
     </message>
@@ -509,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Модель</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Швидкість читання</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Швидкість запису</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Місткість</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Секторів прочитано</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Читань/с</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Прочитаних секторів/с</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Об&apos;єднаних читань/с</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Записано секторів</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Завершено записів</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Об&apos;єднано записів</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Записів/с</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Записано секторів/с</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Об&apos;єднано записів/с</translation>
     </message>
@@ -582,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Гаразд</translation>
@@ -591,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Система</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Показати скорочення</translation>
     </message>
@@ -604,48 +604,48 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Завершення роботи цього процесу може призвести до втрати даних. Ви справді хочете виконати цю дію?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Завершити процес</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Примусове завершення роботи цього процесу може призвести до втрати даних. Ви справді хочете виконати цю дію?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Примусове припинення роботи цієї програми може призвести до втрати даних.
 Ви впевнені, що хочете продовжити?</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Примусове завершення</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Завершити</translation>
@@ -654,7 +654,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation type="unfinished"></translation>
     </message>
@@ -662,7 +662,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Параметри</translation>
     </message>
@@ -670,7 +670,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Розмір</translation>
     </message>
@@ -817,17 +817,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Командний рядок</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Час початку</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Назва</translation>
     </message>
@@ -835,7 +835,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Натисніть пункт програми, роботу якої ви хочете завершити</translation>
     </message>
@@ -843,16 +843,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Пам&apos;ять</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Отримання</translation>
     </message>
@@ -860,85 +860,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>ПРЦ</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Читання з диска</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Запис на диск</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Пам&apos;ять</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Резервна пам&apos;ять</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Не ввімкнено</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Отримання</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Надсилання</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Мережа</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Загалом отримано</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Загалом надіслано</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Надіслання</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Диски</translation>
     </message>
@@ -954,54 +954,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Дуже висока</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Висока</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Звичайна</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Низька</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Дуже низька</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Нетипова</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Некоректна</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, помилка: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Не вдалося змінити рівень пріоритетності процесу</translation>
     </message>
@@ -1027,32 +1027,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Не вдалося призупинити роботу процесу</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Не вдалося відновити роботу процесу</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Не вдалося примусово завершити роботу процесу</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Невідома помилка</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Не вдалося надіслати процесу сигнал</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Не вдалося завершити процес</translation>
     </message>
@@ -1068,19 +1068,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Немає відповіді</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Призупинити</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Лоток</translation>
     </message>
@@ -1088,42 +1088,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Переглянути розташування програми</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Властивості</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Завершити процес</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Відновити роботу процесу</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Вбити процес</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Змінити пріоритетність</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Призупинити процес</translation>
     </message>
@@ -1131,18 +1131,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Нетипова пріоритетність</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Змінити</translation>
@@ -1219,7 +1219,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Немає підтримки</translation>
     </message>
@@ -1262,12 +1262,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Не вдалося встановити тип запуску служби</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Помилка: Не вдалося встановити тип запуску служби через збій підпроцесу.</translation>
     </message>
@@ -1275,19 +1275,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Назва екземпляра служби</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>Гаразд</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
@@ -1295,41 +1295,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Оновити</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Запустити</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Зупинити</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Перезапустити</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>Авто</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>Ручний </translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Тип запуску</translation>
     </message>
@@ -1380,18 +1380,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Параметри</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Можна змінити)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Діапазон: %1-%2</translation>
     </message>
@@ -1399,23 +1399,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Примусове завершення програми</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Розгорнути</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Компактний</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Перегляд</translation>
     </message>
@@ -1423,8 +1423,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Пошук</translation>
     </message>
@@ -1432,25 +1432,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Процеси</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Служби</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Користувачі</translation>
     </message>
@@ -1458,7 +1458,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Редагувати дані облікового запису</translation>
     </message>
@@ -1466,12 +1466,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Адміністратор</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Стандартний користувач</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_ur.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_ur.ts
@@ -4,12 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>سیسٹم مانیٹر</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>سیسٹم مانیٹر ایک ادا دار ہے جو سیسٹم کی واقعی وقت پر لوڈ کا نگرانی کرے، آپ کے سیسٹم پر چل رہے پروسیسز اور سروسز کو دیکھیں اور کنٹرول کریں۔</translation>
     </message>
@@ -17,17 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>details چھپا دیں</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>کل استعمال</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>فردی استعمال</translation>
     </message>
@@ -35,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>پڑھو</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>لکھو</translation>
     </message>
@@ -48,7 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 سیکنڈ</translation>
     </message>
@@ -56,9 +60,9 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
-        <translation>'%1 روز %2 گھنٹے %3 منٹ'</translation>
+        <translation>&apos;%1 روز %2 گھنٹے %3 منٹ&apos;</translation>
     </message>
 </context>
 <context>
@@ -70,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>current فرکیوننسی</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>فرکیوننسی</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -157,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -165,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 سیکنڈ</translation>
     </message>
@@ -173,7 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>تلاش نتائج نہیں</translation>
     </message>
@@ -181,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>details</translation>
     </message>
@@ -189,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>details</translation>
     </message>
@@ -413,6 +418,7 @@
     <name>DBusAlarmNotify</name>
     <message>
         <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>حیثیت</translation>
     </message>
@@ -435,67 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>استعمال</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>دستیاب</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>شیئر کیا گیا</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>کیچ کیا گیا</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>بفرز</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>کیچ چینج</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation type="unfinished">Active</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>نشیع</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>غباردار</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>میپ کیا گیا</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>کل چینج</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>مفتی چینج</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>سلاب</translation>
     </message>
@@ -503,72 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>میڈل</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>پڑھنے کی رفتار</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>لکھنے کی رفتار</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>کیپسٹی</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>سیکٹر پڑھے گئے</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>راء/س</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>سیکٹرز ریڈ/س</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>راء مرج/س</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>سیکٹرز ورائٹن</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>وائٹس کمپلیٹ ہوئے</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>وائٹس مرج</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>وائٹس/س</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>سیکٹرز ورائٹن/س</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>وائٹس مرج/س</translation>
     </message>
@@ -576,7 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
@@ -585,12 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>سیسٹم</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>کیا کرتے ہیں</translation>
     </message>
@@ -598,7 +604,7 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>|-
@@ -606,12 +612,14 @@ Are you sure you want to continue?</source>
 آپ یقیناً جاری رکھنا چاہتے ہیں؟</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>پروسیس ختم کریں</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>|-
@@ -619,7 +627,7 @@ Are you sure you want to continue?</source>
 آپ یقیناً جاری رکھنا چاہتے ہیں؟</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>|-
@@ -627,19 +635,22 @@ Are you sure you want to continue?</source>
 آپ یقیناً جاری رکھنا چاہتے ہیں؟</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation type="unfinished">Force End</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation type="unfinished">End</translation>
@@ -648,7 +659,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>لوگ آوٹ</translation>
     </message>
@@ -656,7 +667,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
@@ -664,7 +675,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>سائیز</translation>
     </message>
@@ -673,6 +684,7 @@ Are you sure you want to continue?</source>
     <name>NetInfoDetailItemDelegate</name>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>IP ایڈریس:</translation>
     </message>
@@ -791,11 +803,13 @@ Are you sure you want to continue?</source>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>ای پی 4</translation>
     </message>
     <message>
         <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>ای پی 6</translation>
     </message>
@@ -808,17 +822,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>کمینڈ لائن</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>شروع وقت</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>نام</translation>
     </message>
@@ -826,7 +840,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>چیک کریں جو ایپلیکیشن کو ختم کرنا چاہیے</translation>
     </message>
@@ -834,12 +848,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>میموري</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>پہنچ</translation>
     </message>
@@ -847,67 +865,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>سی پی یو</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>ڈسک ریڈ</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>ڈسک رائٹ</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>میموري</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>سوپ</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>فعال نہیں کیا گیا</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>ڈاؤن لوڈ</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>آپ لوڈ</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>نیٹ ورک</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>کل پہنچ</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>کل جاری</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>جử</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>ڈسکس</translation>
     </message>
@@ -923,47 +959,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>بسیار زیاد</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>زیاد</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>نرمال</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>کم</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>بسیار کم</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>کسٹم</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>غیر معین</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1، گلٹی: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>پروسس کی اولیت تبدیل کرنے میں کامیاب نہ ہو سکا</translation>
     </message>
@@ -989,32 +1032,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>پروسس کو چھوڑنے میں کامیاب نہ ہو سکا</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>پروسس کو جاری کرنے میں کامیاب نه ہو سکا</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>پروسس کو ختم کرنے میں کامیاب نہ ہو سکا</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>غیر معلوم گلٹی</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>پروسس کو سیگنل بھیجنے میں کامیاب نہ ہو سکا</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>پروسس ختم کرنے میں کامیاب نہ ہو سکا</translation>
     </message>
@@ -1030,17 +1073,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>ری پریس نہیں</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>سپنڈ کریں</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>ٹری</translation>
     </message>
@@ -1048,37 +1093,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>کمانڈ کی جگہ دیکھیں</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>خصوصیات</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>پروسس ختم کریں</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>پروسس جاری کریں</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>پروسيس ہلاک کریں</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>اولیت تبدیل کریں</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>پروسيس ٹھنڈا کریں</translation>
     </message>
@@ -1086,18 +1136,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>اپنی اولیت</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation type="unfinished">Change</translation>
@@ -1174,7 +1224,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>سپورٹ نہیں کیا جا رہا ہے</translation>
     </message>
@@ -1217,12 +1267,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>سروس سٹارٹ اپ ٹائپ سیٹ کرنے میں ناکامی</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation> Error: سروس سٹارٹ اپ ٹائپ سیٹ کرنے میں ناکامی کیوں کہ ایک ٹھنڈا ہو گیا ہے سبس چیتھڑا.</translation>
     </message>
@@ -1230,17 +1280,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>سروس انسٹنس نام</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -1248,37 +1300,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>نیا</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>شروع کریں</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>وقف</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>재시작</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>اوتومیٹک</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>دستی</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>شروع کریں کی نوع</translation>
     </message>
@@ -1329,17 +1385,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(تبدیل کریں گے)</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>محدودیت: %1-%2</translation>
     </message>
@@ -1347,22 +1404,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>اپلیکیشن کو مزید جاری رکھیں</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>مختلف</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>کمپکٹ</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>دیکھیں</translation>
     </message>
@@ -1370,7 +1428,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>تلاش</translation>
     </message>
@@ -1378,17 +1437,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>پروسیسز</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>سروسز</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>صارفین</translation>
     </message>
@@ -1396,7 +1463,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>اکاونٹ اطلاعات تبدیل کریں</translation>
     </message>
@@ -1404,12 +1471,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>ادمینیسٹر</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>معیاری صارف</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_vi.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_vi.ts
@@ -4,13 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
-        <location filename="../main.cpp" line="92"/>
-        <location filename="../main.cpp" line="96"/>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>Theo dõi hệ thống</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="82"/>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>Theo dõi hệ thống là công cụ để theo dõi tải hệ thống thời gian thực, xem và kiểm soát các quá trình và dịch vụ đang chạy trên hệ thống của bạn.</translation>
     </message>
@@ -18,19 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="28"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>Ẩn chi tiết</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="39"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="51"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>Sử dụng tổng thể</translation>
     </message>
     <message>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="42"/>
-        <location filename="../gui/base/base_detail_view_widget.cpp" line="53"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>Sử dụng cá nhân</translation>
     </message>
@@ -38,12 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="138"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>Đọc</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_item_widget.cpp" line="142"/>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>Viết</translation>
     </message>
@@ -51,8 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
-        <location filename="../gui/cpu_detail_widget.cpp" line="154"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="268"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60 giây</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
-        <location filename="../model/cpu_info_model.cpp" line="43"/>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1 ngày %2 giờ %3 phút</translation>
     </message>
@@ -74,13 +74,13 @@
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
-        <source>Current frequency</source>
-        <translation>Tần số hiện tại</translation>
+        <source>Average frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
-        <source>Frequency</source>
-        <translation>Tần số</translation>
+        <source>Max frequency</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
@@ -161,7 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="298"/>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation>Hủy bỏ</translation>
     </message>
@@ -169,7 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
-        <location filename="../gui/chart_view_widget.cpp" line="293"/>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60 giây</translation>
     </message>
@@ -177,8 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="477"/>
-        <location filename="../gui/system_service_table_view.cpp" line="456"/>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>Không tìm thấy kết quả</translation>
     </message>
@@ -186,7 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="87"/>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>Chi tiết</translation>
     </message>
@@ -194,7 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
-        <location filename="../cpu_monitor.cpp" line="70"/>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>Chi tiết</translation>
     </message>
@@ -443,67 +443,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="62"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>Đã sử dụng</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>Còn trống</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="68"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>Chia sẻ</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>Được lưu trữ</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="74"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>Buffer</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>Đổi trang được lưu trữ</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="80"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>Hoạt động</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>Không hoạt động</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="86"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>Lỗi</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>Đã gắn</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="92"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>Đổi trang tổng cộng</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>Đổi trang trống</translation>
     </message>
     <message>
-        <location filename="../gui/mem_summary_view_widget.cpp" line="98"/>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>Slab</translation>
     </message>
@@ -511,72 +511,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="64"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>Mô hình</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="66"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>Tốc độ đọc</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>Tốc độ ghi</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>Dung lượng</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>Sector đã đọc</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>Đọc/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>Sector đọc/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>Đọc hợp nhất/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>Sector đã ghi</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>Viết hoàn thành</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>Viết hợp nhất</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>Ghi/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>Sectors written/s</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>Writes merged/s</translation>
     </message>
@@ -584,7 +584,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
-        <location filename="../gui/dialog/error_dialog.cpp" line="68"/>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -593,12 +593,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
-        <location filename="../common/common.cpp" line="28"/>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>Hệ thống</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="34"/>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Hiển thị phím tắt</translation>
     </message>
@@ -606,7 +606,7 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="166"/>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Dừng quá trình này có thể gây mất dữ liệu.
@@ -614,14 +614,14 @@ Bạn có chắc chắn muốn tiếp tục không?
 </translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="510"/>
-        <location filename="../gui/process_table_view.cpp" line="165"/>
-        <location filename="../gui/process_table_view.cpp" line="366"/>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>Dừng quá trình</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="367"/>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Dừng mạnh quá trình này có thể gây mất dữ liệu.
@@ -629,7 +629,7 @@ Bạn có chắc chắn muốn tiếp tục không?
 </translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="511"/>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>Dừng mạnh ứng dụng này có thể gây mất dữ liệu.
@@ -637,22 +637,22 @@ Bạn có chắc chắn muốn tiếp tục không?
 </translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="519"/>
-        <location filename="../gui/process_table_view.cpp" line="172"/>
-        <location filename="../gui/process_table_view.cpp" line="374"/>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Hủy bỏ</translation>
     </message>
     <message>
-        <location filename="../gui/process_page_widget.cpp" line="520"/>
-        <location filename="../gui/process_table_view.cpp" line="375"/>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>Dừng mạnh</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="173"/>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>Dừng</translation>
@@ -661,7 +661,7 @@ Bạn có chắc chắn muốn tiếp tục không?
 <context>
     <name>Logout</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="299"/>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>Đăng xuất</translation>
     </message>
@@ -669,7 +669,7 @@ Bạn có chắc chắn muốn tiếp tục không?
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../gui/main_window.cpp" line="172"/>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>Cài đặt</translation>
     </message>
@@ -677,7 +677,7 @@ Bạn có chắc chắn muốn tiếp tục không?
 <context>
     <name>MemStatViewWidget</name>
     <message>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="47"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>Kích thước</translation>
     </message>
@@ -824,17 +824,17 @@ Bạn có chắc chắn muốn tiếp tục không?
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="140"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>Dòng lệnh</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="145"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>Thời gian bắt đầu</translation>
     </message>
     <message>
-        <location filename="../gui/process_attribute_dialog.cpp" line="135"/>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>Tên</translation>
     </message>
@@ -842,7 +842,7 @@ Bạn có chắc chắn muốn tiếp tục không?
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
-        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="146"/>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>Nhấn vào ứng dụng bạn muốn kết thúc</translation>
     </message>
@@ -850,16 +850,16 @@ Bạn có chắc chắn muốn tiếp tục không?
 <context>
     <name>Process.Graph.Title</name>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="144"/>
-        <location filename="../gui/mem_detail_view_widget.cpp" line="22"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="97"/>
-        <location filename="../memory_monitor.cpp" line="163"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>Bộ nhớ</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="89"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="115"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>Nhận</translation>
     </message>
@@ -867,85 +867,85 @@ Bạn có chắc chắn muốn tiếp tục không?
 <context>
     <name>Process.Graph.View</name>
     <message>
-        <location filename="../compact_cpu_monitor.cpp" line="220"/>
-        <location filename="../cpu_monitor.cpp" line="216"/>
-        <location filename="../cpu_monitor.cpp" line="225"/>
-        <location filename="../gui/cpu_detail_widget.cpp" line="352"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="143"/>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="145"/>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>Đọc đĩa</translation>
     </message>
     <message>
-        <location filename="../compact_disk_monitor.cpp" line="146"/>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>Viết đĩa</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="176"/>
-        <location filename="../memory_monitor.cpp" line="189"/>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>Bộ nhớ</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="187"/>
-        <location filename="../compact_memory_monitor.cpp" line="193"/>
-        <location filename="../gui/mem_stat_view_widget.cpp" line="105"/>
-        <location filename="../memory_monitor.cpp" line="199"/>
-        <location filename="../memory_monitor.cpp" line="205"/>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>Hoán đổi</translation>
     </message>
     <message>
-        <location filename="../compact_memory_monitor.cpp" line="188"/>
-        <location filename="../memory_monitor.cpp" line="200"/>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>Không kích hoạt</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="152"/>
-        <location filename="../network_monitor.cpp" line="205"/>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>Tải về</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="157"/>
-        <location filename="../network_monitor.cpp" line="210"/>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>Tải lên</translation>
     </message>
     <message>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="145"/>
-        <location filename="../gui/netif_detail_view_widget.cpp" line="25"/>
-        <location filename="../network_monitor.cpp" line="187"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>Mạng</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="154"/>
-        <location filename="../network_monitor.cpp" line="207"/>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>Tổng đã nhận</translation>
     </message>
     <message>
-        <location filename="../compact_network_monitor.cpp" line="159"/>
-        <location filename="../network_monitor.cpp" line="212"/>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>Tổng đã gửi</translation>
     </message>
     <message>
-        <location filename="../gui/netif_item_view_widget.cpp" line="98"/>
-        <location filename="../gui/netif_item_view_widget.cpp" line="124"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>Gửi</translation>
     </message>
     <message>
-        <location filename="../gui/block_dev_detail_view_widget.cpp" line="17"/>
-        <location filename="../gui/detail_view_stacked_widget.cpp" line="146"/>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>Ổ đĩa</translation>
     </message>
@@ -961,54 +961,54 @@ Bạn có chắc chắn muốn tiếp tục không?
 <context>
     <name>Process.Priority</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="615"/>
-        <location filename="../process/process.cpp" line="54"/>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>Rất cao</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="623"/>
-        <location filename="../process/process.cpp" line="55"/>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>Cao</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="631"/>
-        <location filename="../process/process.cpp" line="56"/>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>Bình thường</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="639"/>
-        <location filename="../process/process.cpp" line="57"/>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>Thấp</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="647"/>
-        <location filename="../process/process.cpp" line="58"/>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>Rất thấp</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="655"/>
-        <location filename="../process/process.cpp" line="59"/>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>Tùy chỉnh</translation>
     </message>
     <message>
-        <location filename="../process/process.cpp" line="60"/>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>Không hợp lệ</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="179"/>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>PID: %1, Lỗi: [%2] %3</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="138"/>
-        <location filename="../process/process_db.cpp" line="176"/>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>Không thể thay đổi ưu tiên quá trình</translation>
     </message>
@@ -1034,32 +1034,32 @@ Bạn có chắc chắn muốn tiếp tục không?
 <context>
     <name>Process.Signal</name>
     <message>
-        <location filename="../process/process_db.cpp" line="246"/>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>Không thể tạm dừng quá trình</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="249"/>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>Không thể tiếp tục quá trình</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="252"/>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>Không thể kết thúc quá trình</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="255"/>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>Lỗi không xác định</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="311"/>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>Fehler beim Senden des Signals an den Prozess</translation>
     </message>
     <message>
-        <location filename="../process/process_db.cpp" line="243"/>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>Không thể kết thúc quá trình</translation>
     </message>
@@ -1075,19 +1075,19 @@ Bạn có chắc chắn muốn tiếp tục không?
 <context>
     <name>Process.Table</name>
     <message>
-        <location filename="../model/process_table_model.cpp" line="240"/>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>Không có phản hồi</translation>
     </message>
     <message>
-        <location filename="../model/process_table_model.cpp" line="245"/>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>Dừng lại</translation>
     </message>
     <message>
-        <location filename="../process/process_name.cpp" line="82"/>
-        <location filename="../process/process_name.cpp" line="89"/>
-        <location filename="../process/process_name.cpp" line="92"/>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>Khu vực hệ thống</translation>
     </message>
@@ -1095,42 +1095,42 @@ Bạn có chắc chắn muốn tiếp tục không?
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="662"/>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>Xem vị trí lệnh</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="79"/>
-        <location filename="../gui/process_table_view.cpp" line="666"/>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>Tính năng</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="62"/>
-        <location filename="../gui/process_table_view.cpp" line="590"/>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>Kết thúc quá trình</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="74"/>
-        <location filename="../gui/process_table_view.cpp" line="602"/>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>Tiếp tục quá trình</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="85"/>
-        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>Killing quá trình</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="609"/>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>Thay đổi ưu tiên</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="68"/>
-        <location filename="../gui/process_table_view.cpp" line="596"/>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>Dừng lại quá trình</translation>
     </message>
@@ -1138,18 +1138,18 @@ Bạn có chắc chắn muốn tiếp tục không?
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1024"/>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>Ưu tiên tùy chỉnh</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1056"/>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Huỷ bỏ</translation>
     </message>
     <message>
-        <location filename="../gui/process_table_view.cpp" line="1058"/>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>Thay đổi</translation>
@@ -1226,7 +1226,7 @@ Bạn có chắc chắn muốn tiếp tục không?
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../system/cpu_set.cpp" line="366"/>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>Không hỗ trợ</translation>
     </message>
@@ -1269,12 +1269,12 @@ Bạn có chắc chắn muốn tiếp tục không?
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
-        <location filename="../service/service_manager.cpp" line="322"/>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>Không thể thiết lập loại khởi động dịch vụ</translation>
     </message>
     <message>
-        <location filename="../service/service_manager.cpp" line="388"/>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>Lỗi: Không thể thiết lập loại khởi động dịch vụ do quá trình con bị hỏng.</translation>
     </message>
@@ -1282,19 +1282,19 @@ Bạn có chắc chắn muốn tiếp tục không?
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="150"/>
-        <location filename="../gui/system_service_table_view.cpp" line="216"/>
-        <location filename="../gui/system_service_table_view.cpp" line="282"/>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>Tên thực thể dịch vụ</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="34"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../gui/service_name_sub_input_dialog.cpp" line="35"/>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>Hủy bỏ</translation>
     </message>
@@ -1302,41 +1302,41 @@ Bạn có chắc chắn muốn tiếp tục không?
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="114"/>
-        <location filename="../gui/system_service_table_view.cpp" line="541"/>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>Làm mới</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="99"/>
-        <location filename="../gui/system_service_table_view.cpp" line="521"/>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>Bắt đầu</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="104"/>
-        <location filename="../gui/system_service_table_view.cpp" line="526"/>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>Dừng</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="109"/>
-        <location filename="../gui/system_service_table_view.cpp" line="531"/>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>Khởi động lại</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="537"/>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation type="unfinished">Tự động</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="538"/>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation type="unfinished">Tay</translation>
     </message>
     <message>
-        <location filename="../gui/system_service_table_view.cpp" line="536"/>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>Loại khởi động</translation>
     </message>
@@ -1387,18 +1387,18 @@ Bạn có chắc chắn muốn tiếp tục không?
 <context>
     <name>SystemProtectionSetting</name>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="124"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>Cài đặt</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="156"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>(Thay đổi được</translation>
     </message>
     <message>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="263"/>
-        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="371"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>Khoảng: %1-%2</translation>
     </message>
@@ -1406,23 +1406,23 @@ Bạn có chắc chắn muốn tiếp tục không?
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
-        <location filename="../common/common.cpp" line="55"/>
-        <location filename="../gui/main_window.cpp" line="122"/>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>Kết thúc ứng dụng</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="140"/>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>Mở rộng</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="143"/>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>Tightly packed</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="135"/>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>Xem</translation>
     </message>
@@ -1430,8 +1430,8 @@ Bạn có chắc chắn muốn tiếp tục không?
 <context>
     <name>Title.Bar.Search</name>
     <message>
-        <location filename="../common/common.cpp" line="40"/>
-        <location filename="../gui/toolbar.cpp" line="84"/>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>Tìm kiếm</translation>
     </message>
@@ -1439,25 +1439,25 @@ Bạn có chắc chắn muốn tiếp tục không?
 <context>
     <name>Title.Bar.Switch</name>
     <message>
-        <location filename="../common/common.cpp" line="49"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="53"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/toolbar.cpp" line="43"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>Quá trình</translation>
     </message>
     <message>
-        <location filename="../common/common.cpp" line="94"/>
-        <location filename="../gui/main_window.cpp" line="213"/>
+        <location filename="../common/common.cpp" line="98"/>
         <location filename="../gui/main_window.cpp" line="224"/>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="51"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>Dịch vụ</translation>
     </message>
     <message>
-        <location filename="../gui/main_window.cpp" line="234"/>
-        <location filename="../gui/toolbar.cpp" line="58"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>Người dùng</translation>
     </message>
@@ -1465,7 +1465,7 @@ Bạn có chắc chắn muốn tiếp tục không?
 <context>
     <name>User.Account.Operation</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="97"/>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>Sửa thông tin tài khoản</translation>
     </message>
@@ -1473,12 +1473,12 @@ Bạn có chắc chắn muốn tiếp tục không?
 <context>
     <name>User.Account.Type</name>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>Quản trị viên</translation>
     </message>
     <message>
-        <location filename="../gui/accounts_widget.cpp" line="145"/>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>Người dùng tiêu chuẩn</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_zh_CN.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_zh_CN.ts
@@ -4,10 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>系统监视器</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>系统监视器是一个对硬件负载、程序运行和系统服务，进行监测查看和管理操作的系统工具。</translation>
     </message>
@@ -15,14 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>隐藏详情</translation>
     </message>
     <message>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>总体利用率</translation>
     </message>
     <message>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>个体利用率</translation>
     </message>
@@ -30,10 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>读取</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>写入</translation>
     </message>
@@ -41,6 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60秒</translation>
     </message>
@@ -48,6 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1天%2小时%3分钟</translation>
     </message>
@@ -55,74 +68,92 @@
 <context>
     <name>CPUSummaryTableModel</name>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="91"/>
         <source>Utilization</source>
         <translation>总利用率</translation>
     </message>
     <message>
-        <source>Current frequency</source>
-        <translation>当前频率</translation>
+        <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
+        <source>Average frequency</source>
+        <translation>平均频率</translation>
     </message>
     <message>
-        <source>Frequency</source>
-        <translation>频率</translation>
+        <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
+        <source>Max frequency</source>
+        <translation>最大频率</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
         <source>Sockets</source>
         <translation>插槽</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="106"/>
         <source>Logical processors</source>
         <translation>逻辑处理器</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="110"/>
         <source>Virtualization</source>
         <translation>虚拟化</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="112"/>
         <source>L1i cache</source>
         <translation>L1缓存（指令）</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="116"/>
         <source>L1d cache</source>
         <translation>L1缓存（数据）</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="118"/>
         <source>L2 cache</source>
         <translation>L2缓存</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="122"/>
         <source>L3 cache</source>
         <translation>L3缓存</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="124"/>
         <source>Load average</source>
         <translation>平均负载</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="128"/>
         <source>File descriptors</source>
         <translation>文件描述符数</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="130"/>
         <source>Processes</source>
         <translation>进程数</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="134"/>
         <source>Threads</source>
         <translation>线程数</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="136"/>
         <source>Host name</source>
         <translation>主机名</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="140"/>
         <source>OS type</source>
         <translation>类型</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="142"/>
         <source>Version</source>
         <translation>版本</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="100"/>
         <source>Up time</source>
         <translation>运行时间</translation>
     </message>
@@ -130,6 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation>取 消</translation>
     </message>
@@ -137,6 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60秒</translation>
     </message>
@@ -144,6 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>无搜索结果</translation>
     </message>
@@ -151,6 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>详细信息</translation>
     </message>
@@ -158,6 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>详细信息</translation>
     </message>
@@ -165,26 +202,32 @@
 <context>
     <name>DBus.Unit.Active.State</name>
     <message>
+        <location filename="../dbus/dbus_common.h" line="165"/>
         <source>active</source>
         <translation>已启动</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="167"/>
         <source>reloading</source>
         <translation>重载中</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="169"/>
         <source>inactive</source>
         <translation>未启动</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="170"/>
         <source>failed</source>
         <translation>已失败</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="172"/>
         <source>activating</source>
         <translation>启动中</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="174"/>
         <source>deactivating</source>
         <translation>停止中</translation>
     </message>
@@ -192,30 +235,37 @@
 <context>
     <name>DBus.Unit.Load.State</name>
     <message>
+        <location filename="../dbus/dbus_common.h" line="146"/>
         <source>stub</source>
         <translation>占位</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="149"/>
         <source>not-found</source>
         <translation>未找到</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="151"/>
         <source>bad-setting</source>
         <translation>无效设置</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="152"/>
         <source>error</source>
         <translation>错误</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="153"/>
         <source>merged</source>
         <translation>已合并</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="154"/>
         <source>masked</source>
         <translation>已屏蔽</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="147"/>
         <source>loaded</source>
         <translation>已加载</translation>
     </message>
@@ -223,14 +273,17 @@
 <context>
     <name>DBus.Unit.Startup.Mode</name>
     <message>
+        <location filename="../dbus/dbus_common.h" line="297"/>
         <source>N/A</source>
         <translation>N/A</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="295"/>
         <source>Auto</source>
         <translation>自动</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="296"/>
         <source>Manual</source>
         <translation>手动</translation>
     </message>
@@ -238,34 +291,42 @@
 <context>
     <name>DBus.Unit.State</name>
     <message>
+        <location filename="../dbus/dbus_common.h" line="274"/>
         <source>enabled</source>
         <translation>已启用</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="275"/>
         <source>disabled</source>
         <translation>已禁用</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="276"/>
         <source>static</source>
         <translation>静态</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="277"/>
         <source>transient</source>
         <translation>瞬态</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="278"/>
         <source>indirect</source>
         <translation>间接</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="280"/>
         <source>enabled-runtime</source>
         <translation>运行时启用</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="281"/>
         <source>masked</source>
         <translation>已屏蔽</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="283"/>
         <source>generated</source>
         <translation>已生成</translation>
     </message>
@@ -273,66 +334,82 @@
 <context>
     <name>DBus.Unit.Sub.State</name>
     <message>
+        <location filename="../dbus/dbus_common.h" line="217"/>
         <source>dead</source>
         <translation>dead</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="219"/>
         <source>start-pre</source>
         <translation>预启动</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="221"/>
         <source>start</source>
         <translation>启动中</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="223"/>
         <source>start-post</source>
         <translation>start-post</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="225"/>
         <source>running</source>
         <translation>正在运行</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="227"/>
         <source>exited</source>
         <translation>已退出</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="229"/>
         <source>reload</source>
         <translation>重载中</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="231"/>
         <source>stop</source>
         <translation>已停止</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="233"/>
         <source>stop-watchdog</source>
         <translation>stop-watchdog</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="235"/>
         <source>stop-sigterm</source>
         <translation>stop-sigterm</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="237"/>
         <source>stop-sigkill</source>
         <translation>stop-sigkill</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="239"/>
         <source>stop-post</source>
         <translation>stop-post</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="241"/>
         <source>final-sigterm</source>
         <translation>final-sigterm</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="243"/>
         <source>final-sigkill</source>
         <translation>final-sigkill</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="245"/>
         <source>failed</source>
         <translation>已失败</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="247"/>
         <source>auto-restart</source>
         <translation>自动重启</translation>
     </message>
@@ -340,18 +417,23 @@
 <context>
     <name>DBusAlarmNotify</name>
     <message>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="39"/>
         <source>Your CPU usage is higher than %1%!</source>
         <translation>请注意！您的设备CPU占用已达%1%！</translation>
     </message>
     <message>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="51"/>
         <source>Your memory usage is higher than %1%!</source>
         <translation>请注意！您的设备内存占用已达%1%！</translation>
     </message>
     <message>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="71"/>
         <source>View</source>
         <translation>查看</translation>
     </message>
@@ -359,54 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>已使用</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>可用</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>共享内存</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>高速缓存</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>数据缓存</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>交换缓存区</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>活跃的缓冲文件</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>不活跃的缓冲文件</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>脏页</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>映射大小</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>交换空间大小</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>可用交换空间</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>内核数据结构缓存</translation>
     </message>
@@ -414,58 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>型号</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>读取速度</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>写入速度</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>容量</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>读扇区次数</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>每秒读操作次数</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>每秒读扇区次数</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>每秒合并读操作次数</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>写扇区次数</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>写完成次数</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>合并写完成次数</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>每秒写操作次数</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>每秒写扇区次数</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>每秒合并写操作次数</translation>
     </message>
@@ -473,6 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>确 定</translation>
@@ -481,10 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>系统</translation>
     </message>
     <message>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>显示快捷键</translation>
     </message>
@@ -492,38 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>结束进程会有丢失数据的风险。
 您确定要结束选中的进程吗？</translation>
     </message>
     <message>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>结束进程</translation>
     </message>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>强制结束进程会有丢失数据的风险。
 您确定要结束选中的进程吗？</translation>
     </message>
     <message>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>强制结束应用会有丢失数据的风险。
 您确定要结束选中的应用吗？</translation>
     </message>
     <message>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>强制结束</translation>
     </message>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>结束进程</translation>
@@ -532,6 +656,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>注销</translation>
     </message>
@@ -539,6 +664,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
@@ -546,6 +672,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>容量大小</translation>
     </message>
@@ -553,22 +680,28 @@ Are you sure you want to continue?</source>
 <context>
     <name>NetInfoDetailItemDelegate</name>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>IP地址：</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="157"/>
         <source>Netmask:</source>
         <translation>子网掩码：</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="157"/>
         <source>Broadcast:</source>
         <translation>广播：</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>Prefixlen:</source>
         <translation>掩码长度：</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>Scope:</source>
         <translation>域：</translation>
     </message>
@@ -576,86 +709,109 @@ Are you sure you want to continue?</source>
 <context>
     <name>NetInfoModel</name>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="293"/>
         <source>Connection type</source>
         <translation>连接类型</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="301"/>
         <source>ESSID</source>
         <translation>服务器别号</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="307"/>
         <source>Link quality</source>
         <translation>信号质量</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="312"/>
         <source>Signal strength</source>
         <translation>信号强度</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="317"/>
         <source>Noise level</source>
         <translation>底噪</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="323"/>
         <source>MAC</source>
         <translation>MAC</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="328"/>
         <source>Bandwidth</source>
         <translation>速率</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="333"/>
         <source>RX packets</source>
         <translation>接收包数量</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="338"/>
         <source>RX bytes</source>
         <translation>总计接收</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="343"/>
         <source>RX errors</source>
         <translation>接收（错误包）</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="348"/>
         <source>RX dropped</source>
         <translation>接收（丢弃包）</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="353"/>
         <source>RX overruns</source>
         <translation>接收FIFO</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="358"/>
         <source>RX frame</source>
         <translation>分组帧错误</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="363"/>
         <source>TX packets</source>
         <translation>发送包数量</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="368"/>
         <source>TX bytes</source>
         <translation>总计发送</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="373"/>
         <source>TX errors</source>
         <translation>发送（错误包）</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="383"/>
         <source>TX overruns</source>
         <translation>发送FIFO</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="388"/>
         <source>TX carrier</source>
         <translation>载波损耗</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>IPv4</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>IPv6</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="378"/>
         <source>TX dropped</source>
         <translation>发送（丢弃包）</translation>
     </message>
@@ -663,14 +819,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>命令行</translation>
     </message>
     <message>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>启动时间</translation>
     </message>
     <message>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>进程名</translation>
     </message>
@@ -678,6 +837,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>点击您想结束的应用程序</translation>
     </message>
@@ -685,10 +845,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>内存</translation>
     </message>
     <message>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>接收</translation>
     </message>
@@ -696,54 +862,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>处理器</translation>
     </message>
     <message>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>磁盘读取</translation>
     </message>
     <message>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>磁盘写入</translation>
     </message>
     <message>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>内存</translation>
     </message>
     <message>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>交换空间</translation>
     </message>
     <message>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>未启用</translation>
     </message>
     <message>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>正在接收</translation>
     </message>
     <message>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>正在发送</translation>
     </message>
     <message>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>网络</translation>
     </message>
     <message>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>总计接收</translation>
     </message>
     <message>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>总计发送</translation>
     </message>
     <message>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>发送</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>磁盘</translation>
     </message>
@@ -751,6 +948,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Loading</name>
     <message>
+        <location filename="../gui/process_page_widget.cpp" line="67"/>
         <source>Loading</source>
         <translation>正在加载</translation>
     </message>
@@ -758,38 +956,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>非常高</translation>
     </message>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>高</translation>
     </message>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>普通</translation>
     </message>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>低</translation>
     </message>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>非常低</translation>
     </message>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>自定义</translation>
     </message>
     <message>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>无效</translation>
     </message>
     <message>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>进程号: %1, Error: [%2] %3</translation>
     </message>
     <message>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>改变进程优先级失败</translation>
     </message>
@@ -797,14 +1011,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Show.Mode</name>
     <message>
+        <location filename="../gui/process_page_widget.cpp" line="61"/>
         <source>Applications</source>
         <translation>应用程序</translation>
     </message>
     <message>
+        <location filename="../gui/process_page_widget.cpp" line="63"/>
         <source>My processes</source>
         <translation>我的进程</translation>
     </message>
     <message>
+        <location filename="../gui/process_page_widget.cpp" line="65"/>
         <source>All processes</source>
         <translation>所有进程</translation>
     </message>
@@ -812,26 +1029,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>暂停进程失败</translation>
     </message>
     <message>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>恢复进程失败</translation>
     </message>
     <message>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>强制结束进程失败</translation>
     </message>
     <message>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>未知错误</translation>
     </message>
     <message>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>发送信号到进程失败 </translation>
     </message>
     <message>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>结束进程失败</translation>
     </message>
@@ -839,6 +1062,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Summary</name>
     <message>
+        <location filename="../gui/process_page_widget.cpp" line="58"/>
         <source>(%1 applications and %2 processes are running)</source>
         <translation>（正在运行%1个应用程序和%2个系统进程）</translation>
     </message>
@@ -846,14 +1070,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>无响应</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>暂停</translation>
     </message>
     <message>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>托盘</translation>
     </message>
@@ -861,30 +1090,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>查看命令所在位置</translation>
     </message>
     <message>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>属性</translation>
     </message>
     <message>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>结束进程</translation>
     </message>
     <message>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>继续进程</translation>
     </message>
     <message>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>强制结束进程</translation>
     </message>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>改变优先级</translation>
     </message>
     <message>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>暂停进程</translation>
     </message>
@@ -892,15 +1133,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>自定义优先级</translation>
     </message>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>更 改</translation>
@@ -909,54 +1153,67 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Header</name>
     <message>
+        <location filename="../model/process_table_model.h" line="16"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="18"/>
         <source>CPU</source>
         <translation>处理器</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="22"/>
         <source>Memory</source>
         <translation>内存</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="32"/>
         <source>Disk write</source>
         <translation>磁盘写入</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="30"/>
         <source>Disk read</source>
         <translation>磁盘读取</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="28"/>
         <source>Download</source>
         <translation>下载</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="26"/>
         <source>Upload</source>
         <translation>上传</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="34"/>
         <source>PID</source>
         <translation>进程号</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="20"/>
         <source>User</source>
         <translation>用户</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="36"/>
         <source>Nice</source>
         <translation>Nice</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="38"/>
         <source>Priority</source>
         <translation>优先级</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="23"/>
         <source>Shared memory</source>
         <translation>共享内存</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="24"/>
         <source>Virtual memory</source>
         <translation>虚拟内存</translation>
     </message>
@@ -964,34 +1221,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>不支持</translation>
     </message>
     <message>
+        <location filename="../gui/dialog/settingsdialog.cpp" line="10"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
     <message>
+        <location filename="../gui/dialog/settingsdialog.cpp" line="11"/>
         <source>System Protection</source>
         <translation>系统防护</translation>
     </message>
     <message>
+        <location filename="../gui/dialog/settingsdialog.cpp" line="12"/>
         <source>Show warnings when the usage exceeds the thresholds</source>
         <translation>当数值高于以下阈值时自动报警</translation>
     </message>
     <message>
+        <location filename="../gui/dialog/settingsdialog.cpp" line="13"/>
         <source>CPU warning threshold (%)</source>
         <translation>CPU占用 (%)</translation>
     </message>
     <message>
+        <location filename="../gui/dialog/settingsdialog.cpp" line="14"/>
         <source>Memory warning threshold (%)</source>
         <translation>内存占用 (%)</translation>
     </message>
     <message>
+        <location filename="../gui/dialog/settingsdialog.cpp" line="15"/>
         <source>Warning interval (min)</source>
         <translation>预警间隔 (分钟)</translation>
     </message>
     <message>
+        <location filename="../gui/dialog/settingsdialog.cpp" line="16"/>
         <source>Notifications</source>
         <translation>消息通知</translation>
     </message>
@@ -999,10 +1264,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>服务的启动方式设置失败</translation>
     </message>
     <message>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>错误：由于子进程崩溃，服务的启动方式设置失败</translation>
     </message>
@@ -1010,14 +1277,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>服务实例名</translation>
     </message>
     <message>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>确 定</translation>
     </message>
     <message>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>取 消</translation>
     </message>
@@ -1025,30 +1297,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>刷新</translation>
     </message>
     <message>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>启动</translation>
     </message>
     <message>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>停止</translation>
     </message>
     <message>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>重新启动</translation>
     </message>
     <message>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>自动</translation>
     </message>
     <message>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>手动</translation>
     </message>
     <message>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>设置启动方式</translation>
     </message>
@@ -1056,34 +1339,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Header</name>
     <message>
+        <location filename="../model/system_service_table_model.h" line="16"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
+        <location filename="../model/system_service_table_model.h" line="18"/>
         <source>Load</source>
         <translation>内存加载</translation>
     </message>
     <message>
+        <location filename="../model/system_service_table_model.h" line="23"/>
         <source>Sub</source>
         <translation>运行状态</translation>
     </message>
     <message>
+        <location filename="../model/system_service_table_model.h" line="30"/>
         <source>Description</source>
         <translation>描述</translation>
     </message>
     <message>
+        <location filename="../model/system_service_table_model.h" line="32"/>
         <source>PID</source>
         <translation>进程号</translation>
     </message>
     <message>
+        <location filename="../model/system_service_table_model.h" line="27"/>
         <source>Startup Type</source>
         <translation>启动方式</translation>
     </message>
     <message>
+        <location filename="../model/system_service_table_model.h" line="21"/>
         <source>Start State</source>
         <translation>启动状态</translation>
     </message>
     <message>
+        <location filename="../model/system_service_table_model.h" line="25"/>
         <source>Start Tactic</source>
         <translation>启用策略</translation>
     </message>
@@ -1091,14 +1382,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
     <message>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>（阈值可修改）</translation>
     </message>
     <message>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>数值范围：%1-%2</translation>
     </message>
@@ -1106,18 +1401,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>强制结束应用程序</translation>
     </message>
     <message>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>舒展</translation>
     </message>
     <message>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>紧凑</translation>
     </message>
     <message>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>视图</translation>
     </message>
@@ -1125,6 +1425,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>搜索</translation>
     </message>
@@ -1132,14 +1434,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>程序进程</translation>
     </message>
     <message>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>系统服务</translation>
     </message>
     <message>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>用户</translation>
     </message>
@@ -1147,6 +1460,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>修改帐户信息</translation>
     </message>
@@ -1154,10 +1468,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>管理员</translation>
     </message>
     <message>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>标准用户</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_zh_HK.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_zh_HK.ts
@@ -4,10 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>系統監視器</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>系統監視器是一個對硬件負載、程序運行和系統服務，進行監測查看和管理操作的系統工具。</translation>
     </message>
@@ -15,14 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>隱藏詳情</translation>
     </message>
     <message>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>總體利用率</translation>
     </message>
     <message>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>個體利用率</translation>
     </message>
@@ -30,10 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>讀取</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>寫入</translation>
     </message>
@@ -41,6 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60秒</translation>
     </message>
@@ -48,6 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1天%2小時%3分鐘</translation>
     </message>
@@ -55,74 +68,92 @@
 <context>
     <name>CPUSummaryTableModel</name>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="91"/>
         <source>Utilization</source>
         <translation>總利用率</translation>
     </message>
     <message>
-        <source>Current frequency</source>
-        <translation>當前頻率</translation>
+        <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
+        <source>Average frequency</source>
+        <translation>平均頻率</translation>
     </message>
     <message>
-        <source>Frequency</source>
-        <translation>頻率</translation>
+        <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
+        <source>Max frequency</source>
+        <translation>最大頻率</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
         <source>Sockets</source>
         <translation>插槽</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="106"/>
         <source>Logical processors</source>
         <translation>邏輯處理器</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="110"/>
         <source>Virtualization</source>
         <translation>虛擬化</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="112"/>
         <source>L1i cache</source>
         <translation>L1緩存（指令）</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="116"/>
         <source>L1d cache</source>
         <translation>L1緩存（數據）</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="118"/>
         <source>L2 cache</source>
         <translation>L2緩存</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="122"/>
         <source>L3 cache</source>
         <translation>L3緩存</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="124"/>
         <source>Load average</source>
         <translation>平均負載</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="128"/>
         <source>File descriptors</source>
         <translation>文件描述符數</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="130"/>
         <source>Processes</source>
         <translation>進程</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="134"/>
         <source>Threads</source>
         <translation>線程數</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="136"/>
         <source>Host name</source>
         <translation>主機名</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="140"/>
         <source>OS type</source>
         <translation>類型</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="142"/>
         <source>Version</source>
         <translation>版本</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="100"/>
         <source>Up time</source>
         <translation>運行時間</translation>
     </message>
@@ -130,6 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation>取 消</translation>
     </message>
@@ -137,6 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60秒</translation>
     </message>
@@ -144,6 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>無搜索結果</translation>
     </message>
@@ -151,6 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>詳細訊息</translation>
     </message>
@@ -158,6 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>詳細訊息</translation>
     </message>
@@ -165,26 +202,32 @@
 <context>
     <name>DBus.Unit.Active.State</name>
     <message>
+        <location filename="../dbus/dbus_common.h" line="165"/>
         <source>active</source>
         <translation>已啟動</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="167"/>
         <source>reloading</source>
         <translation>重載中</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="169"/>
         <source>inactive</source>
         <translation>未啟動</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="170"/>
         <source>failed</source>
         <translation>已失敗</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="172"/>
         <source>activating</source>
         <translation>啟動中</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="174"/>
         <source>deactivating</source>
         <translation>停止中</translation>
     </message>
@@ -192,30 +235,37 @@
 <context>
     <name>DBus.Unit.Load.State</name>
     <message>
+        <location filename="../dbus/dbus_common.h" line="146"/>
         <source>stub</source>
         <translation>佔位</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="149"/>
         <source>not-found</source>
         <translation>未找到</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="151"/>
         <source>bad-setting</source>
         <translation>無效設置</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="152"/>
         <source>error</source>
         <translation>錯誤</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="153"/>
         <source>merged</source>
         <translation>已合併</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="154"/>
         <source>masked</source>
         <translation>已屏蔽</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="147"/>
         <source>loaded</source>
         <translation>已加載</translation>
     </message>
@@ -223,14 +273,17 @@
 <context>
     <name>DBus.Unit.Startup.Mode</name>
     <message>
+        <location filename="../dbus/dbus_common.h" line="297"/>
         <source>N/A</source>
         <translation>N/A</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="295"/>
         <source>Auto</source>
         <translation>自動</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="296"/>
         <source>Manual</source>
         <translation>手動</translation>
     </message>
@@ -238,34 +291,42 @@
 <context>
     <name>DBus.Unit.State</name>
     <message>
+        <location filename="../dbus/dbus_common.h" line="274"/>
         <source>enabled</source>
         <translation>已啟用</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="275"/>
         <source>disabled</source>
         <translation>已禁用</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="276"/>
         <source>static</source>
         <translation>靜態</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="277"/>
         <source>transient</source>
         <translation>瞬態</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="278"/>
         <source>indirect</source>
         <translation>間接</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="280"/>
         <source>enabled-runtime</source>
         <translation>運行時啟用</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="281"/>
         <source>masked</source>
         <translation>已屏蔽</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="283"/>
         <source>generated</source>
         <translation>已生成</translation>
     </message>
@@ -273,66 +334,82 @@
 <context>
     <name>DBus.Unit.Sub.State</name>
     <message>
+        <location filename="../dbus/dbus_common.h" line="217"/>
         <source>dead</source>
         <translation>dead</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="219"/>
         <source>start-pre</source>
         <translation>預啟動</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="221"/>
         <source>start</source>
         <translation>啟動中</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="223"/>
         <source>start-post</source>
         <translation>start-post</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="225"/>
         <source>running</source>
         <translation>正在運行</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="227"/>
         <source>exited</source>
         <translation>已退出</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="229"/>
         <source>reload</source>
         <translation>重載中</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="231"/>
         <source>stop</source>
         <translation>已停止</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="233"/>
         <source>stop-watchdog</source>
         <translation>stop-watchdog</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="235"/>
         <source>stop-sigterm</source>
         <translation>stop-sigterm</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="237"/>
         <source>stop-sigkill</source>
         <translation>stop-sigkill</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="239"/>
         <source>stop-post</source>
         <translation>stop-post</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="241"/>
         <source>final-sigterm</source>
         <translation>final-sigterm</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="243"/>
         <source>final-sigkill</source>
         <translation>final-sigkill</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="245"/>
         <source>failed</source>
         <translation>已失敗</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="247"/>
         <source>auto-restart</source>
         <translation>自動重啟</translation>
     </message>
@@ -340,18 +417,23 @@
 <context>
     <name>DBusAlarmNotify</name>
     <message>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="39"/>
         <source>Your CPU usage is higher than %1%!</source>
         <translation>請注意！您的設備CPU佔用已達%1%！</translation>
     </message>
     <message>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="51"/>
         <source>Your memory usage is higher than %1%!</source>
         <translation>請注意！您的設備內存佔用已達%1%！</translation>
     </message>
     <message>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="71"/>
         <source>View</source>
         <translation>查看</translation>
     </message>
@@ -359,54 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>已使用</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>可用</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>共享內存</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>高速緩存</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>數據緩存</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>交換緩存區</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>活躍的緩衝文件</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>不活躍的緩衝文件</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>髒頁</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>映射大小</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>交換空間大小</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>可用交換空間</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>內核數據結構緩存</translation>
     </message>
@@ -414,58 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>型號</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>讀取速度</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>寫入速度</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>容量</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>讀扇區次數</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>每秒讀操作次數</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>每秒讀扇區次數</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>每秒合併讀操作次數</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>寫扇區次數</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>合併寫完成次數</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>每秒寫操作次數</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>每秒寫扇區次數</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>每秒合併寫操作次數</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>寫入已完成</translation>
     </message>
@@ -473,6 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
@@ -481,10 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>系統</translation>
     </message>
     <message>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>顯示快捷鍵</translation>
     </message>
@@ -492,38 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>結束進程會有丟失數據的風險。
 您確定要結束選中的進程嗎？</translation>
     </message>
     <message>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>結束進程</translation>
     </message>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>強制結束進程會有丟失數據的風險。
 您確定要結束選中的進程嗎？</translation>
     </message>
     <message>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>強制結束應用會有丟失數據的風險。
 您確定要結束選中的應用嗎？</translation>
     </message>
     <message>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>強制結束</translation>
     </message>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>結束進程</translation>
@@ -532,6 +656,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>註銷</translation>
     </message>
@@ -539,6 +664,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>設置</translation>
     </message>
@@ -546,6 +672,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>容量大小</translation>
     </message>
@@ -553,22 +680,28 @@ Are you sure you want to continue?</source>
 <context>
     <name>NetInfoDetailItemDelegate</name>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>IP位址：</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="157"/>
         <source>Netmask:</source>
         <translation>子網掩碼：</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="157"/>
         <source>Broadcast:</source>
         <translation>廣播：</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>Prefixlen:</source>
         <translation>掩碼長度：</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>Scope:</source>
         <translation>域：</translation>
     </message>
@@ -576,86 +709,109 @@ Are you sure you want to continue?</source>
 <context>
     <name>NetInfoModel</name>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="293"/>
         <source>Connection type</source>
         <translation>連接類型</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="301"/>
         <source>ESSID</source>
         <translation>伺服器別號</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="307"/>
         <source>Link quality</source>
         <translation>信號質量</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="312"/>
         <source>Signal strength</source>
         <translation>信號強度</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="317"/>
         <source>Noise level</source>
         <translation>底噪</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="323"/>
         <source>MAC</source>
         <translation>MAC</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="328"/>
         <source>Bandwidth</source>
         <translation>速率</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="333"/>
         <source>RX packets</source>
         <translation>接收包數量</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="338"/>
         <source>RX bytes</source>
         <translation>總計接收</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="343"/>
         <source>RX errors</source>
         <translation>接收（錯誤包）</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="348"/>
         <source>RX dropped</source>
         <translation>接收（丟棄包）</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="353"/>
         <source>RX overruns</source>
         <translation>接收FIFO</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="358"/>
         <source>RX frame</source>
         <translation>分組幀錯誤</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="363"/>
         <source>TX packets</source>
         <translation>發送包數量</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="368"/>
         <source>TX bytes</source>
         <translation>總計發送</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="373"/>
         <source>TX errors</source>
         <translation>發送（錯誤包）</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="383"/>
         <source>TX overruns</source>
         <translation>發送FIFO</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="388"/>
         <source>TX carrier</source>
         <translation>載波損耗</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>IPv4</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>IPv6</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="378"/>
         <source>TX dropped</source>
         <translation>發送（丟棄包）</translation>
     </message>
@@ -663,14 +819,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>命令行</translation>
     </message>
     <message>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>啟動時間</translation>
     </message>
     <message>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>名稱</translation>
     </message>
@@ -678,6 +837,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>點擊您想結束的應用程序</translation>
     </message>
@@ -685,10 +845,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>內存</translation>
     </message>
     <message>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>接收</translation>
     </message>
@@ -696,54 +862,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>處理器</translation>
     </message>
     <message>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>磁盤讀取</translation>
     </message>
     <message>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>磁盤寫入</translation>
     </message>
     <message>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>內存</translation>
     </message>
     <message>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>交換空間</translation>
     </message>
     <message>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>未啟用</translation>
     </message>
     <message>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>正在接收</translation>
     </message>
     <message>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>正在發送</translation>
     </message>
     <message>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>網絡</translation>
     </message>
     <message>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>總計接收</translation>
     </message>
     <message>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>總計發送</translation>
     </message>
     <message>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>發送</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>磁盤</translation>
     </message>
@@ -751,6 +948,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Loading</name>
     <message>
+        <location filename="../gui/process_page_widget.cpp" line="67"/>
         <source>Loading</source>
         <translation>正在加載</translation>
     </message>
@@ -758,38 +956,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>非常高</translation>
     </message>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>高</translation>
     </message>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>普通</translation>
     </message>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>低</translation>
     </message>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>非常低</translation>
     </message>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>自定義</translation>
     </message>
     <message>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>無效</translation>
     </message>
     <message>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>進程號: %1, Error: [%2] %3</translation>
     </message>
     <message>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>改變進程優先級失敗</translation>
     </message>
@@ -797,14 +1011,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Show.Mode</name>
     <message>
+        <location filename="../gui/process_page_widget.cpp" line="61"/>
         <source>Applications</source>
         <translation>應用程序</translation>
     </message>
     <message>
+        <location filename="../gui/process_page_widget.cpp" line="63"/>
         <source>My processes</source>
         <translation>我的進程</translation>
     </message>
     <message>
+        <location filename="../gui/process_page_widget.cpp" line="65"/>
         <source>All processes</source>
         <translation>所有進程</translation>
     </message>
@@ -812,26 +1029,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>暫停進程失敗</translation>
     </message>
     <message>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>恢復進程失敗</translation>
     </message>
     <message>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>強制結束進程失敗</translation>
     </message>
     <message>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>未知錯誤</translation>
     </message>
     <message>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>發送信號到進程失敗</translation>
     </message>
     <message>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>結束進程失敗</translation>
     </message>
@@ -839,6 +1062,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Summary</name>
     <message>
+        <location filename="../gui/process_page_widget.cpp" line="58"/>
         <source>(%1 applications and %2 processes are running)</source>
         <translation>（正在運行%1個應用程序和%2個系統進程）</translation>
     </message>
@@ -846,14 +1070,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>無響應</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>暫停</translation>
     </message>
     <message>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>托盤</translation>
     </message>
@@ -861,30 +1090,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>查看命令所在位置</translation>
     </message>
     <message>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>屬性</translation>
     </message>
     <message>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>結束進程</translation>
     </message>
     <message>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>繼續進程</translation>
     </message>
     <message>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>強制結束進程</translation>
     </message>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>改變優先級</translation>
     </message>
     <message>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>暫停進程</translation>
     </message>
@@ -892,15 +1133,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>自定義優先級</translation>
     </message>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>更 改</translation>
@@ -909,54 +1153,67 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Header</name>
     <message>
+        <location filename="../model/process_table_model.h" line="16"/>
         <source>Name</source>
         <translation>名稱</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="18"/>
         <source>CPU</source>
         <translation>處理器</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="22"/>
         <source>Memory</source>
         <translation>內存</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="32"/>
         <source>Disk write</source>
         <translation>磁盤寫入</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="30"/>
         <source>Disk read</source>
         <translation>磁盤讀取</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="28"/>
         <source>Download</source>
         <translation>正在接收</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="26"/>
         <source>Upload</source>
         <translation>正在發送</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="34"/>
         <source>PID</source>
         <translation>進程號</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="20"/>
         <source>User</source>
         <translation>用戶</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="36"/>
         <source>Nice</source>
         <translation>Nice</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="38"/>
         <source>Priority</source>
         <translation>優先級</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="23"/>
         <source>Shared memory</source>
         <translation>共享內存</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="24"/>
         <source>Virtual memory</source>
         <translation>虛擬內存</translation>
     </message>
@@ -964,34 +1221,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>不支持</translation>
     </message>
     <message>
+        <location filename="../gui/dialog/settingsdialog.cpp" line="10"/>
         <source>Settings</source>
         <translation>設置</translation>
     </message>
     <message>
+        <location filename="../gui/dialog/settingsdialog.cpp" line="11"/>
         <source>System Protection</source>
         <translation>系統防護</translation>
     </message>
     <message>
+        <location filename="../gui/dialog/settingsdialog.cpp" line="12"/>
         <source>Show warnings when the usage exceeds the thresholds</source>
         <translation>當數值高於以下閾值時自動報警</translation>
     </message>
     <message>
+        <location filename="../gui/dialog/settingsdialog.cpp" line="13"/>
         <source>CPU warning threshold (%)</source>
         <translation>CPU佔用 (%)</translation>
     </message>
     <message>
+        <location filename="../gui/dialog/settingsdialog.cpp" line="14"/>
         <source>Memory warning threshold (%)</source>
         <translation>內存佔用 (%)</translation>
     </message>
     <message>
+        <location filename="../gui/dialog/settingsdialog.cpp" line="15"/>
         <source>Warning interval (min)</source>
         <translation>預警間隔 (分鐘)</translation>
     </message>
     <message>
+        <location filename="../gui/dialog/settingsdialog.cpp" line="16"/>
         <source>Notifications</source>
         <translation>消息通知</translation>
     </message>
@@ -999,10 +1264,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>服務的啟動方式設置失敗</translation>
     </message>
     <message>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>錯誤：由於子進程崩潰，服務的啟動方式設置失敗</translation>
     </message>
@@ -1010,14 +1277,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>服務實例名</translation>
     </message>
     <message>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>確 定</translation>
     </message>
     <message>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>取 消</translation>
     </message>
@@ -1025,30 +1297,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>刷新</translation>
     </message>
     <message>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>啟動</translation>
     </message>
     <message>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>停止</translation>
     </message>
     <message>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>重新啟動</translation>
     </message>
     <message>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>自動</translation>
     </message>
     <message>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>手動</translation>
     </message>
     <message>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>設置啟動方式</translation>
     </message>
@@ -1056,34 +1339,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Header</name>
     <message>
+        <location filename="../model/system_service_table_model.h" line="16"/>
         <source>Name</source>
         <translation>名稱</translation>
     </message>
     <message>
+        <location filename="../model/system_service_table_model.h" line="18"/>
         <source>Load</source>
         <translation>內存加載</translation>
     </message>
     <message>
+        <location filename="../model/system_service_table_model.h" line="23"/>
         <source>Sub</source>
         <translation>運行狀態</translation>
     </message>
     <message>
+        <location filename="../model/system_service_table_model.h" line="30"/>
         <source>Description</source>
         <translation>描述</translation>
     </message>
     <message>
+        <location filename="../model/system_service_table_model.h" line="32"/>
         <source>PID</source>
         <translation>進程號</translation>
     </message>
     <message>
+        <location filename="../model/system_service_table_model.h" line="27"/>
         <source>Startup Type</source>
         <translation>啟動方式</translation>
     </message>
     <message>
+        <location filename="../model/system_service_table_model.h" line="21"/>
         <source>Start State</source>
         <translation>啓動狀態</translation>
     </message>
     <message>
+        <location filename="../model/system_service_table_model.h" line="25"/>
         <source>Start Tactic</source>
         <translation>啓用策略</translation>
     </message>
@@ -1091,14 +1382,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>設置</translation>
     </message>
     <message>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>（閾值可修改）</translation>
     </message>
     <message>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>數值範圍：%1-%2</translation>
     </message>
@@ -1106,18 +1401,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>強制結束應用程序</translation>
     </message>
     <message>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>舒展</translation>
     </message>
     <message>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>緊湊</translation>
     </message>
     <message>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>查看</translation>
     </message>
@@ -1125,6 +1425,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>搜索</translation>
     </message>
@@ -1132,14 +1434,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>進程</translation>
     </message>
     <message>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>系統服務</translation>
     </message>
     <message>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>用戶</translation>
     </message>
@@ -1147,6 +1460,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>修改帳戶訊息</translation>
     </message>
@@ -1154,10 +1468,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>管理員</translation>
     </message>
     <message>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>標準用戶</translation>
     </message>

--- a/deepin-system-monitor-main/translations/deepin-system-monitor_zh_TW.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_zh_TW.ts
@@ -4,10 +4,13 @@
 <context>
     <name>App.About</name>
     <message>
+        <location filename="../main.cpp" line="101"/>
+        <location filename="../main.cpp" line="105"/>
         <source>System Monitor</source>
         <translation>系統監視器</translation>
     </message>
     <message>
+        <location filename="../main.cpp" line="91"/>
         <source>System Monitor is a tool to monitor realtime system load, view and control processes and services running on your system.</source>
         <translation>系統監視器是一個對硬體負載、程式執行和系統服務，進行監測查看和管理操作的系統工具。</translation>
     </message>
@@ -15,14 +18,19 @@
 <context>
     <name>BaseDetailViewWidget</name>
     <message>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="29"/>
         <source>Hide details</source>
         <translation>隱藏詳情</translation>
     </message>
     <message>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="40"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="52"/>
         <source>Overall utilization</source>
         <translation>總體利用率</translation>
     </message>
     <message>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="43"/>
+        <location filename="../gui/base/base_detail_view_widget.cpp" line="54"/>
         <source>Individual utilization</source>
         <translation>個體利用率</translation>
     </message>
@@ -30,10 +38,12 @@
 <context>
     <name>BlockDevItemWidget</name>
     <message>
+        <location filename="../gui/block_dev_item_widget.cpp" line="154"/>
         <source>Read</source>
         <translation>讀取</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_item_widget.cpp" line="158"/>
         <source>Write</source>
         <translation>寫入</translation>
     </message>
@@ -41,6 +51,8 @@
 <context>
     <name>CPUDetailGrapTableItem</name>
     <message>
+        <location filename="../gui/cpu_detail_widget.cpp" line="168"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="285"/>
         <source>60 seconds</source>
         <translation>60秒</translation>
     </message>
@@ -48,6 +60,7 @@
 <context>
     <name>CPUInfoModel</name>
     <message>
+        <location filename="../model/cpu_info_model.cpp" line="49"/>
         <source>%1 days %2 hours %3 minutes</source>
         <translation>%1天%2小時%3分鐘</translation>
     </message>
@@ -55,74 +68,92 @@
 <context>
     <name>CPUSummaryTableModel</name>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="91"/>
         <source>Utilization</source>
         <translation>總利用率</translation>
     </message>
     <message>
-        <source>Current frequency</source>
-        <translation>目前頻率</translation>
+        <location filename="../gui/cpu_summary_view_widget.h" line="93"/>
+        <source>Average frequency</source>
+        <translation>平均頻率</translation>
     </message>
     <message>
-        <source>Frequency</source>
-        <translation>頻率</translation>
+        <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
+        <source>Max frequency</source>
+        <translation>最大頻率</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="104"/>
         <source>Sockets</source>
         <translation>插槽</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="106"/>
         <source>Logical processors</source>
         <translation>邏輯處理器</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="110"/>
         <source>Virtualization</source>
         <translation>虛擬化</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="112"/>
         <source>L1i cache</source>
         <translation>L1快取（指令）</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="116"/>
         <source>L1d cache</source>
         <translation>L1快取（資料）</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="118"/>
         <source>L2 cache</source>
         <translation>L2快取</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="122"/>
         <source>L3 cache</source>
         <translation>L3快取</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="124"/>
         <source>Load average</source>
         <translation>平均負載</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="128"/>
         <source>File descriptors</source>
         <translation>文件描述符數</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="130"/>
         <source>Processes</source>
         <translation>進程</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="134"/>
         <source>Threads</source>
         <translation>執行緒數</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="136"/>
         <source>Host name</source>
         <translation>主機名稱</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="140"/>
         <source>OS type</source>
         <translation>類型</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="142"/>
         <source>Version</source>
         <translation>版本</translation>
     </message>
     <message>
+        <location filename="../gui/cpu_summary_view_widget.h" line="100"/>
         <source>Up time</source>
         <translation>執行時間</translation>
     </message>
@@ -130,6 +161,7 @@
 <context>
     <name>Cancel</name>
     <message>
+        <location filename="../gui/accounts_widget.cpp" line="310"/>
         <source>Cancel</source>
         <translation>取 消</translation>
     </message>
@@ -137,6 +169,7 @@
 <context>
     <name>ChartViewWidget</name>
     <message>
+        <location filename="../gui/chart_view_widget.cpp" line="321"/>
         <source>60 seconds</source>
         <translation>60秒</translation>
     </message>
@@ -144,6 +177,8 @@
 <context>
     <name>Common.Search</name>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="493"/>
+        <location filename="../gui/system_service_table_view.cpp" line="476"/>
         <source>No search results</source>
         <translation>無搜尋結果</translation>
     </message>
@@ -151,6 +186,7 @@
 <context>
     <name>CompactCpuMonitor</name>
     <message>
+        <location filename="../compact_cpu_monitor.cpp" line="89"/>
         <source>Details</source>
         <translation>詳細訊息</translation>
     </message>
@@ -158,6 +194,7 @@
 <context>
     <name>CpuMonitor</name>
     <message>
+        <location filename="../cpu_monitor.cpp" line="72"/>
         <source>Details</source>
         <translation>詳細訊息</translation>
     </message>
@@ -165,26 +202,32 @@
 <context>
     <name>DBus.Unit.Active.State</name>
     <message>
+        <location filename="../dbus/dbus_common.h" line="165"/>
         <source>active</source>
         <translation>已啟動</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="167"/>
         <source>reloading</source>
         <translation>重載中</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="169"/>
         <source>inactive</source>
         <translation>未啟動</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="170"/>
         <source>failed</source>
         <translation>已失敗</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="172"/>
         <source>activating</source>
         <translation>啟動中</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="174"/>
         <source>deactivating</source>
         <translation>停止中</translation>
     </message>
@@ -192,30 +235,37 @@
 <context>
     <name>DBus.Unit.Load.State</name>
     <message>
+        <location filename="../dbus/dbus_common.h" line="146"/>
         <source>stub</source>
         <translation>stub</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="149"/>
         <source>not-found</source>
         <translation>未找到</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="151"/>
         <source>bad-setting</source>
         <translation>無效設定</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="152"/>
         <source>error</source>
         <translation>錯誤</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="153"/>
         <source>merged</source>
         <translation>已合併</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="154"/>
         <source>masked</source>
         <translation>已封鎖</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="147"/>
         <source>loaded</source>
         <translation>已載入</translation>
     </message>
@@ -223,14 +273,17 @@
 <context>
     <name>DBus.Unit.Startup.Mode</name>
     <message>
+        <location filename="../dbus/dbus_common.h" line="297"/>
         <source>N/A</source>
         <translation>N/A</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="295"/>
         <source>Auto</source>
         <translation>自動</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="296"/>
         <source>Manual</source>
         <translation>手動</translation>
     </message>
@@ -238,34 +291,42 @@
 <context>
     <name>DBus.Unit.State</name>
     <message>
+        <location filename="../dbus/dbus_common.h" line="274"/>
         <source>enabled</source>
         <translation>已啟用</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="275"/>
         <source>disabled</source>
         <translation>已禁用</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="276"/>
         <source>static</source>
         <translation>静态</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="277"/>
         <source>transient</source>
         <translation>瞬態</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="278"/>
         <source>indirect</source>
         <translation>間接</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="280"/>
         <source>enabled-runtime</source>
         <translation>執行時啟用</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="281"/>
         <source>masked</source>
         <translation>已封鎖</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="283"/>
         <source>generated</source>
         <translation>已生成</translation>
     </message>
@@ -273,66 +334,82 @@
 <context>
     <name>DBus.Unit.Sub.State</name>
     <message>
+        <location filename="../dbus/dbus_common.h" line="217"/>
         <source>dead</source>
         <translation>dead</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="219"/>
         <source>start-pre</source>
         <translation>預啟動</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="221"/>
         <source>start</source>
         <translation>啟動中</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="223"/>
         <source>start-post</source>
         <translation>start-post</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="225"/>
         <source>running</source>
         <translation>正在執行</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="227"/>
         <source>exited</source>
         <translation>已退出</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="229"/>
         <source>reload</source>
         <translation>重載中</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="231"/>
         <source>stop</source>
         <translation>已停止</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="233"/>
         <source>stop-watchdog</source>
         <translation>stop-watchdog</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="235"/>
         <source>stop-sigterm</source>
         <translation>stop-sigterm</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="237"/>
         <source>stop-sigkill</source>
         <translation>stop-sigkill</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="239"/>
         <source>stop-post</source>
         <translation>stop-post</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="241"/>
         <source>final-sigterm</source>
         <translation>final-sigterm</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="243"/>
         <source>final-sigkill</source>
         <translation>final-sigkill</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="245"/>
         <source>failed</source>
         <translation>已失敗</translation>
     </message>
     <message>
+        <location filename="../dbus/dbus_common.h" line="247"/>
         <source>auto-restart</source>
         <translation>自動重啟</translation>
     </message>
@@ -340,18 +417,23 @@
 <context>
     <name>DBusAlarmNotify</name>
     <message>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="38"/>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="50"/>
         <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="39"/>
         <source>Your CPU usage is higher than %1%!</source>
         <translation>請注意！您的裝置CPU佔用已達%1%！</translation>
     </message>
     <message>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="51"/>
         <source>Your memory usage is higher than %1%!</source>
         <translation>請注意！您的裝置記憶體佔用已達%1%！</translation>
     </message>
     <message>
+        <location filename="../dbus/dbusalarmnotify.cpp" line="71"/>
         <source>View</source>
         <translation>檢視</translation>
     </message>
@@ -359,54 +441,67 @@
 <context>
     <name>DeailTableModel</name>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="67"/>
         <source>Used</source>
         <translation>已使用</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="69"/>
         <source>Available</source>
         <translation>可用</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="73"/>
         <source>Shared</source>
         <translation>共享記憶體</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="75"/>
         <source>Cached</source>
         <translation>快取記憶體</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="79"/>
         <source>Buffers</source>
         <translation>資料快取</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="81"/>
         <source>Cached swap</source>
         <translation>交換快取區</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="85"/>
         <source>Active</source>
         <translation>活躍的緩衝文件</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="87"/>
         <source>Inactive</source>
         <translation>不活躍的緩衝文件</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="91"/>
         <source>Dirty</source>
         <translation>髒頁</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="93"/>
         <source>Mapped</source>
         <translation>映射大小</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="97"/>
         <source>Total swap</source>
         <translation>交換空間大小</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="99"/>
         <source>Free swap</source>
         <translation>可用交換空間</translation>
     </message>
     <message>
+        <location filename="../gui/mem_summary_view_widget.cpp" line="103"/>
         <source>Slab</source>
         <translation>核心資料結構快取</translation>
     </message>
@@ -414,58 +509,72 @@
 <context>
     <name>DeailTableModelBlock</name>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="70"/>
         <source>Model</source>
         <translation>型號</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="72"/>
         <source>Read speed</source>
         <translation>讀取速度</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="76"/>
         <source>Write speed</source>
         <translation>寫入速度</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="78"/>
         <source>Capacity</source>
         <translation>容量</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="82"/>
         <source>Sectors read</source>
         <translation>讀扇區次數</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="84"/>
         <source>Reads/s</source>
         <translation>每秒讀操作次數</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="88"/>
         <source>Sectors read/s</source>
         <translation>每秒讀扇區次數</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="90"/>
         <source>Reads merged/s</source>
         <translation>每秒合併讀操作次數</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="94"/>
         <source>Sectors written</source>
         <translation>寫扇區次數</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="100"/>
         <source>Writes merged</source>
         <translation>合併寫完成次數</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="102"/>
         <source>Writes/s</source>
         <translation>每秒寫操作次數</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="106"/>
         <source>Sectors written/s</source>
         <translation>每秒寫扇區次數</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="108"/>
         <source>Writes merged/s</source>
         <translation>每秒合併寫操作次數</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_summary_view_widget.cpp" line="96"/>
         <source>Writes completed </source>
         <translation>寫入已完成</translation>
     </message>
@@ -473,6 +582,7 @@
 <context>
     <name>Error.Dialog</name>
     <message>
+        <location filename="../gui/dialog/error_dialog.cpp" line="73"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
@@ -481,10 +591,12 @@
 <context>
     <name>Help.Shortcut.System</name>
     <message>
+        <location filename="../common/common.cpp" line="32"/>
         <source>System</source>
         <translation>系統</translation>
     </message>
     <message>
+        <location filename="../common/common.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>顯示快捷鍵</translation>
     </message>
@@ -492,38 +604,50 @@
 <context>
     <name>Kill.Process.Dialog</name>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="173"/>
         <source>Ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>結束此進程可能導致資料遺失。
 確定繼續？</translation>
     </message>
     <message>
+        <location filename="../gui/process_page_widget.cpp" line="530"/>
+        <location filename="../gui/process_table_view.cpp" line="172"/>
+        <location filename="../gui/process_table_view.cpp" line="379"/>
         <source>End process</source>
         <translation>結束進程</translation>
     </message>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="380"/>
         <source>Force ending this process may cause data loss.
 Are you sure you want to continue?</source>
         <translation>強制結束此進程可能導致資料遺失。
 確定繼續？</translation>
     </message>
     <message>
+        <location filename="../gui/process_page_widget.cpp" line="531"/>
         <source>Force ending this application may cause data loss.
 Are you sure you want to continue?</source>
         <translation>強制結束此應用程式可能導致資料遺失。
 確定繼續？</translation>
     </message>
     <message>
+        <location filename="../gui/process_page_widget.cpp" line="539"/>
+        <location filename="../gui/process_table_view.cpp" line="179"/>
+        <location filename="../gui/process_table_view.cpp" line="387"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
+        <location filename="../gui/process_page_widget.cpp" line="540"/>
+        <location filename="../gui/process_table_view.cpp" line="388"/>
         <source>Force End</source>
         <comment>button</comment>
         <translation>強制結束</translation>
     </message>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="180"/>
         <source>End</source>
         <comment>button</comment>
         <translation>結束進程</translation>
@@ -532,6 +656,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Logout</name>
     <message>
+        <location filename="../gui/accounts_widget.cpp" line="311"/>
         <source>Logout</source>
         <translation>註銷</translation>
     </message>
@@ -539,6 +664,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MainWindow</name>
     <message>
+        <location filename="../gui/main_window.cpp" line="181"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
@@ -546,6 +672,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemStatViewWidget</name>
     <message>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="52"/>
         <source>Size</source>
         <translation>容量大小</translation>
     </message>
@@ -553,22 +680,28 @@ Are you sure you want to continue?</source>
 <context>
     <name>NetInfoDetailItemDelegate</name>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="157"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>IP address:</source>
         <translation>IP位址：</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="157"/>
         <source>Netmask:</source>
         <translation>子網掩碼：</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="157"/>
         <source>Broadcast:</source>
         <translation>廣播：</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>Prefixlen:</source>
         <translation>掩碼長度：</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="159"/>
         <source>Scope:</source>
         <translation>域：</translation>
     </message>
@@ -576,86 +709,109 @@ Are you sure you want to continue?</source>
 <context>
     <name>NetInfoModel</name>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="293"/>
         <source>Connection type</source>
         <translation>連接類型</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="301"/>
         <source>ESSID</source>
         <translation>伺服器別號</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="307"/>
         <source>Link quality</source>
         <translation>訊號質量</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="312"/>
         <source>Signal strength</source>
         <translation>訊號強度</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="317"/>
         <source>Noise level</source>
         <translation>底噪</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="323"/>
         <source>MAC</source>
         <translation>MAC</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="328"/>
         <source>Bandwidth</source>
         <translation>速率</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="333"/>
         <source>RX packets</source>
         <translation>接收包數量</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="338"/>
         <source>RX bytes</source>
         <translation>總計接收</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="343"/>
         <source>RX errors</source>
         <translation>接收（錯誤包）</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="348"/>
         <source>RX dropped</source>
         <translation>接收（丟棄包）</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="353"/>
         <source>RX overruns</source>
         <translation>接收FIFO</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="358"/>
         <source>RX frame</source>
         <translation>分組幀錯誤</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="363"/>
         <source>TX packets</source>
         <translation>發送包數量</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="368"/>
         <source>TX bytes</source>
         <translation>總計發送</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="373"/>
         <source>TX errors</source>
         <translation>發送（錯誤包）</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="383"/>
         <source>TX overruns</source>
         <translation>發送FIFO</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="388"/>
         <source>TX carrier</source>
         <translation>載波損耗</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="267"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="269"/>
         <source>IPv4</source>
         <translation>IPv4</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="282"/>
+        <location filename="../gui/netif_summary_view_widget.h" line="284"/>
         <source>IPv6</source>
         <translation>IPv6</translation>
     </message>
     <message>
+        <location filename="../gui/netif_summary_view_widget.h" line="378"/>
         <source>TX dropped</source>
         <translation>發送（丟棄包）</translation>
     </message>
@@ -663,14 +819,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Attributes.Dialog</name>
     <message>
+        <location filename="../gui/process_attribute_dialog.cpp" line="143"/>
         <source>Command line</source>
         <translation>命令列</translation>
     </message>
     <message>
+        <location filename="../gui/process_attribute_dialog.cpp" line="148"/>
         <source>Start time</source>
         <translation>啟動時間</translation>
     </message>
     <message>
+        <location filename="../gui/process_attribute_dialog.cpp" line="138"/>
         <source>Name</source>
         <translation>名稱</translation>
     </message>
@@ -678,6 +837,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Choose.Window.Dialog</name>
     <message>
+        <location filename="../gui/xwin_kill_preview_background_widget.cpp" line="152"/>
         <source>Click the application you want to end</source>
         <translation>點擊欲結束的應用程式</translation>
     </message>
@@ -685,10 +845,16 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.Title</name>
     <message>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="183"/>
+        <location filename="../gui/mem_detail_view_widget.cpp" line="25"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="107"/>
+        <location filename="../memory_monitor.cpp" line="177"/>
         <source>Memory</source>
         <translation>記憶體</translation>
     </message>
     <message>
+        <location filename="../gui/netif_item_view_widget.cpp" line="95"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="121"/>
         <source>Receive</source>
         <translation>接收</translation>
     </message>
@@ -696,54 +862,85 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Graph.View</name>
     <message>
+        <location filename="../compact_cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="233"/>
+        <location filename="../cpu_monitor.cpp" line="242"/>
+        <location filename="../gui/cpu_detail_widget.cpp" line="371"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="182"/>
         <source>CPU</source>
         <translation>處理器</translation>
     </message>
     <message>
+        <location filename="../compact_disk_monitor.cpp" line="153"/>
         <source>Disk read</source>
         <translation>磁碟讀取</translation>
     </message>
     <message>
+        <location filename="../compact_disk_monitor.cpp" line="154"/>
         <source>Disk write</source>
         <translation>磁碟寫入</translation>
     </message>
     <message>
+        <location filename="../compact_memory_monitor.cpp" line="191"/>
+        <location filename="../memory_monitor.cpp" line="203"/>
         <source>Memory</source>
         <translation>記憶體</translation>
     </message>
     <message>
+        <location filename="../compact_memory_monitor.cpp" line="203"/>
+        <location filename="../compact_memory_monitor.cpp" line="210"/>
+        <location filename="../gui/mem_stat_view_widget.cpp" line="115"/>
+        <location filename="../memory_monitor.cpp" line="214"/>
+        <location filename="../memory_monitor.cpp" line="221"/>
         <source>Swap</source>
         <translation>交換空間</translation>
     </message>
     <message>
+        <location filename="../compact_memory_monitor.cpp" line="204"/>
+        <location filename="../memory_monitor.cpp" line="215"/>
         <source>Not enabled</source>
         <translation>停用</translation>
     </message>
     <message>
+        <location filename="../compact_network_monitor.cpp" line="158"/>
+        <location filename="../network_monitor.cpp" line="216"/>
         <source>Download</source>
         <translation>正在接收</translation>
     </message>
     <message>
+        <location filename="../compact_network_monitor.cpp" line="163"/>
+        <location filename="../network_monitor.cpp" line="221"/>
         <source>Upload</source>
         <translation>正在發送</translation>
     </message>
     <message>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="184"/>
+        <location filename="../gui/netif_detail_view_widget.cpp" line="28"/>
+        <location filename="../network_monitor.cpp" line="198"/>
         <source>Network</source>
         <translation>網路</translation>
     </message>
     <message>
+        <location filename="../compact_network_monitor.cpp" line="160"/>
+        <location filename="../network_monitor.cpp" line="218"/>
         <source>Total Received</source>
         <translation>總計接收</translation>
     </message>
     <message>
+        <location filename="../compact_network_monitor.cpp" line="165"/>
+        <location filename="../network_monitor.cpp" line="223"/>
         <source>Total Sent</source>
         <translation>總計發送</translation>
     </message>
     <message>
+        <location filename="../gui/netif_item_view_widget.cpp" line="104"/>
+        <location filename="../gui/netif_item_view_widget.cpp" line="130"/>
         <source>Send</source>
         <translation>發送</translation>
     </message>
     <message>
+        <location filename="../gui/block_dev_detail_view_widget.cpp" line="21"/>
+        <location filename="../gui/detail_view_stacked_widget.cpp" line="185"/>
         <source>Disks</source>
         <translation>磁碟</translation>
     </message>
@@ -751,6 +948,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Loading</name>
     <message>
+        <location filename="../gui/process_page_widget.cpp" line="67"/>
         <source>Loading</source>
         <translation>正在載入</translation>
     </message>
@@ -758,38 +956,54 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Priority</name>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="633"/>
+        <location filename="../process/process.cpp" line="55"/>
         <source>Very high</source>
         <translation>非常高</translation>
     </message>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="641"/>
+        <location filename="../process/process.cpp" line="56"/>
         <source>High</source>
         <translation>高</translation>
     </message>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="649"/>
+        <location filename="../process/process.cpp" line="57"/>
         <source>Normal</source>
         <translation>普通</translation>
     </message>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="657"/>
+        <location filename="../process/process.cpp" line="58"/>
         <source>Low</source>
         <translation>低</translation>
     </message>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="665"/>
+        <location filename="../process/process.cpp" line="59"/>
         <source>Very low</source>
         <translation>非常低</translation>
     </message>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="673"/>
+        <location filename="../process/process.cpp" line="60"/>
         <source>Custom</source>
         <translation>自訂</translation>
     </message>
     <message>
+        <location filename="../process/process.cpp" line="61"/>
         <source>Invalid</source>
         <translation>無效</translation>
     </message>
     <message>
+        <location filename="../process/process_db.cpp" line="199"/>
         <source>PID: %1, Error: [%2] %3</source>
         <translation>進程號: %1, Error: [%2] %3</translation>
     </message>
     <message>
+        <location filename="../process/process_db.cpp" line="156"/>
+        <location filename="../process/process_db.cpp" line="196"/>
         <source>Failed to change process priority</source>
         <translation>改變進程優先度失敗</translation>
     </message>
@@ -797,14 +1011,17 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Show.Mode</name>
     <message>
+        <location filename="../gui/process_page_widget.cpp" line="61"/>
         <source>Applications</source>
         <translation>應用程式</translation>
     </message>
     <message>
+        <location filename="../gui/process_page_widget.cpp" line="63"/>
         <source>My processes</source>
         <translation>我的進程</translation>
     </message>
     <message>
+        <location filename="../gui/process_page_widget.cpp" line="65"/>
         <source>All processes</source>
         <translation>所有進程</translation>
     </message>
@@ -812,26 +1029,32 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Signal</name>
     <message>
+        <location filename="../process/process_db.cpp" line="267"/>
         <source>Failed to pause process</source>
         <translation>暫停進程失敗</translation>
     </message>
     <message>
+        <location filename="../process/process_db.cpp" line="270"/>
         <source>Failed to resume process</source>
         <translation>繼續進程失敗</translation>
     </message>
     <message>
+        <location filename="../process/process_db.cpp" line="273"/>
         <source>Failed to kill process</source>
         <translation>強制結束進程失敗</translation>
     </message>
     <message>
+        <location filename="../process/process_db.cpp" line="276"/>
         <source>Unknown error</source>
         <translation>未知錯誤</translation>
     </message>
     <message>
+        <location filename="../process/process_db.cpp" line="337"/>
         <source>Failed in sending signal to process</source>
         <translation>發送訊號到進程失敗</translation>
     </message>
     <message>
+        <location filename="../process/process_db.cpp" line="264"/>
         <source>Failed to end process</source>
         <translation>結束進程失敗</translation>
     </message>
@@ -839,6 +1062,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Summary</name>
     <message>
+        <location filename="../gui/process_page_widget.cpp" line="58"/>
         <source>(%1 applications and %2 processes are running)</source>
         <translation>（正在執行 %1 個應用程式以及 %2 個進程）</translation>
     </message>
@@ -846,14 +1070,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table</name>
     <message>
+        <location filename="../model/process_table_model.cpp" line="269"/>
         <source>No response</source>
         <translation>沒有回應</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.cpp" line="275"/>
         <source>Suspend</source>
         <translation>暫停</translation>
     </message>
     <message>
+        <location filename="../process/process_name.cpp" line="90"/>
+        <location filename="../process/process_name.cpp" line="99"/>
+        <location filename="../process/process_name.cpp" line="104"/>
         <source>Tray</source>
         <translation>系統匣</translation>
     </message>
@@ -861,30 +1090,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Context.Menu</name>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="680"/>
         <source>View command location</source>
         <translation>開啟程式位置</translation>
     </message>
     <message>
+        <location filename="../common/common.cpp" line="83"/>
+        <location filename="../gui/process_table_view.cpp" line="684"/>
         <source>Properties</source>
         <translation>屬性</translation>
     </message>
     <message>
+        <location filename="../common/common.cpp" line="66"/>
+        <location filename="../gui/process_table_view.cpp" line="608"/>
         <source>End process</source>
         <translation>結束進程</translation>
     </message>
     <message>
+        <location filename="../common/common.cpp" line="78"/>
+        <location filename="../gui/process_table_view.cpp" line="620"/>
         <source>Resume process</source>
         <translation>繼續進程</translation>
     </message>
     <message>
+        <location filename="../common/common.cpp" line="89"/>
+        <location filename="../gui/process_table_view.cpp" line="691"/>
         <source>Kill process</source>
         <translation>強制結束進程</translation>
     </message>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="627"/>
         <source>Change priority</source>
         <translation>改變優先度</translation>
     </message>
     <message>
+        <location filename="../common/common.cpp" line="72"/>
+        <location filename="../gui/process_table_view.cpp" line="614"/>
         <source>Suspend process</source>
         <translation>暫停進程</translation>
     </message>
@@ -892,15 +1133,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Custom.Priority.Dialog</name>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="1052"/>
         <source>Custom Priority</source>
         <translation>自訂優先度</translation>
     </message>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="1085"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
+        <location filename="../gui/process_table_view.cpp" line="1087"/>
         <source>Change</source>
         <comment>button</comment>
         <translation>更 改</translation>
@@ -909,54 +1153,67 @@ Are you sure you want to continue?</source>
 <context>
     <name>Process.Table.Header</name>
     <message>
+        <location filename="../model/process_table_model.h" line="16"/>
         <source>Name</source>
         <translation>名稱</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="18"/>
         <source>CPU</source>
         <translation>處理器</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="22"/>
         <source>Memory</source>
         <translation>記憶體</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="32"/>
         <source>Disk write</source>
         <translation>磁碟寫入</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="30"/>
         <source>Disk read</source>
         <translation>磁碟讀取</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="28"/>
         <source>Download</source>
         <translation>正在接收</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="26"/>
         <source>Upload</source>
         <translation>正在發送</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="34"/>
         <source>PID</source>
         <translation>進程號</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="20"/>
         <source>User</source>
         <translation>使用者</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="36"/>
         <source>Nice</source>
         <translation>Nice</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="38"/>
         <source>Priority</source>
         <translation>優先度</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="23"/>
         <source>Shared memory</source>
         <translation>共享記憶體</translation>
     </message>
     <message>
+        <location filename="../model/process_table_model.h" line="24"/>
         <source>Virtual memory</source>
         <translation>虛擬記憶體</translation>
     </message>
@@ -964,34 +1221,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../system/cpu_set.cpp" line="426"/>
         <source>Not support</source>
         <translation>不支援</translation>
     </message>
     <message>
+        <location filename="../gui/dialog/settingsdialog.cpp" line="10"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
+        <location filename="../gui/dialog/settingsdialog.cpp" line="11"/>
         <source>System Protection</source>
         <translation>系統防護</translation>
     </message>
     <message>
+        <location filename="../gui/dialog/settingsdialog.cpp" line="12"/>
         <source>Show warnings when the usage exceeds the thresholds</source>
         <translation>當數值高於以下閾值時自動報警</translation>
     </message>
     <message>
+        <location filename="../gui/dialog/settingsdialog.cpp" line="13"/>
         <source>CPU warning threshold (%)</source>
         <translation>CPU占用 (%)</translation>
     </message>
     <message>
+        <location filename="../gui/dialog/settingsdialog.cpp" line="14"/>
         <source>Memory warning threshold (%)</source>
         <translation>記憶體占用 (%)</translation>
     </message>
     <message>
+        <location filename="../gui/dialog/settingsdialog.cpp" line="15"/>
         <source>Warning interval (min)</source>
         <translation>預警間隔 (分鐘)</translation>
     </message>
     <message>
+        <location filename="../gui/dialog/settingsdialog.cpp" line="16"/>
         <source>Notifications</source>
         <translation>消息通知</translation>
     </message>
@@ -999,10 +1264,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Action.Set.Startup.Mode</name>
     <message>
+        <location filename="../service/service_manager.cpp" line="342"/>
         <source>Failed to set service startup type</source>
         <translation>服務的啟動方式設定失敗</translation>
     </message>
     <message>
+        <location filename="../service/service_manager.cpp" line="408"/>
         <source>Error: Failed to set service startup type due to the crashed sub process.</source>
         <translation>錯誤：由於子進程崩潰，服務的啟動方式設定失敗</translation>
     </message>
@@ -1010,14 +1277,19 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Instance.Name.Dialog</name>
     <message>
+        <location filename="../gui/system_service_table_view.cpp" line="157"/>
+        <location filename="../gui/system_service_table_view.cpp" line="224"/>
+        <location filename="../gui/system_service_table_view.cpp" line="292"/>
         <source>Service instance name</source>
         <translation>服務實例名</translation>
     </message>
     <message>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="38"/>
         <source>OK</source>
         <translation>確 定</translation>
     </message>
     <message>
+        <location filename="../gui/service_name_sub_input_dialog.cpp" line="39"/>
         <source>Cancel</source>
         <translation>取 消</translation>
     </message>
@@ -1025,30 +1297,41 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Context.Menu</name>
     <message>
+        <location filename="../common/common.cpp" line="118"/>
+        <location filename="../gui/system_service_table_view.cpp" line="562"/>
         <source>Refresh</source>
         <translation>重新整理</translation>
     </message>
     <message>
+        <location filename="../common/common.cpp" line="103"/>
+        <location filename="../gui/system_service_table_view.cpp" line="542"/>
         <source>Start</source>
         <translation>啟動</translation>
     </message>
     <message>
+        <location filename="../common/common.cpp" line="108"/>
+        <location filename="../gui/system_service_table_view.cpp" line="547"/>
         <source>Stop</source>
         <translation>停止</translation>
     </message>
     <message>
+        <location filename="../common/common.cpp" line="113"/>
+        <location filename="../gui/system_service_table_view.cpp" line="552"/>
         <source>Restart</source>
         <translation>重新啟動</translation>
     </message>
     <message>
+        <location filename="../gui/system_service_table_view.cpp" line="558"/>
         <source>Auto</source>
         <translation>自動</translation>
     </message>
     <message>
+        <location filename="../gui/system_service_table_view.cpp" line="559"/>
         <source>Manual</source>
         <translation>手動</translation>
     </message>
     <message>
+        <location filename="../gui/system_service_table_view.cpp" line="557"/>
         <source>Startup type</source>
         <translation>設定啟動方式</translation>
     </message>
@@ -1056,34 +1339,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Service.Table.Header</name>
     <message>
+        <location filename="../model/system_service_table_model.h" line="16"/>
         <source>Name</source>
         <translation>名稱</translation>
     </message>
     <message>
+        <location filename="../model/system_service_table_model.h" line="18"/>
         <source>Load</source>
         <translation>記憶體載入</translation>
     </message>
     <message>
+        <location filename="../model/system_service_table_model.h" line="23"/>
         <source>Sub</source>
         <translation>執行狀態</translation>
     </message>
     <message>
+        <location filename="../model/system_service_table_model.h" line="30"/>
         <source>Description</source>
         <translation>描述</translation>
     </message>
     <message>
+        <location filename="../model/system_service_table_model.h" line="32"/>
         <source>PID</source>
         <translation>進程號</translation>
     </message>
     <message>
+        <location filename="../model/system_service_table_model.h" line="27"/>
         <source>Startup Type</source>
         <translation>啟動方式</translation>
     </message>
     <message>
+        <location filename="../model/system_service_table_model.h" line="21"/>
         <source>Start State</source>
         <translation>啟動狀態</translation>
     </message>
     <message>
+        <location filename="../model/system_service_table_model.h" line="25"/>
         <source>Start Tactic</source>
         <translation>啟用策略</translation>
     </message>
@@ -1091,14 +1382,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>SystemProtectionSetting</name>
     <message>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="132"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="165"/>
         <source>(Modifiable)</source>
         <translation>（閾值可修改）</translation>
     </message>
     <message>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="278"/>
+        <location filename="../gui/dialog/systemprotectionsetting.cpp" line="387"/>
         <source>Range: %1-%2</source>
         <translation>數值範圍：%1-%2</translation>
     </message>
@@ -1106,18 +1401,23 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Context.Menu</name>
     <message>
+        <location filename="../common/common.cpp" line="59"/>
+        <location filename="../gui/main_window.cpp" line="129"/>
         <source>Force end application</source>
         <translation>強制結束應用程式</translation>
     </message>
     <message>
+        <location filename="../gui/main_window.cpp" line="147"/>
         <source>Expand</source>
         <translation>舒展</translation>
     </message>
     <message>
+        <location filename="../gui/main_window.cpp" line="150"/>
         <source>Compact</source>
         <translation>簡潔</translation>
     </message>
     <message>
+        <location filename="../gui/main_window.cpp" line="142"/>
         <source>View</source>
         <translation>查看</translation>
     </message>
@@ -1125,6 +1425,8 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Search</name>
     <message>
+        <location filename="../common/common.cpp" line="44"/>
+        <location filename="../gui/toolbar.cpp" line="95"/>
         <source>Search</source>
         <translation>搜尋</translation>
     </message>
@@ -1132,14 +1434,25 @@ Are you sure you want to continue?</source>
 <context>
     <name>Title.Bar.Switch</name>
     <message>
+        <location filename="../common/common.cpp" line="53"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/toolbar.cpp" line="45"/>
         <source>Processes</source>
         <translation>進程</translation>
     </message>
     <message>
+        <location filename="../common/common.cpp" line="98"/>
+        <location filename="../gui/main_window.cpp" line="224"/>
+        <location filename="../gui/main_window.cpp" line="235"/>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="53"/>
         <source>Services</source>
         <translation>系統服務</translation>
     </message>
     <message>
+        <location filename="../gui/main_window.cpp" line="245"/>
+        <location filename="../gui/toolbar.cpp" line="60"/>
         <source>Users</source>
         <translation>使用者</translation>
     </message>
@@ -1147,6 +1460,7 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Operation</name>
     <message>
+        <location filename="../gui/accounts_widget.cpp" line="102"/>
         <source>Edit account information</source>
         <translation>修改帳戶訊息</translation>
     </message>
@@ -1154,10 +1468,12 @@ Are you sure you want to continue?</source>
 <context>
     <name>User.Account.Type</name>
     <message>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Administrator</source>
         <translation>管理員</translation>
     </message>
     <message>
+        <location filename="../gui/accounts_widget.cpp" line="152"/>
         <source>Standard User</source>
         <translation>標準使用者</translation>
     </message>


### PR DESCRIPTION
- Added avg_avaliable_cur_freq() function to calculate average frequency across all CPU cores
- Implemented avgFreq() method in CPUSet class to format and return average frequency
- Updated CPU summary view to display average frequency instead of current frequency
- Reorganized frequency display layout: average frequency in first row, max frequency in second row
- Enhanced frequency data collection to include CPU avg MHz in system information

Log: add average CPU frequency calculation and display