### PR TITLE
fix(system-server): harden systemd service name validation

### DIFF
--- a/deepin-system-monitor-system-server/src/service_name_validator.h
+++ b/deepin-system-monitor-system-server/src/service_name_validator.h
@@ -8,41 +8,119 @@
 #define SERVICE_NAME_VALIDATOR_H
 
 #include <QByteArray>
-#include <QRegularExpression>
+#include <QList>
 #include <QString>
-#include <QStringList>
 #include <climits>      // SHRT_MAX
+
+namespace ServiceNameValidatorPrivate {
+
+inline bool isHexDigit(ushort ch)
+{
+    return (ch >= '0' && ch <= '9')
+            || (ch >= 'a' && ch <= 'f')
+            || (ch >= 'A' && ch <= 'F');
+}
+
+inline ushort hexValue(ushort ch)
+{
+    if (ch >= '0' && ch <= '9') {
+        return ch - '0';
+    }
+    if (ch >= 'a' && ch <= 'f') {
+        return ch - 'a' + 10;
+    }
+    return ch - 'A' + 10;
+}
+
+inline bool isAllowedUnitNameLiteral(ushort ch)
+{
+    if (ch >= '0' && ch <= '9') {
+        return true;
+    }
+    if (ch >= 'A' && ch <= 'Z') {
+        return true;
+    }
+    if (ch >= 'a' && ch <= 'z') {
+        return true;
+    }
+
+    switch (ch) {
+    case '_':
+    case ':':
+    case '.':
+    case '-':
+    case '@':
+        return true;
+    default:
+        return false;
+    }
+}
+
+inline bool isFieldSeparator(char ch)
+{
+    return ch == ' ' || ch == '\t' || ch == '\r' || ch == '\v' || ch == '\f';
+}
+
+} // namespace ServiceNameValidatorPrivate
 
 /**
  * @brief 校验传入的 systemctl 服务名是否合法。
  *
- * 采用白名单正则锚定整串匹配，统一拦截空串、超长串、控制字符
- * （制表符/换行等）以及缺少 `.service` 后缀等非法输入，
- * 取代原先只拦截 ';' 与空格的黑名单 contains 判断。
- *
- * 字符集覆盖 systemd service 单元名合法字符（含模板单元 `getty@.service`
- * 及实例 `getty@tty1.service`），并强制 `.service` 后缀——与调用方
- * `ServiceManager` 传入的 systemd `Unit.Id`（完整单元名）语义一致。
+ * 该接口只接收 systemd service unit 的完整名称。这里按 unit name 的
+ * 参数语义做显式检查：拒绝空串、过长参数、路径分隔符、空白/控制字符
+ * 和未转义的特殊字符；仅允许 systemd 的 C 风格字节转义（如 \x20）。
  */
 inline bool isValidServiceName(const QString &name)
 {
     if (name.isEmpty() || name.size() > SHRT_MAX) {
         return false;
     }
-    // ^/$ 锚定整串，避免退化为子串匹配；\.service 强制后缀
-    static const QRegularExpression kServiceNameRe("^[A-Za-z0-9_.:@-]+\\.service$");
-    return kServiceNameRe.match(name).hasMatch();
+
+    static const QString kServiceSuffix(".service");
+    if (!name.endsWith(kServiceSuffix)) {
+        return false;
+    }
+
+    const QString prefix = name.left(name.size() - kServiceSuffix.size());
+    if (prefix.isEmpty() || prefix.startsWith('.')) {
+        return false;
+    }
+
+    for (int i = 0; i < name.size(); ++i) {
+        const ushort ch = name.at(i).unicode();
+        if (ch == '/') {
+            return false;
+        }
+
+        if (ch == '\\') {
+            if (i + 3 >= name.size()
+                    || name.at(i + 1).unicode() != 'x'
+                    || !ServiceNameValidatorPrivate::isHexDigit(name.at(i + 2).unicode())
+                    || !ServiceNameValidatorPrivate::isHexDigit(name.at(i + 3).unicode())) {
+                return false;
+            }
+            const ushort escaped = (ServiceNameValidatorPrivate::hexValue(name.at(i + 2).unicode()) << 4)
+                    | ServiceNameValidatorPrivate::hexValue(name.at(i + 3).unicode());
+            if (escaped == 0 || escaped == '/') {
+                return false;
+            }
+            i += 3;
+            continue;
+        }
+
+        if (!ServiceNameValidatorPrivate::isAllowedUnitNameLiteral(ch)) {
+            return false;
+        }
+    }
+
+    return true;
 }
 
 /**
  * @brief 在 `systemctl list-unit-files` 的输出中判断服务是否存在。
  *
- * 按行解析，逐行取第一列（完整服务名）与 @p name 做精确相等比较，
- * 取代原先对整段输出做字节级子串匹配的 contains 判断，避免把某真实
- * 服务名的子串（如传入 "dbus" 命中 "dbus.service"）误判为存在。
- *
- * 头行（"UNIT FILE …"）与尾行（"N unit files listed."）因第一列
- * 与目标名不等而自然被跳过。
+ * 按行读取 `list-unit-files` 输出，用空白分隔第一列后做精确比较。
+ * 这样既不受普通空格、tab 或多空格排版影响，也不会把子串误判为存在。
  */
 inline bool serviceExistsInList(const QString &name, const QByteArray &listOutput)
 {
@@ -53,10 +131,12 @@ inline bool serviceExistsInList(const QString &name, const QByteArray &listOutpu
         if (line.isEmpty()) {
             continue;
         }
-        // list-unit-files 输出以空白分隔；第一列为完整服务名。
-        // 仅当该列以 .service 结尾才视为候选，使头行（"UNIT FILE …"）
-        // 与尾行（"N unit files listed."）被天然跳过，函数可独立成立。
-        const QByteArray first = line.split(' ').first();
+        int fieldEnd = 0;
+        while (fieldEnd < line.size() && !ServiceNameValidatorPrivate::isFieldSeparator(line.at(fieldEnd))) {
+            ++fieldEnd;
+        }
+
+        const QByteArray first = line.left(fieldEnd);
         if (first.endsWith(".service") && first == target) {
             return true;
         }

--- a/tests/deepin-system-monitor-main/service/ut_service_name_validator.cpp
+++ b/tests/deepin-system-monitor-main/service/ut_service_name_validator.cpp
@@ -21,6 +21,10 @@ TEST_F(UT_ServiceNameValidator, ValidNames)
     EXPECT_TRUE(isValidServiceName("getty@.service"));
     EXPECT_TRUE(isValidServiceName("getty@tty1.service"));
     EXPECT_TRUE(isValidServiceName("a-b_c.d@e.service"));
+    EXPECT_TRUE(isValidServiceName("foo\\x20bar.service"));
+    EXPECT_TRUE(isValidServiceName("foo\\x3bbar.service"));
+    EXPECT_TRUE(isValidServiceName("foo\\x5cbar.service"));
+    EXPECT_TRUE(isValidServiceName("dbus.s\\x65rvice.service"));
 }
 
 TEST_F(UT_ServiceNameValidator, InvalidEmptyAndSuffix)
@@ -36,8 +40,18 @@ TEST_F(UT_ServiceNameValidator, InvalidControlChars)
     EXPECT_FALSE(isValidServiceName("db us.service"));  // 空格
     EXPECT_FALSE(isValidServiceName("db\tus.service")); // 制表符
     EXPECT_FALSE(isValidServiceName("db\nus.service"));  // 换行
+    EXPECT_FALSE(isValidServiceName("dbus.service\n"));  // 尾部换行
+    EXPECT_FALSE(isValidServiceName("dbus.service\r"));  // 尾部回车
     EXPECT_FALSE(isValidServiceName("db;us.service"));  // 分号
     EXPECT_FALSE(isValidServiceName("dbus;"));
+    EXPECT_FALSE(isValidServiceName("db/us.service"));   // 路径分隔符
+    EXPECT_FALSE(isValidServiceName("\\x2f.service"));   // 转义路径分隔符
+    EXPECT_FALSE(isValidServiceName("\\x2F.service"));   // 转义路径分隔符
+    EXPECT_FALSE(isValidServiceName("db\\x2fus.service"));
+    EXPECT_FALSE(isValidServiceName("db\\us.service"));  // 非 systemd 转义的反斜杠
+    EXPECT_FALSE(isValidServiceName("db\\\\us.service")); // 非 systemd 转义的反斜杠
+    EXPECT_FALSE(isValidServiceName("db\\xZZ.service")); // 非法 systemd 转义
+    EXPECT_FALSE(isValidServiceName("dbus.\\x73ervice")); // 后缀必须是字面 .service
 }
 
 TEST_F(UT_ServiceNameValidator, InvalidTooLong)
@@ -63,6 +77,15 @@ TEST_F(UT_ServiceNameValidator, ExistsExactMatch)
     EXPECT_TRUE(serviceExistsInList("dbus.service", kSampleList));
     EXPECT_TRUE(serviceExistsInList("cron.service", kSampleList));
     EXPECT_TRUE(serviceExistsInList("getty@.service", kSampleList));
+}
+
+TEST_F(UT_ServiceNameValidator, ExistsWithTabSeparatedColumns)
+{
+    const QByteArray list =
+        "UNIT FILE\tSTATE\tPRESET\n"
+        "dbus.service\tstatic\t-\n";
+
+    EXPECT_TRUE(serviceExistsInList("dbus.service", list));
 }
 
 TEST_F(UT_ServiceNameValidator, NotExistsSubstringOrSuffix)


### PR DESCRIPTION
Validate service unit names with explicit systemd escape handling.

按systemd转义语义显式校验服务单元名称。

Match unit-file list entries by the first whitespace-separated column.

按服务列表首列精确匹配单元文件名称。

Log: 加固systemctl服务名校验和存在性匹配

Task: https://pms.uniontech.com/task-view-391229.html

Influence: 提升后端DBus设置服务自启动时的输入校验准确性，避免误判。