### PR TITLE
chore: update version to 6.5.45

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+deepin-system-monitor (6.5.45) unstable; urgency=medium
+
+  * fix(test): disable unstable unit tests causing ASan crashes
+  * feat(process): support killing linglong processes via ll-cli
+  * feat(process): integrate AM for linglong app process grouping
+  * fix(ci): clean up stale comments in Arch Linux build workflow
+  * [skip CI] Translate deepin-system-monitor.ts in es
+  * chore: update version to 6.5.44
+
+ -- re2zero <yangwu@uniontech.com>  Thu, 04 Jun 2026 20:24:45 +0800
+
 deepin-system-monitor (6.5.44) unstable; urgency=medium
 
   * chore: Update version to 6.5.44


### PR DESCRIPTION
## Summary
- bump version from 6.5.44 to 6.5.45
- update debian/changelog with commits since 6.5.44

## Changes
| File | Change |
|------|--------|
| debian/changelog | Add 6.5.45 version entry with release notes |

## Summary by Sourcery

Update project metadata for the 6.5.45 release.

Enhancements:
- Bump project version from 6.5.44 to 6.5.45 in release metadata.
- Add a 6.5.45 entry with release notes to debian/changelog.