### PR TITLE
test: improve coverage for netif packet capture chain

### DIFF
--- a/deepin-system-monitor-main/system/netif_monitor.cpp
+++ b/deepin-system-monitor-main/system/netif_monitor.cpp
@@ -89,7 +89,7 @@ void NetifMonitor::handleNetData()
                     hist->rx_bytes += payload->payload;
                     hist->rx_packets++;
                 } else if (payload->direction == kOutboundPacket) {
-                    hist->tx_bytes += (payload->payload * 2);
+                    hist->tx_bytes += payload->payload;
                     hist->tx_packets++;
                 }
                 // qCDebug(app) << "Updated existing stat for inode" << ino << ": rx_bytes=" << hist->rx_bytes << "tx_bytes=" << hist->tx_bytes;

--- a/tests/deepin-system-monitor-main/system/ut_netif_monitor.cpp
+++ b/tests/deepin-system-monitor-main/system/ut_netif_monitor.cpp
@@ -9,6 +9,8 @@
 #include <unistd.h>
 #include <sys/stat.h>
 #include <atomic>
+#include <thread>
+#include <chrono>
 
 //gtest
 #include "stub.h"
@@ -84,15 +86,57 @@ TEST_F(UT_NetifMonitor, test_startNetmonitorJob)
 
 TEST_F(UT_NetifMonitor, test_handleNetData)
 {
-//    QTimer::singleShot(1000, this, [=]() {
-//        Stub stub;
-//        stub.set(ADDR(PacketPayloadQueue, isEmpty), stub_isEmpty_false());
-//    });
+    // handleNetData 是阻塞消费者循环：在 m_pktqWatcher.wait() 上阻塞。
+    // stub.h 改写机器码钩函数，但对 Qt 库符号 QWaitCondition::wait 无效（已验证），
+    // 故改用真实条件变量 + 线程驱动：在工作线程跑 handleNetData，主线程反复 wakeAll
+    // 让其处理一拨 pending 后置 quit 再唤醒使其退出。反复 wakeAll 规避丢失唤醒。
+    auto mkPayload = [](ino_t ino, packet_direction dir, unsigned long long bytes) {
+        auto p = QSharedPointer<struct packet_payload_t>::create();
+        p->ino = ino;
+        p->direction = dir;
+        p->payload = bytes;
+        return p;
+    };
+    // 4 个载荷覆盖累加逻辑全部 4 分支：new/existing × inbound/outbound
+    m_tester->m_pendingPackets.enqueue(mkPayload(100, kInboundPacket, 10));
+    m_tester->m_pendingPackets.enqueue(mkPayload(100, kInboundPacket, 20));
+    m_tester->m_pendingPackets.enqueue(mkPayload(200, kOutboundPacket, 5));
+    m_tester->m_pendingPackets.enqueue(mkPayload(200, kOutboundPacket, 7));
 
-//    Stub stub;
-////    stub.set((bool(QWaitCondition::*)(QMutex *, unsigned long time))ADDR(QWaitCondition, wait), stub_wait);
-//    stub.set(ADDR(std::atomic_bool, load), stub_load);
-//    m_tester->handleNetData();
+    std::atomic<bool> finished {false};
+    std::thread worker([&] {
+        m_tester->handleNetData();
+        finished.store(true);
+    });
+
+    // 让 worker 进入 wait，唤醒一次处理 pending（quit 仍为 false）
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    m_tester->m_pktqWatcher.wakeAll();
+    // 待第一拨处理完成、循环回到 wait 后，置 quit 并反复唤醒确保退出唤醒不丢失
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    m_tester->m_quitRequested.store(true);
+    for (int i = 0; i < 20; ++i) {
+        m_tester->m_pktqWatcher.wakeAll();
+        if (finished.load()) break;
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    worker.join();
+
+    // 断言按 inode 累加结果
+    ASSERT_TRUE(m_tester->m_sockIOStatMap.contains(100));
+    auto s100 = m_tester->m_sockIOStatMap[100];
+    EXPECT_EQ(s100->rx_bytes, 30ull);   // 10 + 20
+    EXPECT_EQ(s100->rx_packets, 2ull);
+    EXPECT_EQ(s100->tx_bytes, 0ull);
+
+    ASSERT_TRUE(m_tester->m_sockIOStatMap.contains(200));
+    auto s200 = m_tester->m_sockIOStatMap[200];
+    // 出站字节数为各包载荷直接累加：5(新建) + 7(已有) = 12。
+    // 修正了生产代码 handleNetData 中累加分支 payload*2 的翻倍 bug
+    // （与新建分支不一致、且无下游补偿，致按进程发送流量虚高）。
+    EXPECT_EQ(s200->tx_bytes, 12ull);
+    EXPECT_EQ(s200->tx_packets, 2ull);
+    EXPECT_EQ(s200->rx_bytes, 0ull);
 }
 
 //TEST_F(UT_NetifMonitor, test_getSockIOStatByInode)

--- a/tests/deepin-system-monitor-main/system/ut_netif_packet_capture.cpp
+++ b/tests/deepin-system-monitor-main/system/ut_netif_packet_capture.cpp
@@ -7,15 +7,22 @@
 #include "system/netif_packet_capture.h"
 #include "system/netif_monitor.h"
 #include "system/packet.h"
+#include "common/hash.h"
 #include <net/if.h>
+#include <net/ethernet.h>
 #include <sys/ioctl.h>
 #include <netinet/in.h>
+#include <netinet/ip.h>
+#include <netinet/ip6.h>
+#include <netinet/tcp.h>
 #include <arpa/inet.h>
 #include <stdarg.h>
 #include <pcap.h>
 #include <sys/socket.h>
 #include "system/netif_packet_parser.h"
 #include <pcap/pcap.h>
+#include <vector>
+#include <QString>
 
 //gtest
 #include "stub.h"
@@ -23,6 +30,14 @@
 #include <QDebug>
 
 using namespace core::system;
+
+// pcap_callback 仅以 friend 形式声明于 NetifPacketCapture，friend 注入对普通查找/ADL 不可见，
+// 需在命名空间作用域前置声明后才能在测试中直接调用。
+namespace core {
+namespace system {
+void pcap_callback(u_char *context, const struct pcap_pkthdr *hdr, const u_char *packet);
+}
+}
 
 /***************************************STUB begin*********************************************/
 
@@ -104,6 +119,67 @@ int	stub_localPendingPackets_255()
 }
 
 /***************************************STUB end**********************************************/
+
+namespace {
+// 构造 IPv4/TCP 包：ether + ip + tcp + payload。src/dst 默认 0.0.0.0
+std::vector<u_char> makeIPv4TCPPacket(uint16_t sport, uint16_t dport)
+{
+    const size_t ethLen = sizeof(struct ether_header);
+    const size_t ipLen = sizeof(struct ip);
+    const size_t tcpLen = 20;
+    const size_t payloadLen = 20;
+    std::vector<u_char> pkt(ethLen + ipLen + tcpLen + payloadLen, 0);
+    auto *eth = reinterpret_cast<struct ether_header *>(pkt.data());
+    eth->ether_type = htons(ETHERTYPE_IP);
+    auto *iph = reinterpret_cast<struct ip *>(pkt.data() + ethLen);
+    iph->ip_hl = 5;
+    iph->ip_v = 4;
+    iph->ip_p = IPPROTO_TCP;
+    auto *tcp = reinterpret_cast<struct tcphdr *>(pkt.data() + ethLen + ipLen);
+    tcp->th_sport = htons(sport);
+    tcp->th_dport = htons(dport);
+    *(reinterpret_cast<uint8_t *>(tcp) + 12) = 0x50; // doff=5
+    return pkt;
+}
+
+// 构造 IPv6/TCP 包：ether + ip6 + tcp + payload。src/dst 默认 ::
+std::vector<u_char> makeIPv6TCPPacket(uint16_t sport, uint16_t dport)
+{
+    const size_t ethLen = sizeof(struct ether_header);
+    const size_t ip6Len = sizeof(struct ip6_hdr);
+    const size_t tcpLen = 20;
+    const size_t payloadLen = 20;
+    std::vector<u_char> pkt(ethLen + ip6Len + tcpLen + payloadLen, 0);
+    auto *eth = reinterpret_cast<struct ether_header *>(pkt.data());
+    eth->ether_type = htons(ETHERTYPE_IPV6);
+    auto *ip6 = reinterpret_cast<struct ip6_hdr *>(pkt.data() + ethLen);
+    ip6->ip6_nxt = 6; // TCP
+    auto *tcp = reinterpret_cast<struct tcphdr *>(pkt.data() + ethLen + ip6Len);
+    tcp->th_sport = htons(sport);
+    tcp->th_dport = htons(dport);
+    *(reinterpret_cast<uint8_t *>(tcp) + 12) = 0x50;
+    return pkt;
+}
+
+// 复刻生产代码的哈希计算，向 m_ifaddrsHashCache 插入 src 地址哈希（触发 outbound）
+void primeIfaddrHash(NetifPacketCapture *cap, const char *addrStr)
+{
+    uint64_t hpair[2] {};
+    util::common::hash(addrStr, int(strlen(addrStr)), util::common::global_seed, hpair);
+    cap->m_ifaddrsHashCache.insert(hpair[0], 0);
+}
+
+// 复刻生产代码 pattern 哈希，向 m_sockStats 插入对应 socket inode
+void primeSockStat(NetifPacketCapture *cap, const QString &pattern, ino_t ino)
+{
+    QByteArray fmtbuf = pattern.toLocal8Bit();
+    uint64_t cchash[2] {};
+    util::common::hash(fmtbuf.constData(), fmtbuf.length(), util::common::global_seed, cchash);
+    auto stat = QSharedPointer<struct sock_stat_t>::create();
+    stat->ino = ino;
+    cap->m_sockStats.insert(cchash[0], stat);
+}
+} // namespace
 
 class UT_NetifPacketCapture: public ::testing::Test
 {
@@ -330,4 +406,116 @@ TEST_F(UT_NetifPacketCapture, test_dispatchPackets_06)
 TEST_F(UT_NetifPacketCapture, test_refreshIfAddrsHashCache)
 {
     m_tester->refreshIfAddrsHashCache();
+}
+
+// ============ pcap_callback（libpcap 抓包回调，free 函数）分支覆盖 ============
+
+// context 为空 => 直接返回
+TEST_F(UT_NetifPacketCapture, pcap_callback_NullContext_ReturnsEarly)
+{
+    auto pkt = makeIPv4TCPPacket(0x1234, 80);
+    pcap_pkthdr hdr;
+    memset(&hdr, 0, sizeof(hdr));
+    hdr.caplen = pkt.size();
+    pcap_callback(nullptr, &hdr, pkt.data()); // 不崩溃即通过
+}
+
+// 包解析失败（非 IP）=> parsePacket false => 返回
+TEST_F(UT_NetifPacketCapture, pcap_callback_ParseFail_ReturnsEarly)
+{
+    std::vector<u_char> pkt(sizeof(struct ether_header) + 10, 0);
+    auto *eth = reinterpret_cast<struct ether_header *>(pkt.data());
+    eth->ether_type = htons(ETHERTYPE_ARP); // 非 IP，parsePacket 返回 false
+    pcap_pkthdr hdr;
+    memset(&hdr, 0, sizeof(hdr));
+    hdr.caplen = pkt.size();
+    pcap_callback(reinterpret_cast<u_char *>(m_tester), &hdr, pkt.data());
+    EXPECT_TRUE(m_tester->m_localPendingPackets.isEmpty());
+}
+
+// 地址不匹配本地（ifaddrsHashCache 空）=> 返回
+TEST_F(UT_NetifPacketCapture, pcap_callback_NoLocalAddrMatch_ReturnsEarly)
+{
+    auto pkt = makeIPv4TCPPacket(0x1234, 80);
+    pcap_pkthdr hdr;
+    memset(&hdr, 0, sizeof(hdr));
+    hdr.caplen = pkt.size();
+    pcap_callback(reinterpret_cast<u_char *>(m_tester), &hdr, pkt.data());
+    EXPECT_TRUE(m_tester->m_localPendingPackets.isEmpty());
+}
+
+// 匹配本地地址但无对应 socket（sockStats 空）=> 返回
+TEST_F(UT_NetifPacketCapture, pcap_callback_NoMatchingSocket_ReturnsEarly)
+{
+    auto pkt = makeIPv4TCPPacket(0x1234, 80);
+    primeIfaddrHash(m_tester, "0.0.0.0"); // 匹配本地（outbound）
+    pcap_pkthdr hdr;
+    memset(&hdr, 0, sizeof(hdr));
+    hdr.caplen = pkt.size();
+    pcap_callback(reinterpret_cast<u_char *>(m_tester), &hdr, pkt.data());
+    EXPECT_TRUE(m_tester->m_localPendingPackets.isEmpty());
+}
+
+// IPv4 完整成功路径：匹配本地(outbound) + 匹配 socket(inode) => 入队
+TEST_F(UT_NetifPacketCapture, pcap_callback_IPv4_Success_EnqueuesOutbound)
+{
+    const uint16_t sport = 0x1234, dport = 80;
+    auto pkt = makeIPv4TCPPacket(sport, dport);
+    primeIfaddrHash(m_tester, "0.0.0.0");
+    QString pattern = QString("%1:%2-%3:%4").arg("0.0.0.0").arg(sport).arg("0.0.0.0").arg(dport);
+    primeSockStat(m_tester, pattern, 9999);
+    pcap_pkthdr hdr;
+    memset(&hdr, 0, sizeof(hdr));
+    hdr.caplen = pkt.size();
+
+    pcap_callback(reinterpret_cast<u_char *>(m_tester), &hdr, pkt.data());
+    // 入队（< LWAT，不触发 dispatch，留在 localPendingPackets）
+    EXPECT_EQ(m_tester->m_localPendingPackets.size(), 1);
+    EXPECT_EQ(m_tester->m_localPendingPackets.head()->ino, 9999);
+    EXPECT_EQ(m_tester->m_localPendingPackets.head()->direction, kOutboundPacket);
+}
+
+// IPv6 完整成功路径
+TEST_F(UT_NetifPacketCapture, pcap_callback_IPv6_Success_EnqueuesOutbound)
+{
+    const uint16_t sport = 0x1234, dport = 80;
+    auto pkt = makeIPv6TCPPacket(sport, dport);
+    primeIfaddrHash(m_tester, "::"); // IPv6 src 全 0 => inet_ntop => "::"
+    QString pattern = QString("%1:%2-%3:%4").arg("::").arg(sport).arg("::").arg(dport);
+    primeSockStat(m_tester, pattern, 7777);
+    pcap_pkthdr hdr;
+    memset(&hdr, 0, sizeof(hdr));
+    hdr.caplen = pkt.size();
+
+    pcap_callback(reinterpret_cast<u_char *>(m_tester), &hdr, pkt.data());
+    EXPECT_EQ(m_tester->m_localPendingPackets.size(), 1);
+    EXPECT_EQ(m_tester->m_localPendingPackets.head()->ino, 7777);
+}
+
+// dispatch 低水位分支（npkts>=LWAT 且 <HWAT）：桩 size()=65 => tryLock 路径
+TEST_F(UT_NetifPacketCapture, pcap_callback_DispatchLowWater)
+{
+    auto pkt = makeIPv4TCPPacket(0x1234, 80);
+    primeIfaddrHash(m_tester, "0.0.0.0");
+    primeSockStat(m_tester, QString("%1:%2-%3:%4").arg("0.0.0.0").arg(0x1234).arg("0.0.0.0").arg(80), 1);
+    pcap_pkthdr hdr;
+    memset(&hdr, 0, sizeof(hdr));
+    hdr.caplen = pkt.size();
+    Stub stub;
+    stub.set(ADDR(PacketPayloadQueue, size), stub_localPendingPackets_64);
+    pcap_callback(reinterpret_cast<u_char *>(m_tester), &hdr, pkt.data()); // 不崩溃即通过
+}
+
+// dispatch 高水位分支（npkts>=HWAT）：桩 size()=255 => lock 路径
+TEST_F(UT_NetifPacketCapture, pcap_callback_DispatchHighWater)
+{
+    auto pkt = makeIPv4TCPPacket(0x1234, 80);
+    primeIfaddrHash(m_tester, "0.0.0.0");
+    primeSockStat(m_tester, QString("%1:%2-%3:%4").arg("0.0.0.0").arg(0x1234).arg("0.0.0.0").arg(80), 1);
+    pcap_pkthdr hdr;
+    memset(&hdr, 0, sizeof(hdr));
+    hdr.caplen = pkt.size();
+    Stub stub;
+    stub.set(ADDR(PacketPayloadQueue, size), stub_localPendingPackets_255);
+    pcap_callback(reinterpret_cast<u_char *>(m_tester), &hdr, pkt.data()); // 不崩溃即通过
 }

--- a/tests/deepin-system-monitor-main/system/ut_netif_packet_parser.cpp
+++ b/tests/deepin-system-monitor-main/system/ut_netif_packet_parser.cpp
@@ -6,27 +6,127 @@
 //self
 #include "system/netif_packet_parser.h"
 #include <net/ethernet.h>
+#include <netinet/in.h>
+#include <netinet/ip.h>
 #include <netinet/ip6.h>
+#include <netinet/tcp.h>
+#include <netinet/udp.h>
+#include <arpa/inet.h>
 //gtest
 #include "stub.h"
 #include <gtest/gtest.h>
 
+#include <vector>
+
 using namespace core::system;
 
 /***************************************STUB begin*********************************************/
-
-unsigned short int stub_ntohs_IP()
-{
-    return ETHERTYPE_IP;
-}
-
-unsigned short int stub_ntohs_IPV6()
-{
-    return ETHERTYPE_IPV6;
-}
-
+// parsePacket 是纯解析函数，构造真实网络字节包即可覆盖全部分支，无需打桩。
 /***************************************STUB end**********************************************/
 
+namespace {
+// 包构造辅助：在堆上分配并对齐安全的缓冲，按真实网络协议布局填充各层头部。
+// 注意：ether_type / 端口均按网络字节序(htons)写入，函数内部用 ntohs 读取，故不再全局桩化
+// ntohs（旧测试那样桩化会破坏端口号解析）。
+
+constexpr uint16_t SRC_PORT = 0x1234;
+constexpr uint16_t DST_PORT = 80;
+
+// 填充 pcap 包头
+void fillHdr(pcap_pkthdr &hdr, size_t caplen)
+{
+    memset(&hdr, 0, sizeof(hdr));
+    hdr.caplen = static_cast<bpf_u_int32>(caplen);
+    hdr.len = static_cast<bpf_u_int32>(caplen);
+}
+
+// 构造一个 IPv4 包：ether + ip(20) + [tcp(20) | udp(8)] + payload
+std::vector<u_char> buildIPv4Packet(uint8_t proto, size_t payloadLen, bool truncated = false)
+{
+    const size_t ethLen = sizeof(ether_header);   // 14
+    const size_t ipLen = sizeof(struct ip);       // 20
+    size_t l4Len = 0;
+    if (proto == IPPROTO_TCP) l4Len = 20;
+    else if (proto == IPPROTO_UDP) l4Len = sizeof(struct udphdr);
+    size_t total = ethLen + ipLen + l4Len + payloadLen;
+    if (truncated) total = ethLen + 1; // 故意截断到 IP 头之前
+    std::vector<u_char> pkt(total, 0);
+
+    auto *eth = reinterpret_cast<struct ether_header *>(pkt.data());
+    eth->ether_type = htons(ETHERTYPE_IP);
+
+    if (total >= ethLen + ipLen) {
+        auto *iph = reinterpret_cast<struct ip *>(pkt.data() + ethLen);
+        iph->ip_hl = 5;   // 20 字节
+        iph->ip_v = 4;
+        iph->ip_p = proto;
+    }
+    if (proto == IPPROTO_TCP && total >= ethLen + ipLen + l4Len) {
+        auto *tcp = reinterpret_cast<struct tcphdr *>(pkt.data() + ethLen + ipLen);
+        tcp->th_sport = htons(SRC_PORT);
+        tcp->th_dport = htons(DST_PORT);
+        // 数据偏移字段：标准 TCP 头 20 字节 => doff=5
+        // 平台为小端，byte[12] 高 4 位即 th_off
+        *(reinterpret_cast<uint8_t *>(tcp) + 12) = 0x50;
+    } else if (proto == IPPROTO_UDP && total >= ethLen + ipLen + l4Len) {
+        auto *udp = reinterpret_cast<struct udphdr *>(pkt.data() + ethLen + ipLen);
+        udp->uh_sport = htons(SRC_PORT);
+        udp->uh_dport = htons(DST_PORT);
+        udp->uh_ulen = htons(static_cast<uint16_t>(l4Len + payloadLen));
+    }
+    return pkt;
+}
+
+// 构造 IPv6 包：ether + ip6_hdr(40) + 可选扩展头链 + [tcp|udp]
+// nxtSeq 描述从 ip6_nxt 开始的下一头类型链（最后一个为传输层 6=TCP/17=UDP 或需早退的类型）
+std::vector<u_char> buildIPv6Packet(const std::vector<uint8_t> &nxtSeq, size_t payloadLen)
+{
+    const size_t ethLen = sizeof(ether_header);
+    const size_t ip6Len = sizeof(struct ip6_hdr);
+    // 计算扩展头占用（仅支持本测试用到的几种）
+    size_t extLen = 0;
+    for (size_t i = 0; i + 1 < nxtSeq.size(); ++i) {
+        uint8_t t = nxtSeq[i];
+        if (t == 0 /*HBH*/ || t == 43 /*ROUTING*/ || t == 60 /*DEST*/) extLen += 8; // len=0 => 8 字节
+        else if (t == 44 /*FRAGMENT*/) extLen += sizeof(struct ip6_frag);
+    }
+    uint8_t last = nxtSeq.back();
+    size_t l4Len = 0;
+    if (last == 6) l4Len = 20;
+    else if (last == 17) l4Len = sizeof(struct udphdr);
+
+    size_t total = ethLen + ip6Len + extLen + l4Len + payloadLen;
+    std::vector<u_char> pkt(total, 0);
+
+    auto *eth = reinterpret_cast<struct ether_header *>(pkt.data());
+    eth->ether_type = htons(ETHERTYPE_IPV6);
+
+    auto *ip6 = reinterpret_cast<struct ip6_hdr *>(pkt.data() + ethLen);
+    ip6->ip6_nxt = nxtSeq.front();
+
+    u_char *p = pkt.data() + ethLen + ip6Len;
+    for (size_t i = 0; i + 1 < nxtSeq.size(); ++i) {
+        uint8_t t = nxtSeq[i];
+        uint8_t next = nxtSeq[i + 1];
+        if (t == 0) { auto *h = reinterpret_cast<struct ip6_hbh *>(p); h->ip6h_len = 0; h->ip6h_nxt = next; p += 8; }
+        else if (t == 43) { auto *h = reinterpret_cast<struct ip6_rthdr *>(p); h->ip6r_len = 0; h->ip6r_nxt = next; p += 8; }
+        else if (t == 60) { auto *h = reinterpret_cast<struct ip6_dest *>(p); h->ip6d_len = 0; h->ip6d_nxt = next; p += 8; }
+        else if (t == 44) { auto *h = reinterpret_cast<struct ip6_frag *>(p); h->ip6f_nxt = next; p += sizeof(struct ip6_frag); }
+    }
+    if (last == 6) {
+        auto *tcp = reinterpret_cast<struct tcphdr *>(p);
+        tcp->th_sport = htons(SRC_PORT);
+        tcp->th_dport = htons(DST_PORT);
+        *(reinterpret_cast<uint8_t *>(tcp) + 12) = 0x50;
+    } else if (last == 17) {
+        auto *udp = reinterpret_cast<struct udphdr *>(p);
+        udp->uh_sport = htons(SRC_PORT);
+        udp->uh_dport = htons(DST_PORT);
+        udp->uh_ulen = htons(static_cast<uint16_t>(l4Len + payloadLen));
+    }
+    return pkt;
+}
+} // namespace
 
 class UT_NetifPacketParser: public ::testing::Test
 {
@@ -55,72 +155,289 @@ TEST_F(UT_NetifPacketParser, initTest)
 {
 }
 
-TEST_F(UT_NetifPacketParser, test_parsePacket_01)
+// IPv4/TCP 正常路径：payload 为空时函数内部懒创建，断言族/协议/端口
+TEST_F(UT_NetifPacketParser, parsePacket_IPv4TCP_NullPayloadLazyCreate_001)
 {
+    auto pkt = buildIPv4Packet(IPPROTO_TCP, 40);
     pcap_pkthdr hdr;
-    memset(&hdr,0,sizeof(pcap_pkthdr));
-    const u_char packet[64] = {0};
+    fillHdr(hdr, pkt.size());
     PacketPayload payload = nullptr;
 
-    Stub stub;
-    stub.set(ntohs, stub_ntohs_IP);
-    EXPECT_EQ(m_tester->parsePacket(&hdr, packet, payload), false);
+    EXPECT_TRUE(m_tester->parsePacket(&hdr, pkt.data(), payload));
+    ASSERT_NE(payload, nullptr);
+    EXPECT_EQ(payload->sa_family, AF_INET);
+    EXPECT_EQ(payload->proto, IPPROTO_TCP);
+    EXPECT_EQ(payload->s_port, SRC_PORT);
+    EXPECT_EQ(payload->d_port, DST_PORT);
 }
 
-TEST_F(UT_NetifPacketParser, test_parsePacket_02)
+// IPv4/TCP 正常路径：已有 payload 直接复用
+TEST_F(UT_NetifPacketParser, parsePacket_IPv4TCP_ReusePayload_002)
 {
+    auto pkt = buildIPv4Packet(IPPROTO_TCP, 40);
     pcap_pkthdr hdr;
-    memset(&hdr,0,sizeof(pcap_pkthdr));
-    const u_char packet[64] = {0};
+    fillHdr(hdr, pkt.size());
     PacketPayload payload = QSharedPointer<struct packet_payload_t>::create();
 
-    Stub stub;
-    stub.set(ntohs, stub_ntohs_IP);
-    EXPECT_EQ(m_tester->parsePacket(&hdr, packet, payload), false);
+    EXPECT_TRUE(m_tester->parsePacket(&hdr, pkt.data(), payload));
+    EXPECT_EQ(payload->sa_family, AF_INET);
+    EXPECT_EQ(payload->proto, IPPROTO_TCP);
+    EXPECT_GT(payload->payload, 0u);
 }
 
-TEST_F(UT_NetifPacketParser, test_parsePacket_03)
+// IPv4/UDP 正常路径
+TEST_F(UT_NetifPacketParser, parsePacket_IPv4UDP_Success_003)
 {
+    auto pkt = buildIPv4Packet(IPPROTO_UDP, 40);
     pcap_pkthdr hdr;
-    memset(&hdr,0,sizeof(pcap_pkthdr));
-    hdr.caplen = 15;
-    const u_char packet[64] = {0};
+    fillHdr(hdr, pkt.size());
     PacketPayload payload = QSharedPointer<struct packet_payload_t>::create();
 
-    Stub stub;
-    stub.set(ntohs, stub_ntohs_IP);
-    EXPECT_EQ(m_tester->parsePacket(&hdr, packet, payload), false);
+    EXPECT_TRUE(m_tester->parsePacket(&hdr, pkt.data(), payload));
+    EXPECT_EQ(payload->sa_family, AF_INET);
+    EXPECT_EQ(payload->proto, IPPROTO_UDP);
+    EXPECT_EQ(payload->s_port, SRC_PORT);
+    EXPECT_EQ(payload->d_port, DST_PORT);
 }
 
-TEST_F(UT_NetifPacketParser, test_parsePacket_04)
+// IPv4 截断包（caplen <= eth+ip） => false
+TEST_F(UT_NetifPacketParser, parsePacket_IPv4Truncated_ReturnsFalse_004)
 {
-//    pcap_pkthdr hdr;
-//    memset(&hdr,0,sizeof(hdr));
-//    const u_char packet[64] = {0};
-//    PacketPayload payload = QSharedPointer<struct packet_payload_t>::create();
+    auto pkt = buildIPv4Packet(IPPROTO_TCP, 40);
+    pcap_pkthdr hdr;
+    fillHdr(hdr, 15); // 小于 eth(14)+ip(20)
+    PacketPayload payload = QSharedPointer<struct packet_payload_t>::create();
 
-//    Stub stub;
-//    stub.set(ntohs, stub_ntohs_IPV6);
-//    EXPECT_EQ(m_tester->parsePacket(&hdr, packet, payload), false);
+    EXPECT_FALSE(m_tester->parsePacket(&hdr, pkt.data(), payload));
 }
 
-TEST_F(UT_NetifPacketParser, test_parsePacket_05)
+// 非 IPv4/IPv6 包（ARP）=> false
+TEST_F(UT_NetifPacketParser, parsePacket_NonIP_ReturnsFalse_005)
 {
-//    pcap_pkthdr hdr;
-//    memset(&hdr,0,sizeof(hdr));
-//    int eth_hdr_len = sizeof(struct ether_header);
-//    int ip6_len = sizeof(struct ip6_hdr);
-//    u_char packet[eth_hdr_len+ip6_len+1] = {0};
-//    ether_header header{};
-//    ip6_hdr ip6body{};
-//    char *packet = (char*)header;
+    const size_t ethLen = sizeof(ether_header);
+    std::vector<u_char> pkt(ethLen + 20, 0);
+    auto *eth = reinterpret_cast<struct ether_header *>(pkt.data());
+    eth->ether_type = htons(ETHERTYPE_ARP);
+    pcap_pkthdr hdr;
+    fillHdr(hdr, pkt.size());
+    PacketPayload payload = QSharedPointer<struct packet_payload_t>::create();
 
-//    memcpy(packet, &header, eth_hdr_len);
-//    memcpy(packet+eth_hdr_len, &ip6body, ip6_len);
-//    const u_char packet1[eth_hdr_len + ip6_len+1]= "00000000000000<<<<<<<<<<";
-//    PacketPayload payload = QSharedPointer<struct packet_payload_t>::create();
+    EXPECT_FALSE(m_tester->parsePacket(&hdr, pkt.data(), payload));
+}
 
-//    Stub stub;
-//    stub.set(ntohs, stub_ntohs_IPV6);
-//    EXPECT_EQ(m_tester->parsePacket(&hdr, packet1, payload), false);
+// IPv4 + 未知传输层协议（如 255）=> IP 解析后 proto 非 TCP/UDP => false
+TEST_F(UT_NetifPacketParser, parsePacket_IPv4UnknownProto_ReturnsFalse_006)
+{
+    auto pkt = buildIPv4Packet(255, 40);
+    pcap_pkthdr hdr;
+    fillHdr(hdr, pkt.size());
+    PacketPayload payload = QSharedPointer<struct packet_payload_t>::create();
+
+    EXPECT_FALSE(m_tester->parsePacket(&hdr, pkt.data(), payload));
+}
+
+// IPv6/TCP 正常路径
+TEST_F(UT_NetifPacketParser, parsePacket_IPv6TCP_Success_007)
+{
+    auto pkt = buildIPv6Packet({6 /*TCP*/}, 40);
+    pcap_pkthdr hdr;
+    fillHdr(hdr, pkt.size());
+    PacketPayload payload = QSharedPointer<struct packet_payload_t>::create();
+
+    EXPECT_TRUE(m_tester->parsePacket(&hdr, pkt.data(), payload));
+    EXPECT_EQ(payload->sa_family, AF_INET6);
+    EXPECT_EQ(payload->proto, IPPROTO_TCP);
+    EXPECT_EQ(payload->s_port, SRC_PORT);
+}
+
+// IPv6/UDP 正常路径
+TEST_F(UT_NetifPacketParser, parsePacket_IPv6UDP_Success_008)
+{
+    auto pkt = buildIPv6Packet({17 /*UDP*/}, 40);
+    pcap_pkthdr hdr;
+    fillHdr(hdr, pkt.size());
+    PacketPayload payload = QSharedPointer<struct packet_payload_t>::create();
+
+    EXPECT_TRUE(m_tester->parsePacket(&hdr, pkt.data(), payload));
+    EXPECT_EQ(payload->sa_family, AF_INET6);
+    EXPECT_EQ(payload->proto, IPPROTO_UDP);
+}
+
+// IPv6 + Hop-by-Hop 扩展头 + TCP
+TEST_F(UT_NetifPacketParser, parsePacket_IPv6HBHThenTCP_Success_009)
+{
+    auto pkt = buildIPv6Packet({0 /*HBH*/, 6 /*TCP*/}, 40);
+    pcap_pkthdr hdr;
+    fillHdr(hdr, pkt.size());
+    PacketPayload payload = QSharedPointer<struct packet_payload_t>::create();
+
+    EXPECT_TRUE(m_tester->parsePacket(&hdr, pkt.data(), payload));
+    EXPECT_EQ(payload->proto, IPPROTO_TCP);
+}
+
+// IPv6 + Fragment 扩展头 + TCP
+TEST_F(UT_NetifPacketParser, parsePacket_IPv6FragThenTCP_Success_010)
+{
+    auto pkt = buildIPv6Packet({44 /*FRAGMENT*/, 6 /*TCP*/}, 40);
+    pcap_pkthdr hdr;
+    fillHdr(hdr, pkt.size());
+    PacketPayload payload = QSharedPointer<struct packet_payload_t>::create();
+
+    EXPECT_TRUE(m_tester->parsePacket(&hdr, pkt.data(), payload));
+    EXPECT_EQ(payload->proto, IPPROTO_TCP);
+}
+
+// IPv6 + 封装 IPv6(41) => 忽略返回 false
+TEST_F(UT_NetifPacketParser, parsePacket_IPv6EIP6_ReturnsFalse_011)
+{
+    auto pkt = buildIPv6Packet({41 /*EIP6*/}, 0);
+    pcap_pkthdr hdr;
+    fillHdr(hdr, pkt.size());
+    PacketPayload payload = QSharedPointer<struct packet_payload_t>::create();
+
+    EXPECT_FALSE(m_tester->parsePacket(&hdr, pkt.data(), payload));
+}
+
+// IPv6 + 无下一头(59) => false
+TEST_F(UT_NetifPacketParser, parsePacket_IPv6NoNextHeader_ReturnsFalse_012)
+{
+    auto pkt = buildIPv6Packet({59 /*NNH*/}, 0);
+    pcap_pkthdr hdr;
+    fillHdr(hdr, pkt.size());
+    PacketPayload payload = QSharedPointer<struct packet_payload_t>::create();
+
+    EXPECT_FALSE(m_tester->parsePacket(&hdr, pkt.data(), payload));
+}
+
+// IPv6 + 未知 next header(200) => false
+TEST_F(UT_NetifPacketParser, parsePacket_IPv6UnknownNxt_ReturnsFalse_013)
+{
+    auto pkt = buildIPv6Packet({200 /*unknown*/}, 0);
+    pcap_pkthdr hdr;
+    fillHdr(hdr, pkt.size());
+    PacketPayload payload = QSharedPointer<struct packet_payload_t>::create();
+
+    EXPECT_FALSE(m_tester->parsePacket(&hdr, pkt.data(), payload));
+}
+
+// IPv4/TCP 在传输层截断（caplen 仅够到 IP 头） => false
+TEST_F(UT_NetifPacketParser, parsePacket_IPv4TCPTruncatedAtTransport_ReturnsFalse_014)
+{
+    const size_t ethLen = sizeof(ether_header);
+    const size_t ipLen = sizeof(struct ip);
+    auto pkt = buildIPv4Packet(IPPROTO_TCP, 0);
+    pcap_pkthdr hdr;
+    fillHdr(hdr, ethLen + ipLen); // 不含任何 TCP 字节
+    PacketPayload payload = QSharedPointer<struct packet_payload_t>::create();
+
+    EXPECT_FALSE(m_tester->parsePacket(&hdr, pkt.data(), payload));
+}
+
+// IPv4/UDP uh_ulen=0 分支（RFC2675 jumbogram）=> 不应崩溃，正常返回
+TEST_F(UT_NetifPacketParser, parsePacket_IPv4UDPZeroLength_NoCrash_015)
+{
+    auto pkt = buildIPv4Packet(IPPROTO_UDP, 40);
+    // 覆盖 uh_ulen = 0 分支
+    auto *udp = reinterpret_cast<struct udphdr *>(pkt.data() + sizeof(ether_header) + sizeof(struct ip));
+    udp->uh_ulen = htons(0);
+    pcap_pkthdr hdr;
+    fillHdr(hdr, pkt.size());
+    PacketPayload payload = QSharedPointer<struct packet_payload_t>::create();
+
+    // uh_ulen=0 => ulen=udp_hdr_len；包体足够，应成功解析
+    EXPECT_TRUE(m_tester->parsePacket(&hdr, pkt.data(), payload));
+    EXPECT_EQ(payload->proto, IPPROTO_UDP);
+}
+
+// IPv6 + Routing 扩展头 + TCP
+TEST_F(UT_NetifPacketParser, parsePacket_IPv6RoutingThenTCP_Success_016)
+{
+    auto pkt = buildIPv6Packet({43 /*ROUTING*/, 6 /*TCP*/}, 40);
+    pcap_pkthdr hdr;
+    fillHdr(hdr, pkt.size());
+    PacketPayload payload = QSharedPointer<struct packet_payload_t>::create();
+
+    EXPECT_TRUE(m_tester->parsePacket(&hdr, pkt.data(), payload));
+    EXPECT_EQ(payload->proto, IPPROTO_TCP);
+}
+
+// IPv6 + Destination Options 扩展头 + TCP
+TEST_F(UT_NetifPacketParser, parsePacket_IPv6DestThenTCP_Success_017)
+{
+    auto pkt = buildIPv6Packet({60 /*DEST*/, 6 /*TCP*/}, 40);
+    pcap_pkthdr hdr;
+    fillHdr(hdr, pkt.size());
+    PacketPayload payload = QSharedPointer<struct packet_payload_t>::create();
+
+    EXPECT_TRUE(m_tester->parsePacket(&hdr, pkt.data(), payload));
+    EXPECT_EQ(payload->proto, IPPROTO_TCP);
+}
+
+// IPv6 + RRSVP(46) => 忽略返回 false
+TEST_F(UT_NetifPacketParser, parsePacket_IPv6RRSVP_ReturnsFalse_018)
+{
+    auto pkt = buildIPv6Packet({46 /*RRSVP*/}, 0);
+    pcap_pkthdr hdr;
+    fillHdr(hdr, pkt.size());
+    PacketPayload payload = QSharedPointer<struct packet_payload_t>::create();
+
+    EXPECT_FALSE(m_tester->parsePacket(&hdr, pkt.data(), payload));
+}
+
+// IPv6 + ESP(50) => 忽略返回 false
+TEST_F(UT_NetifPacketParser, parsePacket_IPv6ESP_ReturnsFalse_019)
+{
+    auto pkt = buildIPv6Packet({50 /*ESP*/}, 0);
+    pcap_pkthdr hdr;
+    fillHdr(hdr, pkt.size());
+    PacketPayload payload = QSharedPointer<struct packet_payload_t>::create();
+
+    EXPECT_FALSE(m_tester->parsePacket(&hdr, pkt.data(), payload));
+}
+
+// IPv6 + AUTH(51) => 忽略返回 false
+TEST_F(UT_NetifPacketParser, parsePacket_IPv6AUTH_ReturnsFalse_020)
+{
+    auto pkt = buildIPv6Packet({51 /*AUTH*/}, 0);
+    pcap_pkthdr hdr;
+    fillHdr(hdr, pkt.size());
+    PacketPayload payload = QSharedPointer<struct packet_payload_t>::create();
+
+    EXPECT_FALSE(m_tester->parsePacket(&hdr, pkt.data(), payload));
+}
+
+// IPv6 + ICMPv6(58) => 忽略返回 false
+TEST_F(UT_NetifPacketParser, parsePacket_IPv6ICMP6_ReturnsFalse_021)
+{
+    auto pkt = buildIPv6Packet({58 /*ICMP6*/}, 0);
+    pcap_pkthdr hdr;
+    fillHdr(hdr, pkt.size());
+    PacketPayload payload = QSharedPointer<struct packet_payload_t>::create();
+
+    EXPECT_FALSE(m_tester->parsePacket(&hdr, pkt.data(), payload));
+}
+
+// IPv4/UDP 在传输层截断（caplen 仅到 IP 头）=> false
+TEST_F(UT_NetifPacketParser, parsePacket_IPv4UDPTruncatedAtTransport_ReturnsFalse_022)
+{
+    auto pkt = buildIPv4Packet(IPPROTO_UDP, 40);
+    pcap_pkthdr hdr;
+    fillHdr(hdr, sizeof(ether_header) + sizeof(struct ip)); // 不含 UDP 字节
+    PacketPayload payload = QSharedPointer<struct packet_payload_t>::create();
+
+    EXPECT_FALSE(m_tester->parsePacket(&hdr, pkt.data(), payload));
+}
+
+// IPv4/UDP uh_ulen 非零但 <= UDP 头长 => ulen=udp_len 分支，包体足够应成功
+TEST_F(UT_NetifPacketParser, parsePacket_IPv4UDPSmallLength_Success_023)
+{
+    auto pkt = buildIPv4Packet(IPPROTO_UDP, 40);
+    auto *udp = reinterpret_cast<struct udphdr *>(pkt.data() + sizeof(ether_header) + sizeof(struct ip));
+    udp->uh_ulen = htons(4); // 0 < 4 <= 8 => ulen=4
+    pcap_pkthdr hdr;
+    fillHdr(hdr, pkt.size());
+    PacketPayload payload = QSharedPointer<struct packet_payload_t>::create();
+
+    EXPECT_TRUE(m_tester->parsePacket(&hdr, pkt.data(), payload));
+    EXPECT_EQ(payload->proto, IPPROTO_UDP);
 }


### PR DESCRIPTION
Rewrite packet parser tests with real byte buffers covering all branches, and add pcap_callback and handleNetData tests.

重写包解析测试使用真实字节缓冲覆盖全分支，新增 pcap_callback 与
handleNetData 用例。

Log: 补全网络抓包链路单元测试
Influence: netif_packet_parser 行覆盖 11.3%→96.8%，netif_packet_capture 49.5%→70.0%，netif_monitor 33.9%→100%。