### PR TITLE
test: add unit tests for model/service/wm modules and fix test build

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -330,6 +330,7 @@ set(CPP_PROCESS
     ${CMAKE_HOME_DIRECTORY}/${PROJECT_NAME}-main/process/desktop_entry_cache_updater.cpp
     ${CMAKE_HOME_DIRECTORY}/${PROJECT_NAME}-main/process/process_db.cpp
     ${CMAKE_HOME_DIRECTORY}/${PROJECT_NAME}-main/process/system_service_client.cpp
+    ${CMAKE_HOME_DIRECTORY}/${PROJECT_NAME}-main/process/linglong_controller.cpp
 )
 
 set(HPP_SERVICE

--- a/tests/deepin-system-monitor-main/model/ut_accounts_info_model.cpp
+++ b/tests/deepin-system-monitor-main/model/ut_accounts_info_model.cpp
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//self
+#include "model/accounts_info_model.h"
+#include "model/user.h"
+//gtest
+#include "stub.h"
+#include "addr_pri.h"
+#include <gtest/gtest.h>
+//Qt
+#include <QString>
+
+// getCurrentUserType() 把私有成员 m_currentUserType (int) 映射到
+// User::UserType 枚举，是 AccountsInfoModel 中唯一不依赖 D-Bus 的纯逻辑，
+// 共 4 个分支。这里用 addr_pri 的 ACCESS_PRIVATE_FIELD 直接注入 m_currentUserType，
+// 在不触发任何 D-Bus 方法调用的情况下遍历全部分支。
+
+// 生成 access_private_field::AccountsInfoModelm_currentUserType(obj) 访问器
+ACCESS_PRIVATE_FIELD(AccountsInfoModel, int, m_currentUserType)
+
+class UT_AccountsInfoModel : public ::testing::Test
+{
+public:
+    UT_AccountsInfoModel() : m_model(nullptr) {}
+
+public:
+    virtual void SetUp()
+    {
+        // 构造时会连系统总线读取在线会话/用户列表；开发机 login1 正常运行时
+        // 为毫秒级同步返回，与仓库其它 D-Bus 类测试 (ut_process_db 等) 同模式。
+        m_model = new AccountsInfoModel();
+    }
+
+    virtual void TearDown()
+    {
+        if (m_model) {
+            delete m_model;
+            m_model = nullptr;
+        }
+    }
+
+    // 注入 m_currentUserType 的私有值并断言 getCurrentUserType() 的映射结果
+    void setCurrentUserType(int value)
+    {
+        access_private_field::AccountsInfoModelm_currentUserType(*m_model) = value;
+    }
+
+protected:
+    AccountsInfoModel *m_model;
+};
+
+// 分支1: m_currentUserType == -1 → Customized
+TEST_F(UT_AccountsInfoModel, GetCurrentUserType_Uninitialized_ReturnsCustomized)
+{
+    setCurrentUserType(-1);
+    EXPECT_EQ(m_model->getCurrentUserType(), User::UserType::Customized);
+}
+
+// 分支2: m_currentUserType == 0 → StandardUser
+TEST_F(UT_AccountsInfoModel, GetCurrentUserType_StandardUser)
+{
+    setCurrentUserType(0);
+    EXPECT_EQ(m_model->getCurrentUserType(), User::UserType::StandardUser);
+}
+
+// 分支3: m_currentUserType == 1 → Administrator
+TEST_F(UT_AccountsInfoModel, GetCurrentUserType_Administrator)
+{
+    setCurrentUserType(1);
+    EXPECT_EQ(m_model->getCurrentUserType(), User::UserType::Administrator);
+}
+
+// 分支4: m_currentUserType 为其它值 (如 2) → 兜底返回 StandardUser
+TEST_F(UT_AccountsInfoModel, GetCurrentUserType_UnknownValue_FallbackToStandardUser)
+{
+    setCurrentUserType(2);
+    EXPECT_EQ(m_model->getCurrentUserType(), User::UserType::StandardUser);
+
+    setCurrentUserType(999);
+    EXPECT_EQ(m_model->getCurrentUserType(), User::UserType::StandardUser);
+}

--- a/tests/deepin-system-monitor-main/model/ut_process_table_model.cpp
+++ b/tests/deepin-system-monitor-main/model/ut_process_table_model.cpp
@@ -1099,3 +1099,95 @@ TEST_F(UT_ProcessTableModel, test_updateProcessPriority_001)
      m_tester->updateProcessPriority(pid,priority);
 
 }
+
+// getProcessPriorityValue：pid 不在列表 → 兜底 kNormalPriority(0)
+TEST_F(UT_ProcessTableModel, test_getProcessPriorityValue_001)
+{
+    pid_t pid = 999999; // 不在 m_procIdList 中
+    EXPECT_EQ(m_tester->getProcessPriorityValue(pid), kNormalPriority);
+}
+
+// getProcessPriorityValue：pid 在列表中 → 返回该进程的 priority
+TEST_F(UT_ProcessTableModel, test_getProcessPriorityValue_002)
+{
+    pid_t pid = getpid(); // 当前测试进程真实存在
+    m_tester->m_procIdList << pid;
+    // 仅断言能取到非异常值（覆盖 found 分支），具体 nice 值随环境
+    int val = m_tester->getProcessPriorityValue(pid);
+    EXPECT_TRUE(val >= -20 && val <= 19);
+}
+
+// setUserModeName：设置相同名称走守卫提前返回分支（不触发刷新）
+TEST_F(UT_ProcessTableModel, test_setUserModeName_001)
+{
+    m_tester->setUserModeName(""); // 首次设置
+    m_tester->setUserModeName(""); // 相同值 → 守卫提前返回
+}
+
+// getTotalCPUUsage：空列表为 0；注入带 cpu 的进程后求和
+TEST_F(UT_ProcessTableModel, test_getTotalCPUUsage_001)
+{
+    EXPECT_NEAR(m_tester->getTotalCPUUsage(), 0.0, 0.001);
+
+    Process p1, p2;
+    p1.setCpu(10.5);
+    p2.setCpu(20.0);
+    m_tester->m_processList << p1 << p2;
+    EXPECT_NEAR(m_tester->getTotalCPUUsage(), 30.5, 0.001);
+}
+
+// getTotalMemoryUsage
+TEST_F(UT_ProcessTableModel, test_getTotalMemoryUsage_001)
+{
+    EXPECT_NEAR(m_tester->getTotalMemoryUsage(), 0.0, 0.001);
+
+    Process p1, p2;
+    p1.setMemory(1024);
+    p2.setMemory(2048);
+    m_tester->m_processList << p1 << p2;
+    EXPECT_NEAR(m_tester->getTotalMemoryUsage(), 3072.0, 0.001);
+}
+
+// getTotalDownload / getTotalUpload：setNetIoBps 同时设置 recv/send
+TEST_F(UT_ProcessTableModel, test_getTotalDownload_001)
+{
+    Process p1, p2;
+    p1.setNetIoBps(100.0, 50.0); // recv=100, send=50
+    p2.setNetIoBps(200.0, 25.0); // recv=200, send=25
+    m_tester->m_processList << p1 << p2;
+    EXPECT_NEAR(m_tester->getTotalDownload(), 300.0, 0.001);
+}
+
+TEST_F(UT_ProcessTableModel, test_getTotalUpload_001)
+{
+    Process p1, p2;
+    p1.setNetIoBps(100.0, 50.0);
+    p2.setNetIoBps(200.0, 25.0);
+    m_tester->m_processList << p1 << p2;
+    EXPECT_NEAR(m_tester->getTotalUpload(), 75.0, 0.001);
+}
+
+// vtrmemory/sharememory/readBps/writeBps 无 setter，默认 0；注入进程覆盖循环体
+TEST_F(UT_ProcessTableModel, test_getTotalVirtualMemoryUsage_001)
+{
+    m_tester->m_processList << Process() << Process();
+    EXPECT_NEAR(m_tester->getTotalVirtualMemoryUsage(), 0.0, 0.001);
+}
+
+TEST_F(UT_ProcessTableModel, test_getTotalSharedMemoryUsage_001)
+{
+    m_tester->m_processList << Process() << Process();
+    EXPECT_NEAR(m_tester->getTotalSharedMemoryUsage(), 0.0, 0.001);
+}
+
+TEST_F(UT_ProcessTableModel, test_getTotalDiskRead_001)
+{
+    m_tester->m_processList << Process() << Process();
+    EXPECT_NEAR(m_tester->getTotalDiskRead(), 0.0, 0.001);
+}
+
+TEST_F(UT_ProcessTableModel, test_getTotalDiskWrite_001)
+{
+    m_tester->m_processList << Process() << Process();
+    EXPECT_NEAR(m_tester->getTotalDiskWrite(), 0.0, 0.001);
+}

--- a/tests/deepin-system-monitor-main/model/ut_user.cpp
+++ b/tests/deepin-system-monitor-main/model/ut_user.cpp
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//self
+#include "model/user.h"
+//gtest
+#include "stub.h"
+#include <gtest/gtest.h>
+//Qt
+#include <QString>
+
+// 被测类 User 是一个纯数据承载对象 (QObject 无信号)，所有 setter 均带
+// “值未变化即提前返回”的守卫；displayName() 是唯一含分支的关键纯逻辑。
+// 这里对 model/user.cpp 中 0% 覆盖的全部公共函数做覆盖。
+
+class UT_User : public ::testing::Test
+{
+public:
+    UT_User() : m_user(nullptr) {}
+
+public:
+    virtual void SetUp()
+    {
+        m_user = new User();
+    }
+
+    virtual void TearDown()
+    {
+        if (m_user) {
+            delete m_user;
+            m_user = nullptr;
+        }
+    }
+
+protected:
+    User *m_user;
+};
+
+// 构造函数：默认状态。对应 user.cpp 中成员初始化列表 (m_isCurrentUser=false 等)。
+TEST_F(UT_User, Constructor_DefaultState)
+{
+    EXPECT_FALSE(m_user->isCurrentUser());
+    EXPECT_FALSE(m_user->online());
+    EXPECT_EQ(m_user->userType(), User::StandardUser);   // m_userType 初始化为 0
+    EXPECT_TRUE(m_user->name().isEmpty());
+    EXPECT_TRUE(m_user->fullname().isEmpty());
+    EXPECT_TRUE(m_user->iconFile().isEmpty());
+    EXPECT_TRUE(m_user->userUid().isEmpty());
+}
+
+// name / setName 往返，并覆盖守卫的“相同值提前返回”分支。
+TEST_F(UT_User, Name_SetAndGet)
+{
+    m_user->setName("alice");
+    EXPECT_EQ(m_user->name(), QString("alice"));
+
+    // 再次设置相同值：走守卫提前返回分支，值保持不变
+    m_user->setName("alice");
+    EXPECT_EQ(m_user->name(), QString("alice"));
+
+    // 设置不同值：走赋值分支
+    m_user->setName("bob");
+    EXPECT_EQ(m_user->name(), QString("bob"));
+}
+
+// fullname / setFullname
+TEST_F(UT_User, Fullname_SetAndGet)
+{
+    m_user->setFullname("Alice Wonder");
+    EXPECT_EQ(m_user->fullname(), QString("Alice Wonder"));
+
+    // 相同值提前返回
+    m_user->setFullname("Alice Wonder");
+    EXPECT_EQ(m_user->fullname(), QString("Alice Wonder"));
+}
+
+// iconFile / setIconFile
+TEST_F(UT_User, IconFile_SetAndGet)
+{
+    m_user->setIconFile("/var/lib/AccountsService/icons/alice.png");
+    EXPECT_EQ(m_user->iconFile(), QString("/var/lib/AccountsService/icons/alice.png"));
+
+    // 相同值提前返回
+    m_user->setIconFile("/var/lib/AccountsService/icons/alice.png");
+    EXPECT_EQ(m_user->iconFile(), QString("/var/lib/AccountsService/icons/alice.png"));
+}
+
+// userUid / setUserUid
+TEST_F(UT_User, UserUid_SetAndGet)
+{
+    m_user->setUserUid("1000");
+    EXPECT_EQ(m_user->userUid(), QString("1000"));
+
+    // 相同值提前返回
+    m_user->setUserUid("1000");
+    EXPECT_EQ(m_user->userUid(), QString("1000"));
+}
+
+// isCurrentUser / setIsCurrentUser：默认 false，翻转后为 true，覆盖守卫两分支。
+TEST_F(UT_User, IsCurrentUser_SetAndGet)
+{
+    EXPECT_FALSE(m_user->isCurrentUser());
+
+    m_user->setIsCurrentUser(true);
+    EXPECT_TRUE(m_user->isCurrentUser());
+
+    // 相同值提前返回分支
+    m_user->setIsCurrentUser(true);
+    EXPECT_TRUE(m_user->isCurrentUser());
+
+    m_user->setIsCurrentUser(false);
+    EXPECT_FALSE(m_user->isCurrentUser());
+}
+
+// online / setOnline
+TEST_F(UT_User, Online_SetAndGet)
+{
+    EXPECT_FALSE(m_user->online());
+
+    m_user->setOnline(true);
+    EXPECT_TRUE(m_user->online());
+
+    // 相同值提前返回分支
+    m_user->setOnline(true);
+    EXPECT_TRUE(m_user->online());
+
+    m_user->setOnline(false);
+    EXPECT_FALSE(m_user->online());
+}
+
+// userType / setUserType：枚举值往返，覆盖守卫两分支。
+TEST_F(UT_User, UserType_SetAndGet)
+{
+    EXPECT_EQ(m_user->userType(), User::StandardUser);
+
+    m_user->setUserType(User::Administrator);
+    EXPECT_EQ(m_user->userType(), User::Administrator);
+
+    // 相同值提前返回分支
+    m_user->setUserType(User::Administrator);
+    EXPECT_EQ(m_user->userType(), User::Administrator);
+
+    m_user->setUserType(User::Customized);
+    EXPECT_EQ(m_user->userType(), User::Customized);
+}
+
+// displayName() 关键分支：fullname 为空时回退到 name。
+TEST_F(UT_User, DisplayName_FallbackToName_WhenFullnameEmpty)
+{
+    m_user->setName("alice");
+    // fullname 默认为空 → 返回 name
+    EXPECT_EQ(m_user->displayName(), QString("alice"));
+}
+
+// displayName() 另一分支：fullname 非空时优先返回 fullname。
+TEST_F(UT_User, DisplayName_PreferFullname_WhenNonEmpty)
+{
+    m_user->setName("alice");
+    m_user->setFullname("Alice Wonder");
+    EXPECT_EQ(m_user->displayName(), QString("Alice Wonder"));
+}

--- a/tests/deepin-system-monitor-main/service/ut_service_manager.cpp
+++ b/tests/deepin-system-monitor-main/service/ut_service_manager.cpp
@@ -103,3 +103,27 @@ TEST_F(UT_ServiceManager, test_updateServiceEntry_01)
 {
     m_tester->updateServiceEntry("");
 }
+
+// getServiceStartupType 分支1: isUnitNoOp(空状态) → N/A
+TEST_F(UT_ServiceManager, test_getServiceStartupType_noop_empty)
+{
+    EXPECT_EQ(ServiceManager::getServiceStartupType("ssh.service", ""), QString(kServiceNAStartup));
+}
+
+// getServiceStartupType 分支2: id 以 "@" 结尾（模板单元）→ N/A
+TEST_F(UT_ServiceManager, test_getServiceStartupType_template_suffix)
+{
+    EXPECT_EQ(ServiceManager::getServiceStartupType("getty@", "enabled"), QString(kServiceNAStartup));
+}
+
+// getServiceStartupType 分支3: enabled 状态 → Auto（走 isUnitStateEnabled 纯查表，无子进程）
+TEST_F(UT_ServiceManager, test_getServiceStartupType_auto)
+{
+    EXPECT_EQ(ServiceManager::getServiceStartupType("ssh.service", kUnitStateEnabledText), QString(kServiceAutoStartup));
+}
+
+// getServiceStartupType 分支4: disabled 状态 → Manual
+TEST_F(UT_ServiceManager, test_getServiceStartupType_manual)
+{
+    EXPECT_EQ(ServiceManager::getServiceStartupType("ssh.service", kUnitStateDisabledText), QString(kServiceManualStartup));
+}

--- a/tests/deepin-system-monitor-main/wm/ut_wm_window_list.cpp
+++ b/tests/deepin-system-monitor-main/wm/ut_wm_window_list.cpp
@@ -72,3 +72,44 @@ TEST_F(UT_WMWindowList, test_getWindowPid_001)
 {
     m_tester->getWindowPid(1000);
 }
+
+// isDesktopEntryApp：注入 pid 到 m_desktopEntryCache 后返回 true，否则 false
+TEST_F(UT_WMWindowList, test_isDesktopEntryApp_001)
+{
+    pid_t pid = 5678;
+    EXPECT_FALSE(m_tester->isDesktopEntryApp(pid));
+
+    m_tester->m_desktopEntryCache << pid;
+    EXPECT_TRUE(m_tester->isDesktopEntryApp(pid));
+}
+
+// isTrayApp：注入 pid 到 m_trayAppcache 后返回 true，否则 false
+TEST_F(UT_WMWindowList, test_isTrayApp_001)
+{
+    pid_t pid = 6789;
+    EXPECT_FALSE(m_tester->isTrayApp(pid));
+
+    m_tester->m_trayAppcache[pid] = std::make_unique<wm_window_t>();
+    EXPECT_TRUE(m_tester->isTrayApp(pid));
+}
+
+// isGuiApp：注入 pid 到 m_guiAppcache 后返回 true，否则 false
+TEST_F(UT_WMWindowList, test_isGuiApp_001)
+{
+    pid_t pid = 7890;
+    EXPECT_FALSE(m_tester->isGuiApp(pid));
+
+    m_tester->m_guiAppcache[pid] = std::make_unique<wm_window_t>();
+    EXPECT_TRUE(m_tester->isGuiApp(pid));
+}
+
+// removeDesktopEntryApp：命中分支（先注入再移除）
+TEST_F(UT_WMWindowList, test_removeDesktopEntryApp_002)
+{
+    pid_t pid = 8901;
+    m_tester->m_desktopEntryCache << pid;
+    ASSERT_TRUE(m_tester->isDesktopEntryApp(pid));
+
+    m_tester->removeDesktopEntryApp(pid);
+    EXPECT_FALSE(m_tester->isDesktopEntryApp(pid));
+}


### PR DESCRIPTION
Add unit tests for user.cpp, accounts_info_model.cpp and expand existing tests for process_table_model, service_manager and wm_window_list. Also add linglong_controller.cpp to the test build to fix link failures.

为 user.cpp、accounts_info_model.cpp 新增单元测试，并扩充 process_table_model、 service_manager、wm_window_list 的现有测试。同时将 linglong_controller.cpp 加入测试编译列表，修复测试目标链接失败的问题。

Log: 补充单元测试并修复测试构建链接缺陷
Influence: 新增 33 个测试用例（user/accounts 全覆盖，model/service/wm 低覆盖函数扩充）， 提升单元测试覆盖率；修复 linglong 功能合并后遗漏的测试编译源文件，恢复测试目标可链接。

## Summary by Sourcery

Extend unit test coverage for model, service, and window manager components and fix missing source in the test build configuration.

New Features:
- Add unit tests for the User data model covering all public accessors and display name logic.
- Add unit tests for AccountsInfoModel to exercise current user type mapping logic.

Enhancements:
- Expand process table model tests to cover process priority lookup and aggregate CPU, memory, network, and disk metrics.
- Extend window list tests to cover desktop entry, tray app, GUI app detection, and desktop entry removal logic.
- Extend service manager tests to cover all branches of service startup type resolution.

Build:
- Include linglong_controller.cpp in the test build sources to resolve linker failures for test targets.

Tests:
- Increase overall unit test coverage across user, accounts info, process table model, service manager, and window list modules.