### PR TITLE
fix(process): handle missing pkexec or kill gracefully

### DIFF
--- a/deepin-system-monitor-main/process/process_controller.cpp
+++ b/deepin-system-monitor-main/process/process_controller.cpp
@@ -51,12 +51,14 @@ void ProcessController::execute()
     // check pkexec existance
     if (!QFile::exists({CMD_PKEXEC})) {
         Q_EMIT resultReady(ENOENT);
-        exit(ENOENT);
+        Q_EMIT finished();
+        return;
     }
     // check kill existance
     if (!QFile::exists({CMD_KILL})) {
         Q_EMIT resultReady(ENOENT);
-        exit(ENOENT);
+        Q_EMIT finished();
+        return;
     }
 
     // format: kill -{signal} {pid}


### PR DESCRIPTION
Avoid calling exit() when pkexec or kill binary is not found.

pkexec 或 kill 不存在时不再终止整个 GUI 应用，仅通知调用方失败。

Log: 修复 pkexec kill 不存在时直接退出应用

Task: https://pms.uniontech.com/task-view-390717.html

Influence: pkexec 或 kill 缺失时仅当前操作失败，不终止整个系统监视器 GUI。

## Summary by Sourcery

Bug Fixes:
- Prevent the system monitor GUI from exiting when pkexec or kill binaries are not found, instead reporting the error and completing the operation gracefully.