### PR TITLE
perf(gui): defer user page construction until first visit

### DIFF
--- a/deepin-system-monitor-main/gui/main_window.cpp
+++ b/deepin-system-monitor-main/gui/main_window.cpp
@@ -87,6 +87,15 @@ void MainWindow::onLoadStatusChanged(bool loading)
     titlebar()->setMenuDisabled(loading);
 }
 
+UserPageWidget *MainWindow::ensureUserPage()
+{
+    if (!m_accountProcPage) {
+        m_accountProcPage = new UserPageWidget(m_pages);
+        m_pages->addWidget(m_accountProcPage);
+    }
+    return m_accountProcPage;
+}
+
 // initialize ui components
 void MainWindow::initUI()
 {
@@ -179,12 +188,13 @@ void MainWindow::initUI()
 
     m_procPage = new ProcessPageWidget(m_pages);
     m_svcPage = new SystemServicePageWidget(m_pages);
-    m_accountProcPage = new UserPageWidget(m_pages);
+    // user 页改为首次点击 user tab 时懒创建（ensureUserPage），
+    // 避免其构造链（AccountsWidget -> AccountsInfoModel）里的
+    // accounts/login1 DBus 进入启动路径。
 
     m_pages->setContentsMargins(0, 0, 0, 0);
     m_pages->addWidget(m_procPage);
     m_pages->addWidget(m_svcPage);
-    m_pages->addWidget(m_accountProcPage);
     m_tbShadow->raise();
 
     installEventFilter(this);
@@ -216,6 +226,7 @@ void MainWindow::initConnections()
     connect(m_toolbar, &Toolbar::accountProcTabButtonClicked, this, [=]() {
         PERF_PRINT_BEGIN("POINT-05", QString("switch(%1->%2)").arg(DApplication::translate("Title.Bar.Switch", "Users")).arg(DApplication::translate("Title.Bar.Switch", "Services")));
         m_toolbar->clearSearchText();
+        ensureUserPage();
         m_pages->setCurrentWidget(m_accountProcPage);
         m_accountProcPage->onUserChanged();
         m_tbShadow->raise();

--- a/deepin-system-monitor-main/gui/main_window.h
+++ b/deepin-system-monitor-main/gui/main_window.h
@@ -127,6 +127,12 @@ private:
     ProcessPageWidget *m_procPage = nullptr;
     SystemServicePageWidget *m_svcPage = nullptr;
     UserPageWidget *m_accountProcPage = nullptr;
+
+    /**
+     * @brief 首次点击 user tab 时懒创建 user 页，避免 accounts/login1 DBus 进入启动路径
+     * @return user 页（调用后永不为 null）
+     */
+    UserPageWidget *ensureUserPage();
     bool m_initLoad = false;
     DShadowLine *m_tbShadow  = nullptr;
     QWidget *m_focusedWidget = nullptr;

--- a/deepin-system-monitor-main/gui/toolbar.cpp
+++ b/deepin-system-monitor-main/gui/toolbar.cpp
@@ -73,9 +73,18 @@ Toolbar::Toolbar(QWidget *parent)
     m_accountProcBtn->installEventFilter(this);
 
     // emit button clicked signal when process or service tab button toggled
-    connect(m_procBtn, &DButtonBoxButton::toggled, this, [ = ](bool) { Q_EMIT procTabButtonClicked(); });
-    connect(m_svcBtn, &DButtonBoxButton::toggled, this, [ = ](bool) { Q_EMIT serviceTabButtonClicked(); });
-    connect(m_accountProcBtn, &DButtonBoxButton::toggled, this, [ = ](bool) { Q_EMIT accountProcTabButtonClicked(); });
+    connect(m_procBtn, &DButtonBoxButton::toggled, this, [ = ](bool checked) {
+        if (checked)
+            Q_EMIT procTabButtonClicked();
+    });
+    connect(m_svcBtn, &DButtonBoxButton::toggled, this, [ = ](bool checked) {
+        if (checked)
+            Q_EMIT serviceTabButtonClicked();
+    });
+    connect(m_accountProcBtn, &DButtonBoxButton::toggled, this, [ = ](bool checked) {
+        if (checked)
+            Q_EMIT accountProcTabButtonClicked();
+    });
     // search text editor instance
     searchEdit = new DSearchEdit(this);
     // set the search edit text max length

--- a/tests/deepin-system-monitor-main/gui/ut_toolbar.cpp
+++ b/tests/deepin-system-monitor-main/gui/ut_toolbar.cpp
@@ -116,6 +116,30 @@ TEST_F(UT_Toolbar, test_setProcessButtonChecked_01)
     m_tester->setProcessButtonChecked(true);
 }
 
+TEST_F(UT_Toolbar, test_tab_uncheck_does_not_emit_clicked_signal)
+{
+    auto buttons = m_tester->findChildren<DButtonBoxButton *>();
+    ASSERT_GE(buttons.size(), 2);
+
+    DButtonBoxButton *checkedButton = nullptr;
+    DButtonBoxButton *uncheckedButton = nullptr;
+    for (auto *button : buttons) {
+        if (button->isChecked()) {
+            checkedButton = button;
+        } else if (!uncheckedButton) {
+            uncheckedButton = button;
+        }
+    }
+
+    ASSERT_NE(checkedButton, nullptr);
+    ASSERT_NE(uncheckedButton, nullptr);
+
+    QSignalSpy processSpy(m_tester, &Toolbar::procTabButtonClicked);
+    uncheckedButton->setChecked(true);
+
+    EXPECT_EQ(processSpy.count(), 0);
+}
+
 TEST_F(UT_Toolbar, test_focusInput_01)
 {
     m_tester->focusInput();
@@ -136,4 +160,3 @@ TEST_F(UT_Toolbar, test_clearSearchText_01)
 {
     m_tester->clearSearchText();
 }
-


### PR DESCRIPTION
Delay user page creation until the user tab is selected.

将用户页构建推迟到首次点击用户页签时执行。

Emit toolbar tab signals only for checked tab buttons.

仅在页签按钮变为选中状态时发送 toolbar 切换信号。

Log: 延迟初始化用户页并避免页签取消选中触发加载

Task: https://pms.uniontech.com/task-view-390703.html

Influence: 减少首屏启动阶段 accounts/login1 相关初始化，并避免重复触发懒加载。

## Summary by Sourcery

Defer construction of the user page until the user tab is first selected and restrict toolbar tab signals to actual tab activation to reduce startup work and avoid redundant lazy-loading triggers.

Bug Fixes:
- Prevent toolbar tab uncheck operations from emitting tab-clicked signals that could redundantly trigger user page lazy-loading.

Enhancements:
- Introduce lazy initialization of the user page via an ensureUserPage helper, avoiding accounts/login1 DBus work during initial startup.

Tests:
- Add a toolbar test ensuring that unchecking a tab does not emit the corresponding clicked signal.