### PR TITLE
fix(system): correct uptime timeval parsing

### DIFF
--- a/deepin-system-monitor-main/system/sys_info.cpp
+++ b/deepin-system-monitor-main/system/sys_info.cpp
@@ -336,12 +336,12 @@ void SysInfo::read_uptime(struct timeval &uptime)
         fPtr.reset(fp);
 
         char buf[128] {};
-        long up_sec, up_usec;
+        double up_sec {};
         if (fgets(buf, sizeof(buf), fp)) {
-            int nm = sscanf(buf, "%ld.%ld", &up_sec, &up_usec);
-            if (nm == 2) {
-                uptime.tv_sec = up_sec;
-                uptime.tv_usec = up_usec * 1000000;
+            int nm = sscanf(buf, "%lf", &up_sec);
+            if (nm == 1) {
+                uptime.tv_sec = static_cast<time_t>(up_sec);
+                uptime.tv_usec = static_cast<suseconds_t>((up_sec - uptime.tv_sec) * 1000000);
 
                 return;
             }


### PR DESCRIPTION
Parse /proc/uptime as floating-point seconds before splitting timeval.

将 /proc/uptime 作为浮点秒数解析，再拆分为 timeval。

Log: 修复 uptime 微秒单位换算错误

Task: https://pms.uniontech.com/task-view-390717.html

Influence: 修复系统运行时间微秒字段异常放大问题，提升采样时间计算准确性。