### PR TITLE
fix(system-server): tighten systemctl service name validation and exi…

### DIFF
--- a/deepin-system-monitor-system-server/src/service_name_validator.h
+++ b/deepin-system-monitor-system-server/src/service_name_validator.h
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// 服务名校验与存在性匹配的纯函数集合。
+// header-only：system-server 与 tests 单测共用同一份实现，避免逻辑重复与漂移。
+
+#ifndef SERVICE_NAME_VALIDATOR_H
+#define SERVICE_NAME_VALIDATOR_H
+
+#include <QByteArray>
+#include <QRegularExpression>
+#include <QString>
+#include <QStringList>
+#include <climits>      // SHRT_MAX
+
+/**
+ * @brief 校验传入的 systemctl 服务名是否合法。
+ *
+ * 采用白名单正则锚定整串匹配，统一拦截空串、超长串、控制字符
+ * （制表符/换行等）以及缺少 `.service` 后缀等非法输入，
+ * 取代原先只拦截 ';' 与空格的黑名单 contains 判断。
+ *
+ * 字符集覆盖 systemd service 单元名合法字符（含模板单元 `getty@.service`
+ * 及实例 `getty@tty1.service`），并强制 `.service` 后缀——与调用方
+ * `ServiceManager` 传入的 systemd `Unit.Id`（完整单元名）语义一致。
+ */
+inline bool isValidServiceName(const QString &name)
+{
+    if (name.isEmpty() || name.size() > SHRT_MAX) {
+        return false;
+    }
+    // ^/$ 锚定整串，避免退化为子串匹配；\.service 强制后缀
+    static const QRegularExpression kServiceNameRe("^[A-Za-z0-9_.:@-]+\\.service$");
+    return kServiceNameRe.match(name).hasMatch();
+}
+
+/**
+ * @brief 在 `systemctl list-unit-files` 的输出中判断服务是否存在。
+ *
+ * 按行解析，逐行取第一列（完整服务名）与 @p name 做精确相等比较，
+ * 取代原先对整段输出做字节级子串匹配的 contains 判断，避免把某真实
+ * 服务名的子串（如传入 "dbus" 命中 "dbus.service"）误判为存在。
+ *
+ * 头行（"UNIT FILE …"）与尾行（"N unit files listed."）因第一列
+ * 与目标名不等而自然被跳过。
+ */
+inline bool serviceExistsInList(const QString &name, const QByteArray &listOutput)
+{
+    const QByteArray target = name.toUtf8();
+    const QList<QByteArray> lines = listOutput.split('\n');
+    for (const QByteArray &rawLine : lines) {
+        const QByteArray line = rawLine.trimmed();
+        if (line.isEmpty()) {
+            continue;
+        }
+        // list-unit-files 输出以空白分隔；第一列为完整服务名。
+        // 仅当该列以 .service 结尾才视为候选，使头行（"UNIT FILE …"）
+        // 与尾行（"N unit files listed."）被天然跳过，函数可独立成立。
+        const QByteArray first = line.split(' ').first();
+        if (first.endsWith(".service") && first == target) {
+            return true;
+        }
+    }
+    return false;
+}
+
+#endif // SERVICE_NAME_VALIDATOR_H

--- a/deepin-system-monitor-system-server/src/systemdbusserver.cpp
+++ b/deepin-system-monitor-system-server/src/systemdbusserver.cpp
@@ -4,6 +4,7 @@
 
 #include "systemdbusserver.h"
 #include "ddlog.h"
+#include "service_name_validator.h"
 
 #include <QCoreApplication>
 #include <QDBusMessage>
@@ -77,8 +78,8 @@ QString SystemDBusServer::setServiceEnable(const QString &serviceName, bool enab
  */
 QString SystemDBusServer::setServiceEnableImpl(const QString &serviceName, bool enable)
 {
-    // 不允许包含';' ' '字符，服务名称长度同样限制
-    if (serviceName.isEmpty() || (serviceName.size() > SHRT_MAX) || serviceName.contains(QRegExp("[; ]"))) {
+    // 服务名白名单校验：拦截空串、超长、控制字符（制表符/换行等）及缺少 .service 后缀
+    if (!isValidServiceName(serviceName)) {
         qWarning() << qPrintable("Invalid service name");
         return QString(strerror(EINVAL));
     }
@@ -97,7 +98,7 @@ QString SystemDBusServer::setServiceEnableImpl(const QString &serviceName, bool 
         return QString(strerror(EIO));
     }
     QByteArray serviceList = listPorcess.readAll();
-    if (!serviceList.contains(serviceName.toUtf8())) {
+    if (!serviceExistsInList(serviceName, serviceList)) {
         qWarning() << qPrintable("Service not exists");
         return QString(strerror(EINVAL));
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -626,6 +626,7 @@ target_include_directories(${PROJECT_NAME_TEST}
         ${CMAKE_HOME_DIRECTORY}/${PROJECT_NAME}-main/3rdparty
         ${CMAKE_HOME_DIRECTORY}/${PROJECT_NAME}-main/3rdparty/include
         ${CMAKE_HOME_DIRECTORY}/${PROJECT_NAME}-main/3rdparty/libsmartcols/src
+        ${CMAKE_HOME_DIRECTORY}/deepin-system-monitor-system-server/src
         )
 
 target_link_libraries(${PROJECT_NAME_TEST}

--- a/tests/deepin-system-monitor-main/service/ut_service_name_validator.cpp
+++ b/tests/deepin-system-monitor-main/service/ut_service_name_validator.cpp
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// self
+#include "service_name_validator.h"
+
+// gtest
+#include <gtest/gtest.h>
+
+class UT_ServiceNameValidator : public ::testing::Test
+{
+};
+
+// ---------------- isValidServiceName ----------------
+
+TEST_F(UT_ServiceNameValidator, ValidNames)
+{
+    EXPECT_TRUE(isValidServiceName("dbus.service"));
+    EXPECT_TRUE(isValidServiceName("cron.service"));
+    EXPECT_TRUE(isValidServiceName("systemd-journald.service"));
+    EXPECT_TRUE(isValidServiceName("getty@.service"));
+    EXPECT_TRUE(isValidServiceName("getty@tty1.service"));
+    EXPECT_TRUE(isValidServiceName("a-b_c.d@e.service"));
+}
+
+TEST_F(UT_ServiceNameValidator, InvalidEmptyAndSuffix)
+{
+    EXPECT_FALSE(isValidServiceName(""));          // 空
+    EXPECT_FALSE(isValidServiceName("dbus"));     // 缺 .service 后缀
+    EXPECT_FALSE(isValidServiceName("dbus.servicex")); // 后缀错误
+    EXPECT_FALSE(isValidServiceName(".service")); // 缺主体
+}
+
+TEST_F(UT_ServiceNameValidator, InvalidControlChars)
+{
+    EXPECT_FALSE(isValidServiceName("db us.service"));  // 空格
+    EXPECT_FALSE(isValidServiceName("db\tus.service")); // 制表符
+    EXPECT_FALSE(isValidServiceName("db\nus.service"));  // 换行
+    EXPECT_FALSE(isValidServiceName("db;us.service"));  // 分号
+    EXPECT_FALSE(isValidServiceName("dbus;"));
+}
+
+TEST_F(UT_ServiceNameValidator, InvalidTooLong)
+{
+    QString longName;
+    longName.fill('a', SHRT_MAX);          // 主体超长
+    longName += ".service";
+    EXPECT_FALSE(isValidServiceName(longName));
+}
+
+// ---------------- serviceExistsInList ----------------
+
+static const char *kSampleList =
+    "UNIT FILE                                  STATE         PRESET\n"
+    "cron.service                               enabled       enabled\n"
+    "dbus.service                               static        -\n"
+    "getty@.service                             enabled       enabled\n"
+    "\n"
+    "3 unit files listed.\n";
+
+TEST_F(UT_ServiceNameValidator, ExistsExactMatch)
+{
+    EXPECT_TRUE(serviceExistsInList("dbus.service", kSampleList));
+    EXPECT_TRUE(serviceExistsInList("cron.service", kSampleList));
+    EXPECT_TRUE(serviceExistsInList("getty@.service", kSampleList));
+}
+
+TEST_F(UT_ServiceNameValidator, NotExistsSubstringOrSuffix)
+{
+    // 子串不应命中
+    EXPECT_FALSE(serviceExistsInList("dbu.service", kSampleList));   // 与 dbus.service 有子串关系但不同
+    EXPECT_FALSE(serviceExistsInList("dbus", kSampleList));         // 缺后缀
+    EXPECT_FALSE(serviceExistsInList("cron.servicex", kSampleList));
+    // 头行/尾行不应命中
+    EXPECT_FALSE(serviceExistsInList("UNIT", kSampleList));
+    EXPECT_FALSE(serviceExistsInList("listed.", kSampleList));
+}
+
+TEST_F(UT_ServiceNameValidator, ExistsEmptyList)
+{
+    EXPECT_FALSE(serviceExistsInList("dbus.service", ""));
+    EXPECT_FALSE(serviceExistsInList("dbus.service", QByteArray()));
+}


### PR DESCRIPTION
…stence match

Validate service names with an anchored whitelist regex instead of a blacklist contains() check, and compare the first column of list-unit-files output exactly instead of a byte-level substring match over the whole output.

服务名校验由黑名单 contains("[; ]") 改为白名单正则锚定整串匹配，
统一拦截空串、超长、制表符/换行等控制字符及缺少 .service 后缀的非法输入；
服务存在性由对整段输出的子串匹配改为按行取第一列精确相等比较，避免把
真实服务名的子串误判为存在，并移除过时的 QRegExp。

Log: 收紧 systemctl 服务名校验和存在性匹配
Task: https://pms.uniontech.com/task-view-391229.html
Influence: DBus 后端不再接受含控制字符或不带 .service 后缀的非法服务名，且服务存在性判断不再因子串误命中而误报成功。