### PR TITLE
fix(network): validate route metric before device selection

### DIFF
--- a/deepin-system-monitor-main/system/netif_packet_capture.cpp
+++ b/deepin-system-monitor-main/system/netif_packet_capture.cpp
@@ -147,13 +147,18 @@ bool NetifPacketCapture::getCurrentDevName()
     for (int i = 0; i < totalList.size(); i++) {
         auto list = totalList[i];
         if (list.size() > devColNum && list.size() > metricColNum) {
+            bool ok = false;
+            int metric = list[metricColNum].toInt(&ok);
+            if (!ok || metric < 0) {
+                continue;
+            }
             // 默认网卡
             if (!list.isEmpty() && list.first() == "0.0.0.0") {
                 metricList.clear();
-                metricList.append(QPair<QString, int>(list[devColNum], list[metricColNum].toInt()));
+                metricList.append(QPair<QString, int>(list[devColNum], metric));
                 break;
             } else {
-                metricList.append(QPair<QString, int>(list[devColNum], list[metricColNum].toInt()));
+                metricList.append(QPair<QString, int>(list[devColNum], metric));
             }
         }
     }


### PR DESCRIPTION
Check toInt conversion result and reject negative metric values when parsing route -n output for best network device selection.

解析 route -n 输出时校验 Metric 转换结果并过滤负值，避免转换失败时静默使用 0 而误选网卡。

Log: 修复路由 Metric 转换未校验问题

Task: https://pms.uniontech.com/task-view-390717.html

Influence: 路由表输出异常时不再误选网卡设备，默认网关优先级逻辑不受影响。

## Summary by Sourcery

Bug Fixes:
- Reject invalid or negative route metric values when building the candidate interface list to prevent incorrect default network device selection.