### PR TITLE
fix: Add XDG_DATA_HOME to XDG_DATA_DIRS

### DIFF
--- a/deepin-system-monitor-main/process/desktop_entry_cache.cpp
+++ b/deepin-system-monitor-main/process/desktop_entry_cache.cpp
@@ -57,6 +57,17 @@ void DesktopEntryCache::updateCache()
     m_cache.clear();
 
     QString xdgDataDirPath(getenv("XDG_DATA_DIRS"));
+    QString xdgDataHomePath(getenv("XDG_DATA_HOME"));
+    // Add XDG_DATA_HOME to XDG_DATA_DIRS
+    if (!xdgDataHomePath.isEmpty()) {
+        if (!xdgDataDirPath.isEmpty()) {
+            xdgDataDirPath += ":" + xdgDataHomePath;
+        } else {
+            xdgDataDirPath = xdgDataHomePath;
+        }
+        qCDebug(app) << "XDG_DATA_DIRS:" << xdgDataDirPath;
+    }
+
     if (xdgDataDirPath.isEmpty()) {
         qCDebug(app) << "XDG_DATA_DIRS is empty, using default path";
         auto fileInfoList = QDir(DESKTOP_ENTRY_PATH).entryInfoList(QDir::Files);


### PR DESCRIPTION
Description: The desktop of the application in compatibility mode is mapped to XDG_DATA-HOME

Log: When checking if the process is cached on the desktop, it will be searched from the XDG_DATA-DIRS directory

Bug: https://pms.uniontech.com/bug-view-333523.html