### PR TITLE
fix(gui): improve selected row text contrast on highlight background

### DIFF
--- a/deepin-system-monitor-main/gui/base/base_item_delegate.cpp
+++ b/deepin-system-monitor-main/gui/base/base_item_delegate.cpp
@@ -117,8 +117,8 @@ void BaseItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
     if (opt.state & DStyle::State_Enabled) {
         if (opt.state & DStyle::State_Selected) {
             // qCDebug(app) << "BaseItemDelegate paint: Item is selected.";
-            // selected row's color
-            forground.setColor(palette.color(cg, DPalette::TextLively));
+            // selected row's color - use HighlightedText for better contrast on highlight background
+            forground.setColor(palette.color(cg, DPalette::HighlightedText));
             if (opt.state & DStyle::State_Sunken) {
                 // qCDebug(app) << "BaseItemDelegate paint: Item is sunken.";
                 // color used when current row pressed by mouse


### PR DESCRIPTION
Use HighlightedText palette color instead of TextLively for selected rows to ensure better readability on highlight background.

将选中行的文本颜色从TextLively改为HighlightedText，确保在高亮背景
上有更好的可读性。

Log: 改进选中行文本对比度
PMS: BUG-361345
Influence: 选中行的文本现在使用HighlightedText颜色，在高亮背景上提供更好的对比度和可读性。