### PR TITLE
fix(system): avoid shell command execution

### DIFF
--- a/deepin-system-monitor-main/stack_trace.h
+++ b/deepin-system-monitor-main/stack_trace.h
@@ -87,8 +87,13 @@ static inline void printStacktrace(int signum)
     // raise origin signal
     raise(signum);
 
-    QString cmd = R"(sleep 0.1 && dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.Launch string:"/usr/share/applications/deepin-system-monitor.desktop";)";
-    QProcess::startDetached("bash", { "-c", cmd });
+    QStringList arguments;
+    arguments << "--session" << "--print-reply"
+              << "--dest=com.deepin.SessionManager"
+              << "/com/deepin/StartManager"
+              << "com.deepin.StartManager.Launch"
+              << "string:/usr/share/applications/deepin-system-monitor.desktop";
+    QProcess::startDetached("dbus-send", arguments);
 }
 
 /**

--- a/deepin-system-monitor-main/system/cpu_set.cpp
+++ b/deepin-system-monitor-main/system/cpu_set.cpp
@@ -779,12 +779,14 @@ void CPUSet::read_cache_from_lscpu_cmd()
         return;   // 不要覆盖 dmidecode 获取的缓存信息
 
     QProcess process;
-    QString command = "lscpu | grep cache";
-    process.start("bash", QStringList() << "-c" << command);
+    process.start("lscpu", QStringList());
     process.waitForFinished(3000);
     QString cache = process.readAllStandardOutput();
     QStringList cacheList = cache.split("\n", QString::SkipEmptyParts);
     for (const QString &cacheLine : qAsConst(cacheList)) {
+        if (!cacheLine.contains("cache"))
+            continue;
+
         QStringList keyValue = cacheLine.split(":", QString::SkipEmptyParts);
         if (keyValue.count() > 1)
             d->m_info[keyValue.value(0).trimmed()] = keyValue.value(1).trimmed();


### PR DESCRIPTION
Run lscpu and dbus-send directly instead of invoking bash -c.

直接执行lscpu和dbus-send，避免通过bash -c解释固定命令。

Log: 修复系统监视器中通过shell执行固定命令的问题
Task: https://pms.uniontech.com/task-view-392045.html
Influence: 避免CPU缓存信息读取和崩溃重启流程通过shell执行固定命令，满足安全编码规范且保持原有核心行为。

## Summary by Sourcery

Avoid executing fixed system-monitor commands via a shell and call the underlying binaries directly to meet secure coding requirements.

Bug Fixes:
- Prevent stack trace restart flow from invoking dbus-send via bash and launch the system monitor by calling dbus-send directly.
- Avoid running lscpu through bash when reading CPU cache information, reducing reliance on the shell for fixed commands.

Enhancements:
- Filter lscpu output in code to only process cache-related lines instead of using a shell grep pipeline.