### PR TITLE
fix(system): avoid shell when reading lscpu cache info

### DIFF
--- a/deepin-system-monitor-main/system/cpu_set.cpp
+++ b/deepin-system-monitor-main/system/cpu_set.cpp
@@ -779,12 +779,14 @@ void CPUSet::read_cache_from_lscpu_cmd()
         return;   // 不要覆盖 dmidecode 获取的缓存信息
 
     QProcess process;
-    QString command = "lscpu | grep cache";
-    process.start("bash", QStringList() << "-c" << command);
+    process.start("lscpu", QStringList());
     process.waitForFinished(3000);
     QString cache = process.readAllStandardOutput();
     QStringList cacheList = cache.split("\n", QString::SkipEmptyParts);
     for (const QString &cacheLine : qAsConst(cacheList)) {
+        if (!cacheLine.contains("cache"))
+            continue;
+
         QStringList keyValue = cacheLine.split(":", QString::SkipEmptyParts);
         if (keyValue.count() > 1)
             d->m_info[keyValue.value(0).trimmed()] = keyValue.value(1).trimmed();


### PR DESCRIPTION
Run lscpu directly and filter cache lines in process.

直接执行lscpu并在进程内过滤缓存信息行。

Log: 修复读取CPU缓存信息时通过shell执行命令的问题

Task: https://pms.uniontech.com/task-view-392045.html

Influence: 避免通过bash -c执行固定命令，满足安全编码规范且保持CPU缓存信息读取行为不变。

## Summary by Sourcery

Bug Fixes:
- Fix CPU cache info retrieval to avoid using bash -c for executing lscpu, aligning with secure coding guidelines.