### PR TITLE
fix(system): avoid disk IO speed division by zero

### DIFF
--- a/deepin-system-monitor-main/system/block_device.cpp
+++ b/deepin-system-monitor-main/system/block_device.cpp
@@ -146,10 +146,10 @@ void BlockDevice::calcDiskIoStates(const QStringList &diskInfo)
     //  auto interval = (m_time_sec > d->_time_Sec) ? (m_time_sec - d->_time_Sec) : 1;
     auto ltime = prev_time.tv_sec + prev_time.tv_usec * 1. / 1000000;
     auto rtime = cur_time.tv_sec + cur_time.tv_usec * 1. / 1000000;
-    auto interval = (rtime > ltime) ? (rtime - ltime) : 1;
+    auto interval = (rtime > ltime) ? (rtime - ltime) : 1.0;
 
-    d->read_speed = rsize / static_cast<quint64>(interval);
-    d->wirte_speed = wsize / static_cast<quint64>(interval);
+    d->read_speed = static_cast<quint64>(rsize / interval);
+    d->wirte_speed = static_cast<quint64>(wsize / interval);
 }
 
 } // namespace system

--- a/tests/deepin-system-monitor-main/system/ut_block_device.cpp
+++ b/tests/deepin-system-monitor-main/system/ut_block_device.cpp
@@ -145,6 +145,22 @@ TEST_F(UT_BlockDevice, test_calcDiskIoStates)
      }
 }
 
+TEST_F(UT_BlockDevice, test_calcDiskIoStates_subSecondInterval)
+{
+    QStringList diskInfo { "8", "0", "sda", "10", "0", "100", "0", "20", "0", "200", "0", "0", "0", "0", "0", "0", "5" };
+
+    m_tester->d->blk_read = 50;
+    m_tester->d->blk_wrtn = 100;
+    m_tester->d->discard_sector = 1;
+    m_tester->timevalList[0] = timeval { 10, 900000 };
+    m_tester->timevalList[1] = timeval { 11, 100000 };
+
+    m_tester->calcDiskIoStates(diskInfo);
+
+    EXPECT_GT(m_tester->readSpeed(), 0ULL);
+    EXPECT_GT(m_tester->writeSpeed(), 0ULL);
+}
+
 TEST_F(UT_BlockDevice, test_deviceName)
 {
     m_tester->deviceName();


### PR DESCRIPTION
Keep sub-second disk IO intervals as double before division.

磁盘IO亚秒级间隔参与除法前保持double精度。

Log: 修复磁盘IO亚秒级间隔除零风险

Influence: 避免磁盘IO采样间隔小于1秒时速率计算出现除零崩溃。