### PR TITLE
perf(system): load dmidecode CPU info asynchronously

### DIFF
--- a/deepin-system-monitor-main/main.cpp
+++ b/deepin-system-monitor-main/main.cpp
@@ -12,7 +12,6 @@
 #include "common/perf.h"
 #include "dbus/dbus_object.h"
 #include "dbus/dbusalarmnotify.h"
-#include "3rdparty/dmidecode/dmidecode.h"
 
 #include <DApplication>
 #include <DApplicationSettings>
@@ -65,9 +64,6 @@ int main(int argc, char *argv[])
     if (!DBusObject::getInstance().registerOrNotify())
         return 0;
 
-    //获取dmidecode中CPU频率信息
-    char *const cmd[] = { "dmidecode", "-t", "4" };
-    get_cpuinfo_from_dmi(3, cmd);
     PERF_PRINT_BEGIN("POINT-01", "");
 
     app.setAutoActivateWindows(true);

--- a/deepin-system-monitor-main/system/cpu_set.cpp
+++ b/deepin-system-monitor-main/system/cpu_set.cpp
@@ -38,10 +38,20 @@ using namespace common::alloc;
 using namespace common::init;
 using namespace DDLog;
 
-static bool read_dmi_cache = false;
-
 namespace core {
 namespace system {
+
+static bool waitForProcessFinished(QProcess &process)
+{
+    if (process.waitForFinished(3000))
+        return true;
+
+    if (process.state() != QProcess::NotRunning) {
+        process.kill();
+        process.waitForFinished(1000);
+    }
+    return false;
+}
 
 /**
    @brief 获取首个有效CPU的当前频率，参考 util-linux 中 lscpu 读取 /proc/cpuinfo 的首个 cpu 的 mhz 信息。
@@ -660,32 +670,35 @@ void CPUSet::read_overall_info()
     d->m_infos = infos;
 }
 
-void CPUSet::read_dmi_cache_info()
+DmiCpuInfo CPUSet::readDmiCpuInfo()
 {
-    if (read_dmi_cache) {
-        return;
+    DmiCpuInfo info;
+
+    char *const cmd[] = {"dmidecode", "-t", "4"};
+    get_cpuinfo_from_dmi(3, cmd);
+    if (CurrentCPUFreq > 0) {
+        info.hasCpuFrequency = true;
+        info.cpuMHz = QString::number(CurrentCPUFreq);
+        info.cpuMaxMHz = QString::number(MaxCPUFreq);
     }
 
-    read_dmi_cache = true;
     QProcess process;
-    //(specialComType=0)如果不是特殊机型直接返回;
-    //(specialComType<=-1)如果是未知类型，则使用之前的判断;
-    //(specialComType>=1)如果是hw机型,略过之前的判断
     qCInfo(app) << "common::specialComType value is:" << specialComType;
-    if (specialComType == 0) {
-        return;
-    } else if (specialComType <= -1) {
+    if (specialComType == 0)
+        return info;
+
+    if (specialComType <= -1) {
         qCInfo(app) << "use dmidecode check board type!";
         process.start("dmidecode", QStringList() << "-s"
                                                  << "system-product-name");
-        process.waitForFinished(-1);
+        if (!waitForProcessFinished(process))
+            return info;
         QString spnInfo = process.readAllStandardOutput();
         if (!spnInfo.contains("KLVV", Qt::CaseInsensitive) && !spnInfo.contains("L540", Qt::CaseInsensitive) && !spnInfo.contains("KLVU", Qt::CaseInsensitive)
             && !spnInfo.contains("PGUV", Qt::CaseInsensitive) && !spnInfo.contains("PGUW", Qt::CaseInsensitive) && !spnInfo.contains("W585", Qt::CaseInsensitive)) {
-
             process.start("dmidecode");
-            process.waitForStarted();
-            process.waitForFinished();
+            if (!waitForProcessFinished(process))
+                return info;
             QString result = process.readAll();
             QStringList lines = result.split('\n');
             for (const QString &line : lines) {
@@ -694,18 +707,18 @@ void CPUSet::read_dmi_cache_info()
                     break;
                 }
             }
-            if (!result.contains("PWC30", Qt::CaseInsensitive)   //w525
-                && !result.contains("PGUX", Qt::CaseInsensitive)) {
+            if (!result.contains("PWC30", Qt::CaseInsensitive) && !result.contains("PGUX", Qt::CaseInsensitive)) {
                 process.close();
-                return;
+                return info;
             }
         }
     }
-    qCInfo(app) << "Current is special computer type!";
 
+    qCInfo(app) << "Current is special computer type!";
     process.start("dmidecode", QStringList() << "-t"
                                              << "cache");
-    process.waitForFinished(-1);
+    if (!waitForProcessFinished(process))
+        return info;
     QString cacheinfo = process.readAllStandardOutput();
     QStringList caches = cacheinfo.split("\n\n", QString::SkipEmptyParts);
     process.close();
@@ -715,7 +728,6 @@ void CPUSet::read_dmi_cache_info()
         if (item.isEmpty())
             continue;
         QMap<QString, QString> mapInfo;
-
         QStringList lines = item.split("\n");
         QString lasKey;
         foreach (const QString &line, lines) {
@@ -747,9 +759,8 @@ void CPUSet::read_dmi_cache_info()
         QString typeStr = strList.last();
         if (typeStr.compare("KB", Qt::CaseInsensitive) == 0)
             typeStr = "KiB";
-        else if (typeStr.compare("MB", Qt::CaseInsensitive) == 0) {
+        else if (typeStr.compare("MB", Qt::CaseInsensitive) == 0)
             typeStr = "MiB";
-        }
         int size = strList.first().toInt();
         if (item["Socket Designation"].contains("L1")) {
             int l1Size = size / 2;
@@ -757,26 +768,34 @@ void CPUSet::read_dmi_cache_info()
                 l1Size /= 1024;
                 typeStr = "MiB";
             }
-            d->m_info.insert("L1d cache", QString::number(l1Size) + " " + typeStr);
-            d->m_info.insert("L1i cache", QString::number(l1Size) + " " + typeStr);
+            info.cacheInfo.insert("L1d cache", QString::number(l1Size) + " " + typeStr);
+            info.cacheInfo.insert("L1i cache", QString::number(l1Size) + " " + typeStr);
         } else {
             if (size >= 1024 && typeStr == "KiB") {
                 size /= 1024;
                 typeStr = "MiB";
             }
-            if (item["Socket Designation"].contains("L2")) {
-                d->m_info.insert("L2 cache", QString::number(size) + " " + typeStr);
-            } else if (item["Socket Designation"].contains("L3")) {
-                d->m_info.insert("L3 cache", QString::number(size) + " " + typeStr);
-            }
+            if (item["Socket Designation"].contains("L2"))
+                info.cacheInfo.insert("L2 cache", QString::number(size) + " " + typeStr);
+            else if (item["Socket Designation"].contains("L3"))
+                info.cacheInfo.insert("L3 cache", QString::number(size) + " " + typeStr);
         }
     }
+
+    return info;
+}
+
+void CPUSet::read_dmi_cache_info()
+{
+    return;
 }
 
 void CPUSet::read_cache_from_lscpu_cmd()
 {
-    if (read_dmi_cache)
-        return;   // 不要覆盖 dmidecode 获取的缓存信息
+    if (d->m_lscpuCacheInfoRead)
+        return;
+
+    d->m_lscpuCacheInfoRead = true;
 
     QProcess process;
     QString command = "lscpu | grep cache";
@@ -981,12 +1000,7 @@ void CPUSet::read_lscpu()
             }
             d->m_info.insert("CPU MHz", nowMHz);
         } else {
-            if (CurrentCPUFreq > 0) {
-                d->m_info.insert("CPU MHz", QString::number(CurrentCPUFreq));
-                d->m_info.insert("CPU max MHz", QString::number(MaxCPUFreq));
-            } else {
-                d->m_info.insert("CPU MHz", "-");
-            }
+            d->m_info.insert("CPU MHz", "-");
         }
         if (ct->bogomips) {
             d->m_info.insert("BogoMIPS", ct->bogomips);
@@ -1067,6 +1081,7 @@ void CPUSet::read_lscpu()
     if (!d->m_info.contains("L3 cache")) {
         d->m_info.insert("L3 cache", "-");
     }
+    applyDmiCpuInfoToCurrentInfo();
     for (size_t i = 0; i < cxt->necaches; i++) {
         struct lscpu_cache *ca = &cxt->ecaches[i];
         if (ca->size == 0)
@@ -1083,6 +1098,32 @@ void CPUSet::read_lscpu()
         }
     }
     lscpu_free_context(cxt);
+}
+
+void CPUSet::applyDmiCpuInfo(const DmiCpuInfo &info)
+{
+    d->m_hasDmiCpuInfo = info.hasData();
+    d->m_dmiHasCpuFrequency = info.hasCpuFrequency;
+    d->m_dmiCpuMHz = info.cpuMHz;
+    d->m_dmiCpuMaxMHz = info.cpuMaxMHz;
+    d->m_dmiCacheInfo = info.cacheInfo;
+
+    applyDmiCpuInfoToCurrentInfo();
+}
+
+void CPUSet::applyDmiCpuInfoToCurrentInfo()
+{
+    if (!d->m_hasDmiCpuInfo)
+        return;
+
+    if (d->m_dmiHasCpuFrequency && !d->m_dmiCpuMHz.isEmpty())
+        d->m_info.insert("CPU MHz", d->m_dmiCpuMHz);
+
+    if (d->m_dmiHasCpuFrequency && !d->m_dmiCpuMaxMHz.isEmpty())
+        d->m_info.insert("CPU max MHz", d->m_dmiCpuMaxMHz);
+
+    for (auto it = d->m_dmiCacheInfo.cbegin(); it != d->m_dmiCacheInfo.cend(); ++it)
+        d->m_info.insert(it.key(), it.value());
 }
 
 qulonglong CPUSet::getUsageTotalDelta() const

--- a/deepin-system-monitor-main/system/cpu_set.h
+++ b/deepin-system-monitor-main/system/cpu_set.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -6,6 +6,7 @@
 #define CPUSET_H
 
 #include "cpu.h"
+#include "dmi_cpu_info.h"
 #include "3rdparty/dmidecode/dmidecode.h"
 #include <QList>
 #include <QSharedDataPointer>
@@ -14,6 +15,7 @@ namespace core {
 namespace system {
 
 class CPUSetPrivate;
+
 class CPUSet
 {
     friend class Process;
@@ -70,6 +72,8 @@ public://usage
 
 public:
     void update();
+    void applyDmiCpuInfo(const DmiCpuInfo &info);
+    static DmiCpuInfo readDmiCpuInfo();
 
 private:
     void read_stats();
@@ -81,6 +85,7 @@ private:
      * @brief read_lscpu 通过lscpu读取CPU信息
      */
     void read_lscpu();
+    void applyDmiCpuInfoToCurrentInfo();
     void read_overall_info();
     QPair<float, float> read_cpu_freq_range_by_cpu7();
 

--- a/deepin-system-monitor-main/system/dmi_cpu_info.h
+++ b/deepin-system-monitor-main/system/dmi_cpu_info.h
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef DEEPIN_SYSTEM_MONITOR_DMI_CPU_INFO_H
+#define DEEPIN_SYSTEM_MONITOR_DMI_CPU_INFO_H
+
+#include <QMap>
+#include <QString>
+
+namespace core {
+namespace system {
+
+struct DmiCpuInfo
+{
+    bool hasCpuFrequency {false};
+    QString cpuMHz;
+    QString cpuMaxMHz;
+    QMap<QString, QString> cacheInfo;
+
+    bool hasData() const
+    {
+        return hasCpuFrequency || !cacheInfo.isEmpty();
+    }
+};
+
+} // namespace system
+} // namespace core
+
+#endif // DEEPIN_SYSTEM_MONITOR_DMI_CPU_INFO_H

--- a/deepin-system-monitor-main/system/private/cpu_set_p.h
+++ b/deepin-system-monitor-main/system/private/cpu_set_p.h
@@ -63,6 +63,13 @@ public:
         , m_usage(std::make_shared<cpu_usage_t>(*(other.m_usage)))
         , m_info(other.m_info)
     {
+        m_lscpuCacheInfoRead = other.m_lscpuCacheInfoRead;
+        m_hasDmiCpuInfo = other.m_hasDmiCpuInfo;
+        m_dmiHasCpuFrequency = other.m_dmiHasCpuFrequency;
+        m_dmiCpuMHz = other.m_dmiCpuMHz;
+        m_dmiCpuMaxMHz = other.m_dmiCpuMaxMHz;
+        m_dmiCacheInfo = other.m_dmiCacheInfo;
+
         for (auto &stat : other.m_statDB) {
             if (stat) {
                 auto cp = std::make_shared<cpu_stat_t>(*stat);
@@ -104,6 +111,12 @@ private:
     friend class CPUSet;
 
     QMap<QString, QString> m_info;   //overall info
+    bool m_lscpuCacheInfoRead {false};
+    bool m_hasDmiCpuInfo {false};
+    bool m_dmiHasCpuFrequency {false};
+    QString m_dmiCpuMHz;
+    QString m_dmiCpuMaxMHz;
+    QMap<QString, QString> m_dmiCacheInfo;
     QList<CPUInfo> m_infos;         //per cpu info
 };
 

--- a/deepin-system-monitor-main/system/system_monitor.cpp
+++ b/deepin-system-monitor-main/system/system_monitor.cpp
@@ -5,6 +5,7 @@
 
 #include "system_monitor.h"
 
+#include "cpu_set.h"
 #include "device_db.h"
 #include "process/process_db.h"
 #include "process/desktop_entry_cache_updater.h"
@@ -12,6 +13,7 @@
 #include "sys_info.h"
 
 #include <QTimerEvent>
+#include <QtConcurrent>
 
 using namespace common::core;
 
@@ -23,8 +25,12 @@ SystemMonitor::SystemMonitor(QObject *parent)
     , m_sysInfo(new SysInfo())
     , m_deviceDB(new DeviceDB())
     , m_processDB(new ProcessDB(this))
+    , m_dmiCpuInfoReader(CPUSet::readDmiCpuInfo)
 {
     m_sysInfo->readSysInfoStatic();
+    m_dmiCpuInfoWatcher = new QFutureWatcher<DmiCpuInfo>(this);
+    connect(m_dmiCpuInfoWatcher, &QFutureWatcher<DmiCpuInfo>::finished,
+            this, &SystemMonitor::onDmiCpuInfoLoadFinished);
 }
 
 SystemMonitor::~SystemMonitor()
@@ -71,6 +77,32 @@ void SystemMonitor::startMonitorJob()
     m_basictimer.stop();
     m_basictimer.start(1000, Qt::VeryCoarseTimer, this);
     updateSystemMonitorInfo();
+    startDmiCpuInfoLoadIfNeeded();
+}
+
+void SystemMonitor::startDmiCpuInfoLoadIfNeeded()
+{
+    if (m_dmiLoadState != DmiLoadState::NotStarted)
+        return;
+
+    m_dmiLoadState = DmiLoadState::Loading;
+    auto reader = m_dmiCpuInfoReader;
+    m_dmiCpuInfoWatcher->setFuture(QtConcurrent::run([reader]() {
+        return reader();
+    }));
+}
+
+void SystemMonitor::onDmiCpuInfoLoadFinished()
+{
+    DmiCpuInfo info = m_dmiCpuInfoWatcher->result();
+    if (!info.hasData()) {
+        m_dmiLoadState = DmiLoadState::Failed;
+        return;
+    }
+
+    m_deviceDB->cpuSet()->applyDmiCpuInfo(info);
+    m_dmiLoadState = DmiLoadState::Loaded;
+    emit statInfoUpdated();
 }
 static uint cnt = 0 ;
 void SystemMonitor::timerEvent(QTimerEvent *event)

--- a/deepin-system-monitor-main/system/system_monitor.h
+++ b/deepin-system-monitor-main/system/system_monitor.h
@@ -6,8 +6,11 @@
 #ifndef SYSTEM_MONITOR_H
 #define SYSTEM_MONITOR_H
 
+#include "dmi_cpu_info.h"
+
 #include <QObject>
 #include <QBasicTimer>
+#include <QFutureWatcher>
 
 namespace core {
 namespace process {
@@ -20,6 +23,7 @@ using namespace core::process;
 namespace core {
 namespace system {
 
+class CPUSet;
 class DeviceDB;
 class SysInfo;
 
@@ -48,8 +52,17 @@ protected:
     void timerEvent(QTimerEvent *event);
 
 private:
+    enum class DmiLoadState {
+        NotStarted,
+        Loading,
+        Loaded,
+        Failed
+    };
+
     void updateSystemMonitorInfo();
     void recountAppAndProcess();
+    void startDmiCpuInfoLoadIfNeeded();
+    void onDmiCpuInfoLoadFinished();
 
 private:
     SysInfo      *m_sysInfo;
@@ -57,6 +70,9 @@ private:
     ProcessDB    *m_processDB;
 
     QBasicTimer m_basictimer;
+    QFutureWatcher<DmiCpuInfo> *m_dmiCpuInfoWatcher {};
+    DmiLoadState m_dmiLoadState {DmiLoadState::NotStarted};
+    DmiCpuInfo (*m_dmiCpuInfoReader)() {};
 };
 
 } // namespace system

--- a/deepin-system-monitor-plugin-popup/system/cpu_set.cpp
+++ b/deepin-system-monitor-plugin-popup/system/cpu_set.cpp
@@ -486,7 +486,39 @@ void CPUSet::read_overall_info()
             d->m_info[keyValue.value(0).trimmed()] = keyValue.value(1).trimmed();
     }
 
+    applyDmiCpuInfoToCurrentInfo();
     d->m_infos = infos;
+}
+
+DmiCpuInfo CPUSet::readDmiCpuInfo()
+{
+    return DmiCpuInfo();
+}
+
+void CPUSet::applyDmiCpuInfo(const DmiCpuInfo &info)
+{
+    d->m_hasDmiCpuInfo = info.hasData();
+    d->m_dmiHasCpuFrequency = info.hasCpuFrequency;
+    d->m_dmiCpuMHz = info.cpuMHz;
+    d->m_dmiCpuMaxMHz = info.cpuMaxMHz;
+    d->m_dmiCacheInfo = info.cacheInfo;
+
+    applyDmiCpuInfoToCurrentInfo();
+}
+
+void CPUSet::applyDmiCpuInfoToCurrentInfo()
+{
+    if (!d->m_hasDmiCpuInfo)
+        return;
+
+    if (d->m_dmiHasCpuFrequency && !d->m_dmiCpuMHz.isEmpty())
+        d->m_info.insert("CPU MHz", d->m_dmiCpuMHz);
+
+    if (d->m_dmiHasCpuFrequency && !d->m_dmiCpuMaxMHz.isEmpty())
+        d->m_info.insert("CPU max MHz", d->m_dmiCpuMaxMHz);
+
+    for (auto it = d->m_dmiCacheInfo.cbegin(); it != d->m_dmiCacheInfo.cend(); ++it)
+        d->m_info.insert(it.key(), it.value());
 }
 
 qulonglong CPUSet::getUsageTotalDelta() const

--- a/deepin-system-monitor-plugin-popup/system/cpu_set.h
+++ b/deepin-system-monitor-plugin-popup/system/cpu_set.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -6,6 +6,7 @@
 #define CPUSET_H
 
 #include "system/cpu.h"
+#include "system/dmi_cpu_info.h"
 
 #include <QList>
 #include <QSharedDataPointer>
@@ -70,11 +71,14 @@ public://usage
 
 public:
     void update();
+    void applyDmiCpuInfo(const DmiCpuInfo &info);
+    static DmiCpuInfo readDmiCpuInfo();
 
 private:
     void read_stats();
 
     void read_overall_info();
+    void applyDmiCpuInfoToCurrentInfo();
 
 private:
     QSharedDataPointer<CPUSetPrivate> d;

--- a/tests/deepin-system-monitor-main/system/ut_cpu_set.cpp
+++ b/tests/deepin-system-monitor-main/system/ut_cpu_set.cpp
@@ -7,6 +7,7 @@
 #include "system/cpu_set.h"
 #include "system/cpu.h"
 #include "system/private/cpu_set_p.h"
+#include "common/common.h"
 
 //gtest
 #include "stub.h"
@@ -323,4 +324,36 @@ TEST_F(UT_CPUSet, test_getUsageTotalDelta_02)
     m_tester->d->cpusageTotal[kCurrentStat] = 0;
     qulonglong totalDelta = m_tester->getUsageTotalDelta();
     EXPECT_NE(totalDelta, 0);
+}
+
+TEST_F(UT_CPUSet, test_applyDmiCpuInfo_01)
+{
+    DmiCpuInfo info;
+    info.hasCpuFrequency = true;
+    info.cpuMHz = "1800";
+    info.cpuMaxMHz = "3200";
+    info.cacheInfo.insert("L1d cache", "64 KiB");
+    info.cacheInfo.insert("L2 cache", "2 MiB");
+
+    m_tester->applyDmiCpuInfo(info);
+
+    EXPECT_EQ(m_tester->curFreq(), common::format::formatHz(1800, common::format::MHz));
+    EXPECT_EQ(m_tester->maxFreq(), common::format::formatHz(3200, common::format::MHz));
+    EXPECT_EQ(m_tester->l1dCache(), "64 KiB");
+    EXPECT_EQ(m_tester->l2Cache(), "2 MiB");
+}
+
+TEST_F(UT_CPUSet, test_DmiCpuInfo_hasData_01)
+{
+    DmiCpuInfo emptyInfo;
+    EXPECT_FALSE(emptyInfo.hasData());
+
+    DmiCpuInfo freqInfo;
+    freqInfo.hasCpuFrequency = true;
+    freqInfo.cpuMHz = "1200";
+    EXPECT_TRUE(freqInfo.hasData());
+
+    DmiCpuInfo cacheInfo;
+    cacheInfo.cacheInfo.insert("L3 cache", "8 MiB");
+    EXPECT_TRUE(cacheInfo.hasData());
 }

--- a/tests/deepin-system-monitor-main/system/ut_system_monitor.cpp
+++ b/tests/deepin-system-monitor-main/system/ut_system_monitor.cpp
@@ -11,6 +11,7 @@
 #include <gtest/gtest.h>
 
 //qt
+#include <QSignalSpy>
 #include <QTimerEvent>
 
 using namespace core::system;
@@ -38,6 +39,30 @@ protected:
     SystemMonitor *m_tester;
 };
 
+static DmiCpuInfo stub_readDmiCpuInfo_for_system_monitor()
+{
+    DmiCpuInfo info;
+    info.hasCpuFrequency = true;
+    info.cpuMHz = "1600";
+    info.cpuMaxMHz = "3000";
+    return info;
+}
+
+TEST_F(UT_SystemMonitor, test_startDmiCpuInfoLoadIfNeeded_01)
+{
+    m_tester->m_dmiCpuInfoReader = stub_readDmiCpuInfo_for_system_monitor;
+    QSignalSpy spy(m_tester->m_dmiCpuInfoWatcher, &QFutureWatcher<DmiCpuInfo>::finished);
+
+    m_tester->startDmiCpuInfoLoadIfNeeded();
+    EXPECT_EQ(m_tester->m_dmiLoadState, SystemMonitor::DmiLoadState::Loading);
+
+    ASSERT_TRUE(spy.wait(1000));
+    EXPECT_EQ(m_tester->m_dmiLoadState, SystemMonitor::DmiLoadState::Loaded);
+
+    m_tester->startDmiCpuInfoLoadIfNeeded();
+    EXPECT_EQ(m_tester->m_dmiLoadState, SystemMonitor::DmiLoadState::Loaded);
+}
+
 TEST_F(UT_SystemMonitor, initTest)
 {
 }
@@ -64,8 +89,12 @@ TEST_F(UT_SystemMonitor, test_sysInfo)
 
 TEST_F(UT_SystemMonitor, test_startMonitorJob)
 {
+    m_tester->m_dmiCpuInfoReader = stub_readDmiCpuInfo_for_system_monitor;
+    QSignalSpy spy(m_tester->m_dmiCpuInfoWatcher, &QFutureWatcher<DmiCpuInfo>::finished);
+
     m_tester->startMonitorJob();
     EXPECT_TRUE(m_tester->m_basictimer.isActive() == true);
+    ASSERT_TRUE(spy.wait(1000));
 }
 
 TEST_F(UT_SystemMonitor, test_timerEvent)


### PR DESCRIPTION
Move DMI CPU frequency and cache reads off the startup path.

将DMI CPU频率和缓存读取移出启动路径。

Apply the result as a CPU info overlay with timeout protection.

异步读取后以CPU信息覆盖层应用，并增加超时保护。

Log: 异步加载dmidecode CPU信息
Task: https://pms.uniontech.com/task-view-390703.html
Influence: 缩短系统监视器首窗启动阻塞，dmidecode异常时限定等待时间。