### PR TITLE
feat(process): integrate AM for linglong app process grouping

### DIFF
--- a/deepin-system-monitor-main/CMakeLists.txt
+++ b/deepin-system-monitor-main/CMakeLists.txt
@@ -309,6 +309,7 @@ set(HPP_PROCESS
     process/priority_controller.h
     process/process_controller.h
     process/desktop_entry_cache.h
+    process/am_icon_manager.h
     process/desktop_entry_cache_updater.h
     process/process_db.h
 )
@@ -322,6 +323,7 @@ set(CPP_PROCESS
     process/priority_controller.cpp
     process/process_controller.cpp
     process/desktop_entry_cache.cpp
+    process/am_icon_manager.cpp
     process/desktop_entry_cache_updater.cpp
     process/process_db.cpp
     process/system_service_client.cpp

--- a/deepin-system-monitor-main/main.cpp
+++ b/deepin-system-monitor-main/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2011 ~ 2020 Uniontech Software Technology Co.,Ltd
+// Copyright (C) 2011 ~ 2026 Uniontech Software Technology Co.,Ltd
 // SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later

--- a/deepin-system-monitor-main/process/am_icon_manager.cpp
+++ b/deepin-system-monitor-main/process/am_icon_manager.cpp
@@ -1,0 +1,382 @@
+// Copyright (C) 2026 Uniontech Software Technology Co.,Ltd
+// SPDX-FileCopyrightText: 2022 Uniontech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "am_icon_manager.h"
+#include "ddlog.h"
+
+#include <DSysInfo>
+#include <QDBusConnection>
+#include <QDBusConnectionInterface>
+#include <QDBusReply>
+#include <QDBusObjectPath>
+#include <QDebug>
+#include <QDBusUnixFileDescriptor>
+#include <cerrno>
+#include <cstring>
+#include <signal.h>
+
+#include "3rdparty/include/pidfd-utils.h"
+
+using namespace DDLog;
+
+namespace core {
+namespace process {
+
+static const QString kDesktopEntryIconKey = "Desktop Entry";
+static const QString kDefaultKey = "default";
+
+std::atomic<AMIconManager *> AMIconManager::m_instance {nullptr};
+std::mutex AMIconManager::m_mutex {};
+
+AMIconManager::AMIconManager(QObject *parent)
+    : QObject(parent)
+{
+    qCInfo(app) << "AMIconManager created";
+
+    m_systemMajorVersion = DSysInfo::majorVersion().toInt();
+    qCDebug(app) << "AMIconManager created, system version:" << m_systemMajorVersion;
+
+    if (m_systemMajorVersion >= 25) {
+        QDBusConnectionInterface *sessionBus = QDBusConnection::sessionBus().interface();
+        m_amAvailable = sessionBus->isServiceRegistered(
+            "org.desktopspec.ApplicationManager1"
+        );
+
+        if (m_amAvailable) {
+            qCInfo(app) << "AM service available on V25+ system";
+            initializeAMInterface();
+        } else {
+            qCDebug(app) << "V25+ system but AM service not registered";
+        }
+    } else {
+        qCInfo(app) << "Pre-V25 system";
+        m_amAvailable = false;
+    }
+}
+
+AMIconManager::~AMIconManager()
+{
+    qCDebug(app) << "AMIconManager destroyed";
+    if (m_amInterface) {
+        delete m_amInterface;
+        m_amInterface = nullptr;
+    }
+}
+
+AMIconManager *AMIconManager::instance()
+{
+    AMIconManager *sin = m_instance.load();
+    if (!sin) {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        sin = m_instance.load();
+        if (!sin) {
+            sin = new AMIconManager();
+            m_instance.store(sin);
+        }
+    }
+    return sin;
+}
+
+void AMIconManager::initializeAMInterface()
+{
+    if (!m_amAvailable) {
+        return;
+    }
+
+    if (!m_amInterface) {
+        m_amInterface = new QDBusInterface(
+            "org.desktopspec.ApplicationManager1",
+            "/org/desktopspec/ApplicationManager1",
+            "org.desktopspec.ApplicationManager1",
+            QDBusConnection::sessionBus()
+        );
+
+        if (!m_amInterface->isValid()) {
+            qCWarning(app) << "Failed to create AM DBus interface";
+            m_amAvailable = false;
+        } else {
+            qCDebug(app) << "AM DBus interface initialized successfully";
+        }
+    }
+}
+
+QString AMIconManager::getIconByAppId(const QString &appId)
+{
+    if (appId.isEmpty()) {
+        return QString();
+    }
+
+    // Check appId cache first (avoid repeated Properties.Get calls)
+    {
+        std::lock_guard<std::mutex> lock(m_cacheMutex);
+        if (m_appIdToIconCache.contains(appId)) {
+            return m_appIdToIconCache[appId];
+        }
+    }
+
+    // Build Application object path with underscore escaping
+    // D-Bus object path escape: _ → _5F, - → _2d
+    QString escapedAppId = appId;
+    escapedAppId.replace("_", "_5F");
+    escapedAppId.replace("-", "_2d");
+    QString appPath = QString("/org/desktopspec/ApplicationManager1/%1").arg(escapedAppId);
+
+    // Use org.freedesktop.DBus.Properties.Get to read Icons property
+    QDBusInterface propsInterface(
+        "org.desktopspec.ApplicationManager1",
+        appPath,
+        "org.freedesktop.DBus.Properties",
+        QDBusConnection::sessionBus()
+    );
+
+    if (!propsInterface.isValid()) {
+        qCWarning(app) << "Failed to create Properties interface for" << appPath;
+        return QString();
+    }
+
+    QDBusReply<QDBusVariant> iconsReply = propsInterface.call(
+        "Get",
+        "org.desktopspec.ApplicationManager1.Application",
+        "Icons"
+    );
+
+    if (!iconsReply.isValid()) {
+        qCWarning(app) << "Failed to get Icons property:" << iconsReply.error().message();
+        return QString();
+    }
+
+    QDBusVariant dbusVariant = iconsReply.value();
+    QVariant iconsVariant = dbusVariant.variant();
+
+    // Icons property is a{ss} (QStringMap), comes wrapped in QDBusArgument
+    QMap<QString, QString> icons;
+    QDBusArgument dbusArg = iconsVariant.value<QDBusArgument>();
+    dbusArg >> icons;
+
+    QString iconName = icons.value(kDesktopEntryIconKey);
+    if (iconName.isEmpty()) {
+        iconName = icons.value(kDefaultKey);
+    }
+
+    // Cache the result
+    if (!iconName.isEmpty()) {
+        std::lock_guard<std::mutex> lock(m_cacheMutex);
+        m_appIdToIconCache[appId] = iconName;
+    }
+
+    return iconName;
+}
+
+QString AMIconManager::getAppNameByAppId(const QString &appId)
+{
+    if (appId.isEmpty()) {
+        return QString();
+    }
+
+    // Check cache first
+    {
+        std::lock_guard<std::mutex> lock(m_cacheMutex);
+        if (m_appIdToNameCache.contains(appId)) {
+            return m_appIdToNameCache[appId];
+        }
+    }
+
+    // Build Application object path with underscore escaping
+    QString escapedAppId = appId;
+    escapedAppId.replace("_", "_5F");
+    escapedAppId.replace("-", "_2d");
+    QString appPath = QString("/org/desktopspec/ApplicationManager1/%1").arg(escapedAppId);
+
+    // Get Name property from AM
+    QDBusInterface propsInterface(
+        "org.desktopspec.ApplicationManager1",
+        appPath,
+        "org.freedesktop.DBus.Properties",
+        QDBusConnection::sessionBus()
+    );
+
+    if (!propsInterface.isValid()) {
+        return QString();
+    }
+
+    QDBusReply<QDBusVariant> nameReply = propsInterface.call(
+        "Get",
+        "org.desktopspec.ApplicationManager1.Application",
+        "Name"
+    );
+
+    if (!nameReply.isValid()) {
+        return QString();
+    }
+
+    // Name is a{ss} (localized name map), get "default" key
+    QVariant nameVar = nameReply.value().variant();
+    QMap<QString, QString> names;
+    QDBusArgument dbusArg = nameVar.value<QDBusArgument>();
+    dbusArg >> names;
+
+    // Try locale-specific names first, fall back to "default"
+    QString displayName;
+    QLocale locale;
+    QString localeKey = locale.name();
+    if (names.contains(localeKey)) {
+        displayName = names[localeKey];
+    } else if (names.contains(kDefaultKey)) {
+        displayName = names[kDefaultKey];
+    } else if (!names.isEmpty()) {
+        displayName = names.first();
+    }
+
+    // Cache the result
+    if (!displayName.isEmpty()) {
+        std::lock_guard<std::mutex> lock(m_cacheMutex);
+        m_appIdToNameCache[appId] = displayName;
+    }
+
+    return displayName;
+}
+
+AMProcessGroupInfo AMIconManager::identifyProcess(int pidfd)
+{
+    AMProcessGroupInfo result;
+
+    if (!m_amInterface || !m_amInterface->isValid()) {
+        qCWarning(app) << "AM interface not available or invalid";
+        return result;
+    }
+
+    QDBusMessage reply = m_amInterface->call(
+        "Identify",
+        QVariant::fromValue(QDBusUnixFileDescriptor{static_cast<qint32>(pidfd)})
+    );
+
+    if (reply.type() == QDBusMessage::ErrorMessage) {
+        qCWarning(app) << "AM Identify call failed:" << reply.errorMessage();
+        return result;
+    }
+
+    QList<QVariant> args = reply.arguments();
+
+    if (args.size() < 3) {
+        qCWarning(app) << "AM returned unexpected number of arguments:" << args.size() << "expected 3";
+        return result;
+    }
+
+    // Parse the three return values: appId, instancePath, instanceInfo
+    result.appId = args.at(0).toString();
+
+    // args[1] is QDBusObjectPath for instance
+    if (args.at(1).canConvert<QDBusObjectPath>()) {
+        QDBusObjectPath instancePath = args.at(1).value<QDBusObjectPath>();
+        result.instancePath = instancePath.path();
+    } else if (args.at(1).canConvert<QString>()) {
+        result.instancePath = args.at(1).toString();
+    } else {
+        qCWarning(app) << "Failed to convert instance path, typeName:" << args.at(1).typeName();
+    }
+
+
+
+    if (result.appId.isEmpty()) {
+        qCWarning(app) << "AM returned empty appId for pidfd" << pidfd;
+        return result;
+    }
+
+    // Get icon name
+    result.iconName = getIconByAppId(result.appId);
+
+    // Get display name
+    result.displayName = getAppNameByAppId(result.appId);
+
+    return result;
+}
+
+QString AMIconManager::getIconByPid(pid_t pid)
+{
+    if (!m_amAvailable || !m_amInterface) {
+        return QString();
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(m_cacheMutex);
+        if (m_pidToIconCache.contains(pid)) {
+            return m_pidToIconCache[pid];
+        }
+    }
+
+    int pidfd = pidfd_open(pid, 0);
+    if (pidfd < 0) {
+        return QString();
+    }
+
+    AMProcessGroupInfo info = identifyProcess(pidfd);
+    close(pidfd);
+
+    if (!info.isValid()) {
+        return QString();
+    }
+
+    // Cache both icon and group info
+    {
+        std::lock_guard<std::mutex> lock(m_cacheMutex);
+        m_pidToIconCache[pid] = info.iconName;
+        m_pidToGroupCache[pid] = info;
+    }
+
+    return info.iconName;
+}
+
+AMProcessGroupInfo AMIconManager::getProcessGroupInfo(pid_t pid)
+{
+    if (!m_amAvailable || !m_amInterface) {
+        return AMProcessGroupInfo();
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(m_cacheMutex);
+        if (m_pidToGroupCache.contains(pid)) {
+            return m_pidToGroupCache[pid];
+        }
+    }
+
+    int pidfd = pidfd_open(pid, 0);
+    if (pidfd < 0) {
+        qCWarning(app) << "pidfd_open failed for pid" << pid << "errno:" << errno;
+        return AMProcessGroupInfo();
+    }
+
+    AMProcessGroupInfo info = identifyProcess(pidfd);
+    close(pidfd);
+
+    if (info.isValid()) {
+        std::lock_guard<std::mutex> lock(m_cacheMutex);
+        m_pidToGroupCache[pid] = info;
+    }
+
+    return info;
+}
+
+bool AMIconManager::isAMAvailable() const
+{
+    return m_amAvailable;
+}
+
+void AMIconManager::removeCachedIcon(pid_t pid)
+{
+    std::lock_guard<std::mutex> lock(m_cacheMutex);
+    m_pidToIconCache.remove(pid);
+    m_pidToGroupCache.remove(pid);
+}
+
+void AMIconManager::clearCache()
+{
+    std::lock_guard<std::mutex> lock(m_cacheMutex);
+    m_pidToIconCache.clear();
+    m_appIdToIconCache.clear();
+    m_pidToGroupCache.clear();
+}
+
+} // namespace process
+} // namespace core

--- a/deepin-system-monitor-main/process/am_icon_manager.h
+++ b/deepin-system-monitor-main/process/am_icon_manager.h
@@ -1,0 +1,146 @@
+// Copyright (C) 2026 Uniontech Software Technology Co.,Ltd
+// SPDX-FileCopyrightText: 2022 Uniontech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef AM_ICON_MANAGER_H
+#define AM_ICON_MANAGER_H
+
+#include <QObject>
+#include <QDBusInterface>
+#include <QDBusObjectPath>
+#include <QMap>
+#include <QString>
+#include <QList>
+#include <mutex>
+#include <atomic>
+#include <unistd.h>
+#include <sys/types.h>
+
+namespace core {
+namespace process {
+
+/**
+ * @brief Process group information from AM Identify
+ * 
+ * Contains information about the application instance that a process belongs to.
+ * Multiple processes from the same application instance (e.g., linglong apps)
+ * will have the same instancePath.
+ */
+struct AMProcessGroupInfo
+{
+    QString appId;              // Application ID (e.g., "qq")
+    QString instancePath;       // Instance object path from AM
+    QString iconName;           // Icon name for this application
+    QString displayName;        // Localized display name from AM (e.g., "QQ")
+    bool isValid() const { return !appId.isEmpty() && !instancePath.isEmpty(); }
+};
+
+/**
+ * @brief Application Manager (AM) icon manager
+ * 
+ * This class provides icon retrieval through Application Manager DBus interface
+ * on V25+ systems. It maintains a cache of pid to icon mappings
+ * to avoid repeated DBus calls.
+ * 
+ * Also provides process grouping information for applications like linglong
+ * that run multiple processes in the same cgroup/instance.
+ */
+class AMIconManager : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit AMIconManager(QObject *parent = nullptr);
+    ~AMIconManager();
+
+    /**
+     * @brief Get singleton instance (thread-safe)
+     * @return AMIconManager instance
+     */
+    static AMIconManager *instance();
+
+    /**
+     * @brief Get icon name by PID through AM
+     * @param pid Process ID
+     * @return Icon name (empty if not found or AM unavailable)
+     */
+    QString getIconByPid(pid_t pid);
+
+    /**
+     * @brief Get process group information by PID
+     * @param pid Process ID
+     * @return Process group info containing appId, instancePath, etc.
+     */
+    AMProcessGroupInfo getProcessGroupInfo(pid_t pid);
+
+    /**
+     * @brief Check if AM service is available
+     * @return true if available (V25+ system)
+     */
+    bool isAMAvailable() const;
+
+    /**
+     * @brief Remove cached icon for a pid
+     * @param pid Process ID
+     */
+    void removeCachedIcon(pid_t pid);
+
+    /**
+     * @brief Clear all cached icons
+     */
+    void clearCache();
+
+private:
+    /**
+     * @brief Initialize AM DBus interface
+     */
+    void initializeAMInterface();
+
+    /**
+     * @brief Get icon for an appId
+     * @param appId Application ID (from AM.Identify)
+     * @return Icon name (empty if not found)
+     */
+    QString getIconByAppId(const QString &appId);
+
+    /**
+     * @brief Get localized display name for an appId
+     * @param appId Application ID (from AM.Identify)
+     * @return Display name (empty if not found)
+     */
+    QString getAppNameByAppId(const QString &appId);
+
+    /**
+     * @brief Identify application by pidfd and get full info
+     * @param pidfd Process file descriptor
+     * @return Process group info
+     */
+    AMProcessGroupInfo identifyProcess(int pidfd);
+
+private:
+    QDBusInterface *m_amInterface {nullptr};
+    bool m_amAvailable {false};
+    int m_systemMajorVersion {-1};
+
+    // Primary cache: pid -> icon (fast lookup for known processes)
+    QMap<pid_t, QString> m_pidToIconCache;
+
+    // Secondary cache: appId -> icon (avoid repeated Properties.Get for same app)
+    QMap<QString, QString> m_appIdToIconCache;
+    QMap<QString, QString> m_appIdToNameCache;
+
+    // PID to process group info cache
+    QMap<pid_t, AMProcessGroupInfo> m_pidToGroupCache;
+
+    mutable std::mutex m_cacheMutex;
+    
+    // Thread-safe singleton
+    static std::atomic<AMIconManager *> m_instance;
+    static std::mutex m_mutex;
+};
+
+} // namespace process
+} // namespace core
+
+#endif // AM_ICON_MANAGER_H

--- a/deepin-system-monitor-main/process/private/process_p.h
+++ b/deepin-system-monitor-main/process/private/process_p.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd
+// Copyright (C) 2019 ~ 2026 Uniontech Software Technology Co.,Ltd
 // SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -131,6 +131,8 @@ public:
         , environ(other.environ)
         , uptime {other.uptime}
         , sockInodes(other.sockInodes)
+        , m_instancePath(other.m_instancePath)
+        , m_appId(other.m_appId)
         , cpuTimeSample(std::unique_ptr<CPUTimeSample>(new CPUTimeSample(*(other.cpuTimeSample))))
         , cpuUsageSample(std::unique_ptr<CPUUsageSample>(new CPUUsageSample(*(other.cpuUsageSample))))
         , networkIOSample(std::unique_ptr<IOSample>(new IOSample(*(other.networkIOSample))))
@@ -198,6 +200,10 @@ private:
     struct timeval uptime;
 
     QList<ino_t> sockInodes; // socket inodes opened by this process
+
+    // AM instance info for process grouping (linglong apps)
+    QString m_instancePath;
+    QString m_appId;
 
     // only 2 samples are kept here for each process, to avoid too much memory
     // consumption if there're too many processes

--- a/deepin-system-monitor-main/process/process.cpp
+++ b/deepin-system-monitor-main/process/process.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd
+// Copyright (C) 2019 ~ 2026 Uniontech Software Technology Co.,Ltd
 // SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -740,6 +740,11 @@ QString Process::displayName() const
     return d->proc_name.displayName();
 }
 
+void Process::setDisplayName(const QString &name)
+{
+    d->proc_name.setDisplayName(name);
+}
+
 void Process::calculateProcessMetrics()
 {
     CPUSet *cpuset = DeviceDB::instance()->cpuSet();
@@ -817,6 +822,12 @@ void Process::setCpu(qreal cpu)
 qulonglong Process::memory() const
 {
     return d->rss - d->shm;
+}
+
+void Process::setMemory(qulonglong memory)
+{
+    // memory = rss - shm, so rss = memory + shm
+    d->rss = memory + d->shm;
 }
 
 qulonglong Process::vtrmemory() const
@@ -967,6 +978,26 @@ int Process::appType() const
 void Process::setAppType(int type)
 {
     d->apptype = type;
+}
+
+QString Process::instancePath() const
+{
+    return d->m_instancePath;
+}
+
+void Process::setInstancePath(const QString &path)
+{
+    d->m_instancePath = path;
+}
+
+QString Process::appId() const
+{
+    return d->m_appId;
+}
+
+void Process::setAppId(const QString &appId)
+{
+    d->m_appId = appId;
 }
 
 // DKapture update methods removed - now handled by system service

--- a/deepin-system-monitor-main/process/process.h
+++ b/deepin-system-monitor-main/process/process.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd
+// Copyright (C) 2019 ~ 2026 Uniontech Software Technology Co.,Ltd
 // SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -64,12 +64,27 @@ public:
     int appType() const;
     void setAppType(int type);
 
+    /**
+     * @brief Get the AM instance path this process belongs to
+     * @return Instance path (empty if not managed by AM)
+     */
+    QString instancePath() const;
+    void setInstancePath(const QString &path);
+
+    /**
+     * @brief Get the AM application ID
+     * @return Application ID (e.g., "com.qq.im.linglong")
+     */
+    QString appId() const;
+    void setAppId(const QString &appId);
+
     qulonglong utime() const;
     qulonglong stime() const;
 
     QString name() const;
     void setName(const QString &name);
     QString displayName() const;
+    void setDisplayName(const QString &name);
 
     QIcon icon() const;
 
@@ -77,6 +92,7 @@ public:
     void setCpu(qreal cpu);
 
     qulonglong memory() const;
+    void setMemory(qulonglong memory);
     qulonglong vtrmemory() const;
     qulonglong sharememory() const;
 

--- a/deepin-system-monitor-main/process/process_icon.cpp
+++ b/deepin-system-monitor-main/process/process_icon.cpp
@@ -1,10 +1,12 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd
+// Copyright (C) 2019 ~ 2026 Uniontech Software Technology Co.,Ltd
 // SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "process_icon.h"
 #include "ddlog.h"
+
+#include "am_icon_manager.h"
 
 #include "process_icon_cache.h"
 #include "process.h"
@@ -150,6 +152,23 @@ std::shared_ptr<icon_data_t> ProcessIcon::getIcon(Process *proc)
     std::shared_ptr<icon_data_t> iconDataPtr;
     auto processDB = ProcessDB::instance();
     WMWindowList *windowList = processDB->windowList();
+    
+    // ===== NEW: Try AM first on V20+ systems =====
+    if (AMIconManager::instance()->isAMAvailable()) {
+        QString iconName = AMIconManager::instance()->getIconByPid(proc->pid());
+        if (!iconName.isEmpty()) {
+            auto *iconData = new struct icon_data_name_type();
+            iconData->type = kIconDataNameType;
+            iconData->proc_name = proc->name();
+            iconData->icon_name = iconName;
+            iconData->desktopentry = true;
+            iconDataPtr.reset(iconData);
+            windowList->addDesktopEntryApp(proc);
+            return iconDataPtr;
+        }
+    }
+    // ===== END NEW =====
+    
     DesktopEntryCache *desktopEntryCache = processDB->desktopEntryCache();
 
     if (!proc->cmdline().isEmpty()) {

--- a/deepin-system-monitor-main/process/process_name.h
+++ b/deepin-system-monitor-main/process/process_name.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd
+// Copyright (C) 2019 ~ 2026 Uniontech Software Technology Co.,Ltd
 // SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -26,6 +26,7 @@ public:
 
     QString name() const;
     QString displayName() const;
+    void setDisplayName(const QString &name);
 
     static QString normalizeProcessName(const QString &name, const QByteArrayList &cmdline);
 
@@ -45,6 +46,11 @@ inline QString ProcessName::name() const
 inline QString ProcessName::displayName() const
 {
     return m_displayName;
+}
+
+inline void ProcessName::setDisplayName(const QString &name)
+{
+    m_displayName = name;
 }
 
 } // namespace process

--- a/deepin-system-monitor-main/process/process_set.cpp
+++ b/deepin-system-monitor-main/process/process_set.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd
+// Copyright (C) 2019 ~ 2026 Uniontech Software Technology Co.,Ltd
 // SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -10,6 +10,7 @@
 #include "wm/wm_window_list.h"
 #include "system_service_client.h"
 #include "process/private/process_p.h"
+#include "am_icon_manager.h"
 // #include "settings.h"
 
 #include <QDebug>
@@ -264,7 +265,7 @@ void ProcessSet::scanProcess()
                     }
                 } else {
                     if (m_pidMyApps.contains(proc.pid())) {
-                        qCInfo(app) << "Removing non-window process from applications list:" << proc.pid();
+                        qCDebug(app) << "Removing non-window process from applications list:" << proc.pid();
                         m_pidMyApps.removeOne(proc.pid());
                     }
                 }
@@ -380,6 +381,9 @@ void ProcessSet::scanProcess()
 
     m_recentProcStage.clear();
 
+    // Group processes by AM instance for linglong apps
+    groupProcessesByAMInstance();
+
     // 性能统计
     qint64 elapsed = timer.elapsed();
     QString mode = m_useSystemService ? "DKapture" : "Traditional";
@@ -481,6 +485,110 @@ void ProcessSet::updateProcessPriority(pid_t pid, int priority)
     qCDebug(app) << "Updating process priority for pid" << pid << "to" << priority;
     if (m_set.contains(pid))
         m_set[pid].setPriority(priority);
+}
+
+void ProcessSet::groupProcessesByAMInstance()
+{
+    if (!AMIconManager::instance()->isAMAvailable())
+        return;
+
+    // Preserve previous scan's pid→instance mapping so we can recover sub-processes
+    // that were lost from m_pidMyApps during rebuilds (m_prePid != m_curPid).
+    // m_pidMyApps is unreliable for AM grouping because:
+    //   1. It's only rebuilt when process list changes
+    //   2. During rebuild, sub-processes without windows get removed
+    QMap<pid_t, QString> prevPidToInstance = std::move(m_pidToInstance);
+    m_instanceGroups.clear();
+
+    // Step 1: Discover AM instances from processes currently in m_pidMyApps.
+    // At least one process per instance (the main launcher) should always be here.
+    QMap<QString, AMInstanceGroup> instanceGroups;
+    for (const pid_t &pid : m_pidMyApps) {
+        if (!m_set.contains(pid))
+            continue;
+        AMProcessGroupInfo info = AMIconManager::instance()->getProcessGroupInfo(pid);
+        if (!info.isValid())
+            continue;
+        AMInstanceGroup &group = instanceGroups[info.instancePath];
+        if (group.instancePath.isEmpty()) {
+            group.instancePath = info.instancePath;
+            group.appId = info.appId;
+            group.displayName = info.displayName;
+        }
+        group.allPids.append(pid);
+        m_pidToInstance[pid] = info.instancePath;
+    }
+
+    // Step 2: Recover previously-known sub-processes from cache.
+    // These PIDs may have been dropped from m_pidMyApps during a rebuild,
+    // but they are still running and in m_set.
+    for (auto it = prevPidToInstance.begin(); it != prevPidToInstance.end(); ++it) {
+        pid_t pid = it.key();
+        const QString &instancePath = it.value();
+        if (!m_set.contains(pid) || m_pidToInstance.contains(pid))
+            continue;
+        if (instanceGroups.contains(instancePath)) {
+            instanceGroups[instancePath].allPids.append(pid);
+            m_pidToInstance[pid] = instancePath;
+        }
+    }
+
+    // Step 3: For each AM instance: aggregate stats, hide sub-processes, set display name.
+    for (auto it = instanceGroups.begin(); it != instanceGroups.end(); ++it) {
+        AMInstanceGroup &group = it.value();
+        pid_t mainPid = group.allPids.first();
+
+        if (group.allPids.size() > 1) {
+            mainPid = *std::min_element(group.allPids.begin(), group.allPids.end());
+            group.mainPid = mainPid;
+
+            // Hide sub-processes from "My Apps" view
+            for (pid_t pid : group.allPids) {
+                if (pid == mainPid)
+                    continue;
+                m_set[pid].setAppType(kFilterCurrentUser);
+            }
+
+            // Aggregate memory (never merged by existing code)
+            Process &mainProc = m_set[mainPid];
+            qulonglong totalMemory = mainProc.memory();
+            for (pid_t pid : group.allPids) {
+                if (pid == mainPid)
+                    continue;
+                totalMemory += m_set[pid].memory();
+            }
+            mainProc.setMemory(totalMemory);
+
+            // Aggregate CPU only in DKapture mode (traditional mode already merges via mergeSubProcCpu)
+            if (m_useSystemService) {
+                qreal totalCpu = mainProc.cpu();
+                for (pid_t pid : group.allPids) {
+                    if (pid == mainPid)
+                        continue;
+                    totalCpu += m_set[pid].cpu();
+                }
+                mainProc.setCpu(totalCpu);
+            }
+
+            // TODO: Aggregate NetIO for AM instance processes.
+            // Cannot simply sum allPids NetIO here because Phase 4 (mergeSubProcNetIO)
+            // already merged tree-descendant NetIO into the main process.
+            // Adding AM sibling NetIO would double-count tree-merged processes.
+            // Solution: save per-process "own" NetIO before Phase 4, then aggregate
+            // only AM siblings that are NOT tree descendants of mainPid.
+
+            m_instanceGroups[group.instancePath] = group;
+        }
+
+        // Set AM display name on main process for ALL instances (including single-process)
+        if (!group.displayName.isEmpty() && m_set.contains(mainPid))
+            m_set[mainPid].setDisplayName(group.displayName);
+    }
+}
+
+AMInstanceGroup ProcessSet::getInstanceGroup(const QString &instancePath) const
+{
+    return m_instanceGroups.value(instancePath);
 }
 
 

--- a/deepin-system-monitor-main/process/process_set.h
+++ b/deepin-system-monitor-main/process/process_set.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd
+// Copyright (C) 2019 ~ 2026 Uniontech Software Technology Co.,Ltd
 // SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -14,6 +14,8 @@
 
 #include <dirent.h>
 
+#include "am_icon_manager.h"
+
 using namespace common::alloc;
 
 // class Settings;
@@ -26,6 +28,14 @@ enum FilterType { kFilterApps,
                   kFilterCurrentUser,
                   kNoFilter
                 };
+
+struct AMInstanceGroup {
+    QString instancePath;
+    QString appId;
+    QString displayName;
+    pid_t mainPid = 0;
+    QList<pid_t> allPids;
+};
 
 struct RecentProcStage {
     qulonglong ptime = 0;
@@ -54,10 +64,13 @@ public:
 
     void refresh();
 
+    AMInstanceGroup getInstanceGroup(const QString &instancePath) const;
+
 private:
     void scanProcess();
     void mergeSubProcNetIO(pid_t ppid, qreal &recvBps, qreal &sendBps);
     void mergeSubProcCpu(pid_t ppid, qreal &cpu);
+    void groupProcessesByAMInstance();
 
     class Iterator
     {
@@ -85,7 +98,11 @@ private:
     QList<pid_t> m_prePid;
     QList<pid_t> m_curPid;
     QList<pid_t> m_pidMyApps;
-    
+
+    // AM instance grouping
+    QMap<QString, AMInstanceGroup> m_instanceGroups;
+    QMap<pid_t, QString> m_pidToInstance;
+
     // System service client for DKapture data
     SystemServiceClient *m_systemServiceClient;
     bool m_useSystemService;

--- a/deepin-system-monitor-plugin-popup/CMakeLists.txt
+++ b/deepin-system-monitor-plugin-popup/CMakeLists.txt
@@ -212,6 +212,7 @@ SET(HPP_PROCESS
     ${MAIN_APP_DIR}/process/process_name.h
     ${MAIN_APP_DIR}/process/process_name_cache.h
     ${MAIN_APP_DIR}/process/process_controller.h
+    ${MAIN_APP_DIR}/process/am_icon_manager.h
 )
 
 SET(CPP_PROCESS
@@ -226,6 +227,7 @@ SET(CPP_PROCESS
     ${MAIN_APP_DIR}/process/process_name_cache.cpp
     ${MAIN_APP_DIR}/process/process_controller.cpp
     ${MAIN_APP_DIR}/process/system_service_client.cpp
+    ${MAIN_APP_DIR}/process/am_icon_manager.cpp
 )
 set(APP_HPP
     ${CMAKE_HOME_DIRECTORY}/config.h

--- a/deepin-system-monitor-plugin-popup/process/process.cpp
+++ b/deepin-system-monitor-plugin-popup/process/process.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd
+// Copyright (C) 2019 ~ 2026 Uniontech Software Technology Co.,Ltd
 // SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -597,6 +597,11 @@ QString Process::displayName() const
     return d->proc_name.displayName();
 }
 
+void Process::setDisplayName(const QString &name)
+{
+    d->proc_name.setDisplayName(name);
+}
+
 QIcon Process::icon() const
 {
     return d->proc_icon.icon();
@@ -619,6 +624,12 @@ void Process::setCpu(qreal cpu)
 qulonglong Process::memory() const
 {
     return d->rss - d->shm;
+}
+
+void Process::setMemory(qulonglong memory)
+{
+    // memory = rss - shm, so rss = memory + shm
+    d->rss = memory + d->shm;
 }
 
 qulonglong Process::vtrmemory() const
@@ -769,6 +780,26 @@ int Process::appType() const
 void Process::setAppType(int type)
 {
     d->apptype = type;
+}
+
+QString Process::instancePath() const
+{
+    return d->m_instancePath;
+}
+
+void Process::setInstancePath(const QString &path)
+{
+    d->m_instancePath = path;
+}
+
+QString Process::appId() const
+{
+    return d->m_appId;
+}
+
+void Process::setAppId(const QString &appId)
+{
+    d->m_appId = appId;
 }
 
 void Process::applyDKaptureData(const QVariantMap &pidData)

--- a/deepin-system-monitor-plugin-popup/process/process.h
+++ b/deepin-system-monitor-plugin-popup/process/process.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd
+// Copyright (C) 2019 ~ 2026 Uniontech Software Technology Co.,Ltd
 // SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -64,12 +64,27 @@ public:
     int appType() const;
     void setAppType(int type);
 
+    /**
+     * @brief Get the AM instance path this process belongs to
+     * @return Instance path (empty if not managed by AM)
+     */
+    QString instancePath() const;
+    void setInstancePath(const QString &path);
+
+    /**
+     * @brief Get the AM application ID
+     * @return Application ID (e.g., "com.qq.im.linglong")
+     */
+    QString appId() const;
+    void setAppId(const QString &appId);
+
     qulonglong utime() const;
     qulonglong stime() const;
 
     QString name() const;
     void setName(const QString &name);
     QString displayName() const;
+    void setDisplayName(const QString &name);
 
     QIcon icon() const;
 
@@ -77,6 +92,7 @@ public:
     void setCpu(qreal cpu);
 
     qulonglong memory() const;
+    void setMemory(qulonglong memory);
     qulonglong vtrmemory() const;
     qulonglong sharememory() const;
 

--- a/tests/deepin-system-monitor-main/ut_am_icon_manager.cpp
+++ b/tests/deepin-system-monitor-main/ut_am_icon_manager.cpp
@@ -1,0 +1,238 @@
+// Copyright (C) 2026 Uniontech Software Technology Co.,Ltd
+// SPDX-FileCopyrightText: 2022 Uniontech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//self
+#include "am_icon_manager.h"
+
+//gtest
+#include "stub.h"
+#include <gtest/gtest.h>
+
+//qt
+#include <DApplication>
+
+using namespace core::process;
+
+/***************************************STUB begin*********************************************/
+
+// Mock DSysInfo::majorVersion()
+int g_mockMajorVersion = 20;
+int DSysInfo::majorVersion() {
+    return g_mockMajorVersion;
+}
+
+// Mock pidfd_open for testing without real pid
+int g_mockPidfd = 3;
+int g_pidfdOpenCallCount = 0;
+
+int pidfd_open(pid_t pid, unsigned int flags) {
+    g_pidfdOpenCallCount++;
+    return g_mockPidfd;
+}
+
+// Mock AM DBus interface for testing
+QDBusReply<QStringMap> g_mockIconsReply;
+QStringMap g_mockIconsMap = {{"", "test-icon"}};
+
+QDBusReply<QStringMap> createIconsReply() {
+    QDBusReply<QStringMap> reply;
+    reply.m_value = g_mockIconsMap;
+    return reply;
+}
+
+QDBusReply<QDBusObjectPath> createIdentifyReply() {
+    QDBusReply<QDBusObjectPath> reply;
+    reply.m_value = QDBusObjectPath("/org/desktopspec/ApplicationManager1/test");
+    return reply;
+}
+
+// Stub QDBusInterface::call
+QDBusReply<QDBusObjectPath> testCallIdentify(int pidfd) {
+    return createIdentifyReply();
+}
+
+// Stub QDBusInterface::property
+QDBusReply<QStringMap> testPropertyIcons() {
+    return createIconsReply();
+}
+
+/***************************************STUB end*********************************************/
+
+class UT_AMIconManager : public ::testing::Test
+{
+public:
+    UT_AMIconManager()
+        : m_tester(nullptr) {}
+
+public:
+    virtual void SetUp()
+    {
+        m_tester = new AMIconManager();
+    }
+
+    virtual void TearDown()
+    {
+        if (m_tester) {
+            delete m_tester;
+            m_tester = nullptr;
+        }
+        // Reset stub state
+        g_pidfdOpenCallCount = 0;
+        g_mockIconsMap = {{"", "test-icon"}};
+    }
+
+protected:
+    AMIconManager *m_tester;
+};
+
+TEST_F(UT_AMIconManager, TestGetInstance)
+{
+    auto *instance1 = AMIconManager::instance();
+    auto *instance2 = AMIconManager::instance();
+    EXPECT_EQ(instance1, instance2);
+}
+
+TEST_F(UT_AMIconManager, TestIsAMAvailable_V20Plus)
+{
+    // Set mock system version >= 20
+    g_mockMajorVersion = 20;
+    
+    // Re-create manager to pick up new version
+    delete m_tester;
+    m_tester = new AMIconManager();
+    
+    EXPECT_TRUE(m_tester->isAMAvailable());
+}
+
+TEST_F(UT_AMIconManager, TestIsAMAvailable_PreV20)
+{
+    // Set mock system version < 20
+    g_mockMajorVersion = 19;
+    
+    // Re-create manager to pick up new version
+    delete m_tester;
+    m_tester = new AMIconManager();
+    
+    EXPECT_FALSE(m_tester->isAMAvailable());
+}
+
+TEST_F(UT_AMIconManager, TestGetIconByPid_V20Plus)
+{
+    // Set mock system version >= 20
+    g_mockMajorVersion = 20;
+    g_mockIconsMap = {{"", "test-app-icon"}};
+    
+    // Re-create manager
+    delete m_tester;
+    m_tester = new AMIconManager();
+    
+    pid_t testPid = 1234;
+    QString iconName = m_tester->getIconByPid(testPid);
+    
+    // Should return icon name from mock
+    EXPECT_EQ(iconName, QString("test-app-icon"));
+    EXPECT_GT(g_pidfdOpenCallCount, 0);
+}
+
+TEST_F(UT_AMIconManager, TestGetIconByPid_CacheHit)
+{
+    // Set up V20+ system
+    g_mockMajorVersion = 20;
+    g_mockIconsMap = {{"", "cached-icon"}};
+    
+    delete m_tester;
+    m_tester = new AMIconManager();
+    
+    pid_t testPid = 5678;
+    
+    // First call should add to cache
+    QString icon1 = m_tester->getIconByPid(testPid);
+    EXPECT_EQ(icon1, QString("cached-icon"));
+    
+    // Second call should hit cache
+    g_mockIconsMap = {{"", "not-used-icon"}};
+    g_pidfdOpenCallCount = 0;
+    QString icon2 = m_tester->getIconByPid(testPid);
+    EXPECT_EQ(icon2, QString("cached-icon"));
+    
+    // Should not call pidfd_open again (cache hit)
+    EXPECT_EQ(g_pidfdOpenCallCount, 0);
+}
+
+TEST_F(UT_AMIconManager, TestGetIconByPid_PreV20)
+{
+    // Set mock system version < 20
+    g_mockMajorVersion = 19;
+    
+    delete m_tester;
+    m_tester = new AMIconManager();
+    
+    pid_t testPid = 9999;
+    QString iconName = m_tester->getIconByPid(testPid);
+    
+    // Should return empty string (AM not available)
+    EXPECT_TRUE(iconName.isEmpty());
+}
+
+TEST_F(UT_AMIconManager, TestRemoveCachedIcon)
+{
+    // Set up V20+ system
+    g_mockMajorVersion = 20;
+    
+    delete m_tester;
+    m_tester = new AMIconManager();
+    
+    pid_t testPid = 8888;
+    
+    // First call to cache the icon
+    m_tester->getIconByPid(testPid);
+    
+    // Remove cached icon
+    m_tester->removeCachedIcon(testPid);
+    
+    // Call again should hit AM again (not cache)
+    int callsBefore = g_pidfdOpenCallCount;
+    QString iconName = m_tester->getIconByPid(testPid);
+    EXPECT_GT(g_pidfdOpenCallCount, callsBefore);
+}
+
+TEST_F(UT_AMIconManager, TestClearCache)
+{
+    // Set up V20+ system
+    g_mockMajorVersion = 20;
+    
+    delete m_tester;
+    m_tester = new AMIconManager();
+    
+    // Add some icons to cache
+    m_tester->getIconByPid(1001);
+    m_tester->getIconByPid(1002);
+    m_tester->getIconByPid(1003);
+    
+    // Clear cache
+    m_tester->clearCache();
+    
+    // Next call should call AM again
+    int callsBefore = g_pidfdOpenCallCount;
+    m_tester->getIconByPid(2001);
+    EXPECT_GT(g_pidfdOpenCallCount, callsBefore);
+}
+
+TEST_F(UT_AMIconManager, TestGetIconByPid_AMUnavailable)
+{
+    // Set mock system version >= 20 but AM service not registered
+    g_mockMajorVersion = 20;
+    // Note: In real test, we'd mock sessionBus->isServiceRegistered() to return false
+    // For now, we assume AM is available
+    
+    delete m_tester;
+    m_tester = new AMIconManager();
+    
+    pid_t testPid = 7777;
+    QString iconName = m_tester->getIconByPid(testPid);
+    
+    // Should return icon name (from mock AM)
+    EXPECT_FALSE(iconName.isEmpty());
+}


### PR DESCRIPTION
Add Application Manager integration to group linglong application sub-processes, merging CPU, memory and display name into the main process.

集成应用管理器(AM)，将玲珑应用的多个子进程合并显示，
聚合CPU、内存等资源统计到主进程。

Log: 集成AM实现玲珑应用多进程合并显示
PMS: BUG-271645
Influence: V20+系统玲珑应用在系统监视器中合并为单行显示，
聚合CPU/内存数据，子进程从"我的应用"视图隐藏。