### PR TITLE
fix(system-server): trim systemctl is-enabled output for status check

### DIFF
--- a/deepin-system-monitor-system-server/src/systemdbusserver.cpp
+++ b/deepin-system-monitor-system-server/src/systemdbusserver.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -108,7 +108,7 @@ QString SystemDBusServer::setServiceEnableImpl(const QString &serviceName, bool 
     // 检测是否执行成功
     process.start("systemctl", { "is-enabled", serviceName });
     process.waitForFinished();
-    QString checkRet = process.readAll();
+    QString checkRet = QString::fromLocal8Bit(process.readAll()).trimmed();
     if (enable && ("enabled" == checkRet)) {
         return {};
     } else if (!enable && ("disabled" == checkRet)) {


### PR DESCRIPTION
systemctl is-enabled returns output with trailing newline, causing direct string comparison against "enabled"/"disabled" to always fail.

systemctl is-enabled 输出包含尾部换行符，导致字符串直接比较恒为假，
成功操作被误判为失败。

Log: 修复systemctl is-enabled输出换行导致状态误判
PMS: https://pms.uniontech.com/task-view-391229.html
Influence: 修复后服务自启动设置结果判断正确，不再将成功误报为失败。