### PR TITLE
fix(dialog): ensure error dialog stays on top

### DIFF
--- a/deepin-system-monitor-main/gui/dialog/error_dialog.cpp
+++ b/deepin-system-monitor-main/gui/dialog/error_dialog.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -38,6 +38,8 @@ void ErrorDialog::initUI()
     setIcon(QIcon::fromTheme("dialog-warning"));
     // set dialog attribute
     setAttribute(Qt::WA_DeleteOnClose);
+    // set window to stay on top so user can see error messages
+    setWindowFlags(windowFlags() | Qt::BypassWindowManagerHint);
     // set maximum width to avoid displaying extra wide dialog
     setMaximumWidth(720);
 


### PR DESCRIPTION
Add BypassWindowManagerHint flag to keep error dialog visible.

添加BypassWindowManagerHint标志，确保错误对话框始终可见。

Log: 修复错误对话框不置顶问题
PMS: BUG-316357
Influence: 修复后错误对话框将始终显示在最前面，确保用户能够看到重要的错误提示信息。