### PR TITLE
fix(process): guard missing stat name delimiter

### DIFF
--- a/deepin-system-monitor-main/process/process.cpp
+++ b/deepin-system-monitor-main/process/process.cpp
@@ -312,11 +312,14 @@ bool Process::readStat()
 
     // get process name between (...)
     begin = strchr(buf.data(), '(');
+    if (!begin) {
+        return false;
+    }
     begin += 1;
 
     pos = strrchr(buf.data(), ')');
     if (!pos) {
-        return !ok;
+        return false;
     }
 
     *pos = '\0';


### PR DESCRIPTION
Return false when /proc stat misses the process name delimiter.

当 /proc stat 缺少进程名分隔符时返回 false。

Log: 修复进程 stat 解析空指针风险

Task: https://pms.uniontech.com/task-view-390717.html

Influence: 异常 /proc stat 格式下不再触发空指针未定义行为，正常进程信息读取逻辑不变。

## Summary by Sourcery

Guard process stat parsing against missing process name delimiters to avoid null dereferences and undefined behavior.

Bug Fixes:
- Return failure when /proc stat lacks the opening '(' delimiter for the process name.
- Return failure when /proc stat lacks the closing ')' delimiter for the process name instead of relying on previous state.