### PR TITLE
fix(gui): update disk and network scrollbar policy

### DIFF
--- a/deepin-system-monitor-main/gui/block_dev_stat_view_widget.cpp
+++ b/deepin-system-monitor-main/gui/block_dev_stat_view_widget.cpp
@@ -19,6 +19,7 @@ BlockStatViewWidget::BlockStatViewWidget(QWidget *parent) : QScrollArea(parent)
     m_centralWidget = new QWidget(this);
     this->setWidget(m_centralWidget);
     this->setFrameShape(QFrame::NoFrame);
+    this->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
     onUpdateData();
     connect(SystemMonitor::instance(), &SystemMonitor::statInfoUpdated, this, &BlockStatViewWidget::onUpdateData);
@@ -43,6 +44,9 @@ void BlockStatViewWidget::updateWidgetGeometry()
     if (deviceCount <= 0) {
         return ;
     }
+
+    setHorizontalScrollBarPolicy(deviceCount > 4 ? Qt::ScrollBarAlwaysOn : Qt::ScrollBarAlwaysOff);
+    setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
     if (deviceCount == 1) {
         showItem1();

--- a/deepin-system-monitor-main/gui/netif_stat_view_widget.cpp
+++ b/deepin-system-monitor-main/gui/netif_stat_view_widget.cpp
@@ -18,6 +18,7 @@ NetifStatViewWidget::NetifStatViewWidget(QWidget *parent) : DScrollArea(parent)
     m_centralWidget = new QWidget(this);
     this->setWidget(m_centralWidget);
     this->setFrameShape(QFrame::NoFrame);
+    this->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
     m_info = DeviceDB::instance()->netifInfoDB();
 }
@@ -98,6 +99,9 @@ void NetifStatViewWidget::updateWidgetGeometry()
 {
     const QMap<QByteArray, NetifInfoPtr> &netifInfoDB = m_info->infoDB();
     int netCount  = netifInfoDB.size();
+
+    setHorizontalScrollBarPolicy(netCount > 4 ? Qt::ScrollBarAlwaysOn : Qt::ScrollBarAlwaysOff);
+    setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
     if (netCount == 1)
         showItemOnlyeOne();

--- a/tests/deepin-system-monitor-main/gui/ut_block_dev_stat_view_widget.cpp
+++ b/tests/deepin-system-monitor-main/gui/ut_block_dev_stat_view_widget.cpp
@@ -75,6 +75,57 @@ TEST_F(UT_BlockStatViewWidget, initTest)
 
 }
 
+TEST_F(UT_BlockStatViewWidget, test_scrollBarPolicy_01)
+{
+    Stub stub;
+    stub.set(ADDR(BlockStatViewWidget, showItem1), stub_updateWidgetGeometry_showItem1);
+    stub.set(ADDR(BlockStatViewWidget, showItemLg2), stub_updateWidgetGeometry_showItemLg2);
+
+    m_tester->m_listDevice.clear();
+    for (int i = 0; i < 5; ++i) {
+        BlockDevice blockDev;
+        m_tester->m_listDevice.append(blockDev);
+    }
+    m_tester->updateWidgetGeometry();
+    EXPECT_EQ(m_tester->horizontalScrollBarPolicy(), Qt::ScrollBarAlwaysOn);
+    EXPECT_EQ(m_tester->verticalScrollBarPolicy(), Qt::ScrollBarAlwaysOff);
+
+    m_tester->m_listDevice.clear();
+    for (int i = 0; i < 4; ++i) {
+        BlockDevice blockDev;
+        m_tester->m_listDevice.append(blockDev);
+    }
+    m_tester->updateWidgetGeometry();
+    EXPECT_EQ(m_tester->horizontalScrollBarPolicy(), Qt::ScrollBarAlwaysOff);
+    EXPECT_EQ(m_tester->verticalScrollBarPolicy(), Qt::ScrollBarAlwaysOff);
+
+    m_tester->m_listDevice.clear();
+    BlockDevice blockDev;
+    m_tester->m_listDevice.append(blockDev);
+    m_tester->updateWidgetGeometry();
+    EXPECT_EQ(m_tester->horizontalScrollBarPolicy(), Qt::ScrollBarAlwaysOff);
+    EXPECT_EQ(m_tester->verticalScrollBarPolicy(), Qt::ScrollBarAlwaysOff);
+}
+
+TEST_F(UT_BlockStatViewWidget, test_scrollBarPolicy_02)
+{
+    m_tester->m_listDevice.clear();
+    for (int i = 0; i < 5; ++i) {
+        BlockDevice blockDev;
+        m_tester->m_listDevice.append(blockDev);
+    }
+
+    Stub stub;
+    stub.set(ADDR(BlockStatViewWidget, showItemLg2), stub_updateWidgetGeometry_showItemLg2);
+    m_tester->updateWidgetGeometry();
+    EXPECT_EQ(m_tester->horizontalScrollBarPolicy(), Qt::ScrollBarAlwaysOn);
+
+    static QResizeEvent re(QSize(10, 10), QSize(20, 20));
+    m_tester->resizeEvent(&re);
+    EXPECT_EQ(m_tester->horizontalScrollBarPolicy(), Qt::ScrollBarAlwaysOn);
+    EXPECT_EQ(m_tester->verticalScrollBarPolicy(), Qt::ScrollBarAlwaysOff);
+}
+
 TEST_F(UT_BlockStatViewWidget, test_resizeEvent_01)
 {
     static QResizeEvent re(QSize(10, 10), QSize(20, 20));

--- a/tests/deepin-system-monitor-main/gui/ut_netif_stat_view_widget.cpp
+++ b/tests/deepin-system-monitor-main/gui/ut_netif_stat_view_widget.cpp
@@ -25,6 +25,18 @@ void stub_onModelUpdate_updateData()
 {
     return;
 }
+
+static int g_stubNetifCount = 0;
+const QMap<QByteArray, NetifInfoPtr> stub_updateWidgetGeometry_infoDB_custom()
+{
+    QMap<QByteArray, NetifInfoPtr> map;
+    NetifInfoPtr ptr;
+    for (int i = 0; i < g_stubNetifCount; ++i) {
+        map.insert(QByteArray::number(i + 1), ptr);
+    }
+    return map;
+}
+
 const QMap<QByteArray, NetifInfoPtr> stub_updateWidgetGeometry_infoDB_1()
 {
     QMap<QByteArray, NetifInfoPtr> map;
@@ -113,6 +125,42 @@ protected:
 TEST_F(UT_NetifStatViewWidget, initTest)
 {
 
+}
+
+TEST_F(UT_NetifStatViewWidget, test_scrollBarPolicy_01)
+{
+    Stub stub;
+    stub.set(ADDR(core::system::NetifInfoDB, infoDB), stub_updateWidgetGeometry_infoDB_custom);
+
+    g_stubNetifCount = 5;
+    m_tester->updateWidgetGeometry();
+    EXPECT_EQ(m_tester->horizontalScrollBarPolicy(), Qt::ScrollBarAlwaysOn);
+    EXPECT_EQ(m_tester->verticalScrollBarPolicy(), Qt::ScrollBarAlwaysOff);
+
+    g_stubNetifCount = 4;
+    m_tester->updateWidgetGeometry();
+    EXPECT_EQ(m_tester->horizontalScrollBarPolicy(), Qt::ScrollBarAlwaysOff);
+    EXPECT_EQ(m_tester->verticalScrollBarPolicy(), Qt::ScrollBarAlwaysOff);
+
+    g_stubNetifCount = 1;
+    m_tester->updateWidgetGeometry();
+    EXPECT_EQ(m_tester->horizontalScrollBarPolicy(), Qt::ScrollBarAlwaysOff);
+    EXPECT_EQ(m_tester->verticalScrollBarPolicy(), Qt::ScrollBarAlwaysOff);
+}
+
+TEST_F(UT_NetifStatViewWidget, test_scrollBarPolicy_02)
+{
+    Stub stub;
+    stub.set(ADDR(core::system::NetifInfoDB, infoDB), stub_updateWidgetGeometry_infoDB_custom);
+
+    g_stubNetifCount = 5;
+    m_tester->updateWidgetGeometry();
+    EXPECT_EQ(m_tester->horizontalScrollBarPolicy(), Qt::ScrollBarAlwaysOn);
+
+    static QResizeEvent event(QSize(10, 10), QSize(20, 20));
+    m_tester->resizeEvent(&event);
+    EXPECT_EQ(m_tester->horizontalScrollBarPolicy(), Qt::ScrollBarAlwaysOn);
+    EXPECT_EQ(m_tester->verticalScrollBarPolicy(), Qt::ScrollBarAlwaysOff);
 }
 
 TEST_F(UT_NetifStatViewWidget, test_updateWidgetGeometry_01)


### PR DESCRIPTION
Control horizontal scrollbar visibility for disk and network stat views.

磁盘或网卡数量大于 4 时显示横向滚动条，小于等于 4 时隐藏横向滚动条，并保持垂直滚动条隐藏。

Log: 修复磁盘和网卡统计卡片滚动条显示策略

Bug: https://pms.uniontech.com/bug-view-364287.html

Influence: 磁盘或网卡数量变化时，统计卡片横向滚动条按数量正确显示或隐藏，不影响其他功能。

## Summary by Sourcery

Adjust scrollbar visibility policies in disk and network statistics views based on the number of devices or interfaces and ensure behavior is validated by tests.

Bug Fixes:
- Fix disk statistics view to only show a horizontal scrollbar when more than four block devices are present while keeping the vertical scrollbar hidden.
- Fix network statistics view to only show a horizontal scrollbar when more than four network interfaces are present while keeping the vertical scrollbar hidden.

Tests:
- Add unit tests covering scrollbar visibility behavior in disk statistics views for different device counts and resize events.
- Add unit tests covering scrollbar visibility behavior in network statistics views for different interface counts and resize events.