### PR TITLE
feat(process): support killing linglong processes via ll-cli

### DIFF
--- a/deepin-system-monitor-main/CMakeLists.txt
+++ b/deepin-system-monitor-main/CMakeLists.txt
@@ -308,6 +308,7 @@ set(HPP_PROCESS
     process/process_name_cache.h
     process/priority_controller.h
     process/process_controller.h
+    process/linglong_controller.h
     process/desktop_entry_cache.h
     process/am_icon_manager.h
     process/desktop_entry_cache_updater.h
@@ -322,6 +323,7 @@ set(CPP_PROCESS
     process/process_name_cache.cpp
     process/priority_controller.cpp
     process/process_controller.cpp
+    process/linglong_controller.cpp
     process/desktop_entry_cache.cpp
     process/am_icon_manager.cpp
     process/desktop_entry_cache_updater.cpp

--- a/deepin-system-monitor-main/process/am_icon_manager.cpp
+++ b/deepin-system-monitor-main/process/am_icon_manager.cpp
@@ -13,6 +13,7 @@
 #include <QDBusObjectPath>
 #include <QDebug>
 #include <QDBusUnixFileDescriptor>
+#include <DDesktopEntry>
 #include <cerrno>
 #include <cstring>
 #include <signal.h>
@@ -286,11 +287,28 @@ AMProcessGroupInfo AMIconManager::identifyProcess(int pidfd)
 
     // Get icon name
     result.iconName = getIconByAppId(result.appId);
-
-    // Get display name
     result.displayName = getAppNameByAppId(result.appId);
 
+    result.linglongAppId = resolveLinglongAppId(result.appId);
+
     return result;
+}
+
+QString AMIconManager::resolveLinglongAppId(const QString &appId)
+{
+    if (m_linglongAppIdCache.contains(appId)) {
+        return m_linglongAppIdCache[appId];
+    }
+
+    QString desktopPath = QString("/var/lib/linglong/entries/apps/share/applications/%1.desktop").arg(appId);
+    if (!QFile::exists(desktopPath)) {
+        m_linglongAppIdCache[appId] = QString();
+        return QString();
+    }
+    DDesktopEntry entry(desktopPath);
+    QString linglongId = entry.stringValue("X-linglong");
+    m_linglongAppIdCache[appId] = linglongId;
+    return linglongId;
 }
 
 QString AMIconManager::getIconByPid(pid_t pid)

--- a/deepin-system-monitor-main/process/am_icon_manager.h
+++ b/deepin-system-monitor-main/process/am_icon_manager.h
@@ -29,11 +29,13 @@ namespace process {
  */
 struct AMProcessGroupInfo
 {
-    QString appId;              // Application ID (e.g., "qq")
+    QString appId;              // Application ID from AM (e.g., "deepin-editor")
+    QString linglongAppId;     // Full linglong appId for ll-cli (e.g., "org.deepin.editor"), empty if not linglong
     QString instancePath;       // Instance object path from AM
     QString iconName;           // Icon name for this application
     QString displayName;        // Localized display name from AM (e.g., "QQ")
     bool isValid() const { return !appId.isEmpty() && !instancePath.isEmpty(); }
+    bool isLinglong() const { return !linglongAppId.isEmpty(); }
 };
 
 /**
@@ -118,6 +120,8 @@ private:
      */
     AMProcessGroupInfo identifyProcess(int pidfd);
 
+    QString resolveLinglongAppId(const QString &appId);
+
 private:
     QDBusInterface *m_amInterface {nullptr};
     bool m_amAvailable {false};
@@ -132,6 +136,9 @@ private:
 
     // PID to process group info cache
     QMap<pid_t, AMProcessGroupInfo> m_pidToGroupCache;
+
+    // linglong appId cache: AM appId -> linglong reverse domain appId
+    QHash<QString, QString> m_linglongAppIdCache;
 
     mutable std::mutex m_cacheMutex;
     

--- a/deepin-system-monitor-main/process/linglong_controller.cpp
+++ b/deepin-system-monitor-main/process/linglong_controller.cpp
@@ -1,0 +1,75 @@
+// Copyright (C) 2026 Uniontech Software Technology Co.,Ltd
+// SPDX-FileCopyrightText: 2026 Uniontech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "linglong_controller.h"
+
+#include "application.h"
+#include "ddlog.h"
+
+#include <QFile>
+#include <QProcess>
+#include <QRegularExpression>
+
+#include <cerrno>
+#include <csignal>
+
+#define CMD_LL_CLI "/usr/bin/ll-cli"
+
+using namespace DDLog;
+
+LinglongController::LinglongController(const QString &appId, int signal, QObject *parent)
+    : QObject(parent)
+    , m_appId(appId)
+    , m_signal(signal)
+{
+    qCDebug(app) << "LinglongController created for appId:" << m_appId << "with signal:" << m_signal;
+    m_proc = new QProcess(this);
+    connect(m_proc, &QProcess::started, this, [=]() {
+        qCDebug(app) << "QProcess started";
+        Q_EMIT gApp->backgroundTaskStateChanged(Application::kTaskStarted);
+    });
+    connect(m_proc, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
+            this, [=](int rc, QProcess::ExitStatus) {
+                qCDebug(app) << "ll-cli kill finished with rc:" << rc;
+                if (rc != 0) {
+                    QString stderrOutput = QString::fromLocal8Bit(m_proc->readAllStandardError()).trimmed();
+                    qCWarning(app) << "ll-cli kill failed. appId:" << m_appId
+                                   << "rc:" << rc << "stderr:" << stderrOutput;
+                }
+                Q_EMIT resultReady(rc);
+                Q_EMIT gApp->backgroundTaskStateChanged(Application::kTaskFinished);
+                m_proc->deleteLater();
+                Q_EMIT finished();
+            });
+}
+
+void LinglongController::execute()
+{
+    qCDebug(app) << "Executing ll-cli kill for appId:" << m_appId;
+
+    // Validate appId format: only allow reverse domain characters
+    static const QRegularExpression appIdRe("^[a-zA-Z0-9.-]+$");
+    if (!appIdRe.match(m_appId).hasMatch()) {
+        qCWarning(app) << "Invalid linglong appId format:" << m_appId;
+        Q_EMIT resultReady(EINVAL);
+        Q_EMIT finished();
+        return;
+    }
+
+    if (!QFile::exists(CMD_LL_CLI)) {
+        qCWarning(app) << "ll-cli not found at" << CMD_LL_CLI;
+        Q_EMIT resultReady(ENOENT);
+        Q_EMIT finished();
+        return;
+    }
+
+    // ll-cli kill -s expects signal name (e.g., SIGTERM, SIGKILL), not number
+    QString sigName = (m_signal == SIGKILL) ? "SIGKILL" : "SIGTERM";
+    QStringList params;
+    params << "kill" << "-s" << sigName << m_appId;
+    qCDebug(app) << "Starting process:" << CMD_LL_CLI << params;
+
+    m_proc->start(CMD_LL_CLI, params);
+}

--- a/deepin-system-monitor-main/process/linglong_controller.h
+++ b/deepin-system-monitor-main/process/linglong_controller.h
@@ -1,0 +1,55 @@
+// Copyright (C) 2026 Uniontech Software Technology Co.,Ltd
+// SPDX-FileCopyrightText: 2026 Uniontech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef LINGLONG_CONTROLLER_H
+#define LINGLONG_CONTROLLER_H
+
+#include <QObject>
+
+class QProcess;
+
+/**
+ * @brief Proxy class to execute ll-cli kill for linglong container processes
+ *
+ * Linglong applications run in isolated namespaces where the host's kill()
+ * cannot reach them. This class wraps `ll-cli kill <appId> -s <signal>` via
+ * QProcess to terminate linglong container processes.
+ */
+class LinglongController : public QObject
+{
+    Q_OBJECT
+
+public:
+    /**
+     * @brief Linglong controller constructor
+     * @param appId Linglong application ID (e.g., "com.qq.im")
+     * @param signal Signal to send (SIGTERM or SIGKILL)
+     * @param parent Parent object
+     */
+    explicit LinglongController(const QString &appId, int signal, QObject *parent = nullptr);
+
+    /**
+     * @brief Execute ll-cli kill in a subprocess
+     */
+    void execute();
+
+Q_SIGNALS:
+    /**
+     * @brief Process execute result ready signal
+     * @param code Return code of the finished process
+     */
+    void resultReady(int code);
+    /**
+     * @brief Process finished signal
+     */
+    void finished();
+
+private:
+    QString m_appId;
+    int m_signal {0};
+    QProcess *m_proc;
+};
+
+#endif  // LINGLONG_CONTROLLER_H

--- a/deepin-system-monitor-main/process/process_db.cpp
+++ b/deepin-system-monitor-main/process/process_db.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd
+// Copyright (C) 2019 - 2026 Uniontech Software Technology Co.,Ltd
 // SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -13,6 +13,8 @@
 #include "process_name.h"
 #include "process_name_cache.h"
 #include "process_controller.h"
+#include "linglong_controller.h"
+#include "am_icon_manager.h"
 #include "priority_controller.h"
 
 #include <QReadLocker>
@@ -227,6 +229,40 @@ void ProcessDB::onProcessPrioritysetChanged(pid_t pid, int priority)
 void ProcessDB::sendSignalToProcess(pid_t pid, int signal)
 {
     qCDebug(app) << "sendSignalToProcess called for pid" << pid << "with signal" << signal;
+
+    AMProcessGroupInfo groupInfo = AMIconManager::instance()->getProcessGroupInfo(pid);
+    if (groupInfo.isValid() && groupInfo.isLinglong() && (signal == SIGTERM || signal == SIGKILL)) {
+        qCInfo(app) << "Linglong process detected, using ll-cli kill. PID:" << pid
+                     << "appId:" << groupInfo.linglongAppId << "signal:" << signal;
+        auto *ctrl = new LinglongController(groupInfo.linglongAppId, signal, this);
+        connect(ctrl, &LinglongController::resultReady, this, [this, pid, signal, groupInfo](int code) {
+            if (code != 0) {
+                qCWarning(app) << "ll-cli kill failed. PID:" << pid << "appId:" << groupInfo.linglongAppId << "rc:" << code;
+                ErrorContext ec {};
+                ec.setCode(ErrorContext::kErrorTypeSystem);
+                ec.setSubCode(code);
+                ec.setErrorName(signal == SIGTERM
+                                     ? QApplication::translate("Process.Signal", "Failed to end process")
+                                     : QApplication::translate("Process.Signal", "Failed to kill process"));
+                ec.setErrorMessage(QString("PID: %1, AppId: %2, ll-cli kill failed with code: %3")
+                                       .arg(pid)
+                                       .arg(groupInfo.linglongAppId)
+                                       .arg(code));
+                Q_EMIT processControlResultReady(ec);
+            } else {
+                qCInfo(app) << "ll-cli kill succeeded. PID:" << pid << "appId:" << groupInfo.linglongAppId;
+                if (signal == SIGTERM) {
+                    Q_EMIT processEnded(pid);
+                } else {
+                    Q_EMIT processKilled(pid);
+                }
+            }
+        });
+        connect(ctrl, &LinglongController::finished, ctrl, &QObject::deleteLater);
+        ctrl->execute();
+        return;
+    }
+
     ErrorContext ec = {};
     auto errfmt = [ = ](decltype(errno) err, const QString & title, int p, int sig,
     ErrorContext & ectx) -> ErrorContext & {


### PR DESCRIPTION
Detect linglong container processes by AMProcessGroupInfo.appId and dispatch to `ll-cli kill <appId> -s <signal>` instead of host kill().

通过 AMProcessGroupInfo.appId 检测玲珑容器进程，
使用 ll-cli kill 替代宿主机 kill() 终止进程。

Log: 支持通过 ll-cli kill 终止玲珑容器进程
Influence: 右键"结束进程"/"强制结束进程"对玲珑应用进程生效，普通进程行为不受影响。