### PR TITLE
fix(system): clamp disk IO counter rollback deltas

### DIFF
--- a/deepin-system-monitor-main/system/block_device.cpp
+++ b/deepin-system-monitor-main/system/block_device.cpp
@@ -69,18 +69,22 @@ void BlockDevice::readDeviceInfo()
             calcDiskIoStates(deviceInfo);
             readDeviceModel();
             d->capacity = readDeviceSize(deviceInfo[2]);
+            auto safeDelta = [](quint64 current, quint64 previous) -> quint64 {
+                return (current >= previous) ? (current - previous) : 0;
+            };
+
             if (d->read_iss != 0)
-                d->r_ps = (deviceInfo[3].toULongLong() - d->read_iss) / static_cast<quint64>(interval);
+                d->r_ps = safeDelta(deviceInfo[3].toULongLong(), d->read_iss) / static_cast<quint64>(interval);
             if (d->blk_read != 0)
-                d->rsec_ps = (deviceInfo[5].toULongLong() - d->blk_read) / static_cast<quint64>(interval);
+                d->rsec_ps = safeDelta(deviceInfo[5].toULongLong(), d->blk_read) / static_cast<quint64>(interval);
             if (d->blk_wrtn != 0)
-                d->wsec_ps = (deviceInfo[9].toULongLong() - d->blk_wrtn) / static_cast<quint64>(interval);
+                d->wsec_ps = safeDelta(deviceInfo[9].toULongLong(), d->blk_wrtn) / static_cast<quint64>(interval);
             if (d->read_merged != 0)
-                d->rrqm_ps = (deviceInfo[4].toULongLong() - d->read_merged) / static_cast<quint64>(interval);
+                d->rrqm_ps = safeDelta(deviceInfo[4].toULongLong(), d->read_merged) / static_cast<quint64>(interval);
             if (d->write_com != 0)
-                d->w_ps = (deviceInfo[7].toULongLong() - d->write_com) / static_cast<quint64>(interval);
+                d->w_ps = safeDelta(deviceInfo[7].toULongLong(), d->write_com) / static_cast<quint64>(interval);
             if (d->write_merged != 0)
-                d->wrqm_ps = (deviceInfo[8].toULongLong() - d->write_merged) / static_cast<quint64>(interval);
+                d->wrqm_ps = safeDelta(deviceInfo[8].toULongLong(), d->write_merged) / static_cast<quint64>(interval);
             d->blk_read = deviceInfo[5].toULongLong();
             d->bytes_read = deviceInfo[5].toULongLong() * SECTOR_SIZE;
             if (deviceInfo[3].toULongLong() != 0)

--- a/tests/deepin-system-monitor-main/system/ut_block_device.cpp
+++ b/tests/deepin-system-monitor-main/system/ut_block_device.cpp
@@ -161,6 +161,51 @@ TEST_F(UT_BlockDevice, test_calcDiskIoStates_subSecondInterval)
     EXPECT_GT(m_tester->writeSpeed(), 0ULL);
 }
 
+TEST_F(UT_BlockDevice, test_readDeviceInfo_counterRollback)
+{
+    QFile file(PROC_PATH_DISK);
+    if (!file.open(QIODevice::ReadOnly)) {
+        return;
+    }
+
+    QStringList deviceInfo;
+    QTextStream in(&file);
+    while (!in.atEnd()) {
+        const QString line = in.readLine();
+        if (line.contains("loop")) {
+            continue;
+        }
+
+        const QStringList fields = line.split(" ", QString::SkipEmptyParts);
+        if (fields.size() > 16) {
+            deviceInfo = fields;
+            break;
+        }
+    }
+    file.close();
+
+    if (deviceInfo.isEmpty()) {
+        return;
+    }
+
+    m_tester->d->name = deviceInfo[2].toLocal8Bit();
+    m_tester->d->read_iss = deviceInfo[3].toULongLong() + 1;
+    m_tester->d->read_merged = deviceInfo[4].toULongLong() + 1;
+    m_tester->d->blk_read = deviceInfo[5].toULongLong() + 1;
+    m_tester->d->write_com = deviceInfo[7].toULongLong() + 1;
+    m_tester->d->write_merged = deviceInfo[8].toULongLong() + 1;
+    m_tester->d->blk_wrtn = deviceInfo[9].toULongLong() + 1;
+
+    m_tester->readDeviceInfo();
+
+    EXPECT_EQ(0, m_tester->readRequestIssuedPerSecond());
+    EXPECT_EQ(0, m_tester->readRequestMergedPerSecond());
+    EXPECT_EQ(0, m_tester->sectorsReadPerSecond());
+    EXPECT_EQ(0, m_tester->writeRequestIssuedPerSecond());
+    EXPECT_EQ(0, m_tester->writeRequestMergedPerSecond());
+    EXPECT_EQ(0, m_tester->sectorsWrittenPerSecond());
+}
+
 TEST_F(UT_BlockDevice, test_deviceName)
 {
     m_tester->deviceName();


### PR DESCRIPTION
Clamp disk IO rate deltas to zero when counters move backwards.

磁盘IO计数器回退时将速率差值收敛为0。

Log: 修复磁盘IO计数器回退下溢

PMS: TASK-391229

Influence: 避免块设备计数器重置后显示异常大的磁盘IO速率。