### PR TITLE
fix(dbus): defer ControlCenter DBus interface init to first use

### DIFF
--- a/deepin-system-monitor-main/model/accounts_info_model.cpp
+++ b/deepin-system-monitor-main/model/accounts_info_model.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #include "accounts_info_model.h"
 #include "helper.hpp"
 #include "ddlog.h"
@@ -19,7 +23,14 @@ const QString LoginPath = "/org/freedesktop/login1";
 const QString LoginInterface = "org.freedesktop.login1.Manager";
 
 AccountsInfoModel::AccountsInfoModel(QObject *parent)
-    : QObject(parent), m_accountsInter(new QDBusInterface(common::systemInfo().AccountsService, common::systemInfo().AccountsPath, common::systemInfo().AccountsInterface, QDBusConnection::systemBus(), this)), m_LoginInter(new QDBusInterface(LoginService, LoginPath, LoginInterface, QDBusConnection::systemBus(), this)), m_controlInter(new QDBusInterface(common::systemInfo().ControlCenterService, common::systemInfo().ControlCenterPath, common::systemInfo().ControlCenterInterface, QDBusConnection::sessionBus(), this)), m_currentUserType(-1)
+    : QObject(parent)
+    , m_accountsInter(new QDBusInterface(common::systemInfo().AccountsService,
+                                         common::systemInfo().AccountsPath,
+                                         common::systemInfo().AccountsInterface,
+                                         QDBusConnection::systemBus(), this))
+    , m_LoginInter(new QDBusInterface(LoginService, LoginPath, LoginInterface,
+                                      QDBusConnection::systemBus(), this))
+    , m_currentUserType(-1)
 {
     qDBusRegisterMetaType<SessionInfo>();
     qDBusRegisterMetaType<SessionInfoList>();
@@ -225,6 +236,12 @@ bool AccountsInfoModel::LogoutByUserName(const QString &userName)
 void AccountsInfoModel::EditAccount()
 {
     qCInfo(app) << "Opening account settings";
+    if (!m_controlInter) {
+        m_controlInter = new QDBusInterface(common::systemInfo().ControlCenterService,
+                                            common::systemInfo().ControlCenterPath,
+                                            common::systemInfo().ControlCenterInterface,
+                                            QDBusConnection::sessionBus(), this);
+    }
     if (m_controlInter) {
         bool version = common::systemInfo().isOldVersion();
         if (version) {

--- a/deepin-system-monitor-main/model/accounts_info_model.h
+++ b/deepin-system-monitor-main/model/accounts_info_model.h
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #ifndef ACCOUNTS_INFO_MODEL_H
 #define ACCOUNTS_INFO_MODEL_H
 #include "user.h"
@@ -87,7 +91,7 @@ private:
     QMap<QString, User * > m_userMap ;
     QStringList m_onlineUsers;
     QDBusInterface *m_LoginInter;
-    QDBusInterface *m_controlInter;
+    QDBusInterface *m_controlInter = nullptr;
     QString m_currentUserName;
     int m_currentUserType;
     SessionInfoList m_sessionList {};


### PR DESCRIPTION
Move m_controlInter creation from constructor to EditAccount() to prevent session bus blocking during startup.

将控制中心DBus接口初始化从构造函数延迟到EditAccount()首次调用，
避免启动时session bus异常导致卡住。

Log: 延迟初始化ControlCenter DBus接口，避免启动卡顿
PMS: TASK-389931
Influence: 修复在session bus异常环境下启动系统监视器可能卡住的问题。