### PR TITLE
fix(system): avoid shell in crash restart command

### DIFF
--- a/deepin-system-monitor-main/stack_trace.h
+++ b/deepin-system-monitor-main/stack_trace.h
@@ -87,8 +87,13 @@ static inline void printStacktrace(int signum)
     // raise origin signal
     raise(signum);
 
-    QString cmd = R"(sleep 0.1 && dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.Launch string:"/usr/share/applications/deepin-system-monitor.desktop";)";
-    QProcess::startDetached("bash", { "-c", cmd });
+    QStringList arguments;
+    arguments << "--session" << "--print-reply"
+              << "--dest=com.deepin.SessionManager"
+              << "/com/deepin/StartManager"
+              << "com.deepin.StartManager.Launch"
+              << "string:/usr/share/applications/deepin-system-monitor.desktop";
+    QProcess::startDetached("dbus-send", arguments);
 }
 
 /**


### PR DESCRIPTION
Run dbus-send directly when relaunching system monitor after a crash.

崩溃后重启系统监视器时直接执行dbus-send，避免通过shell解释命令。

Log: 修复崩溃重启命令通过shell执行的问题
Task: https://pms.uniontech.com/task-view-392045.html
Influence: 避免崩溃处理流程通过bash -c执行固定命令，满足安全编码规范。

## Summary by Sourcery

Bug Fixes:
- Fix crash recovery so the system monitor relaunch command no longer executes through bash -c.