### PR TITLE
fix: remove deepin prefix from Chinese translations in desktop file

### DIFF
--- a/deepin-system-monitor-main/translations/desktop/deepin-system-monitor.desktop
+++ b/deepin-system-monitor-main/translations/desktop/deepin-system-monitor.desktop
@@ -132,7 +132,7 @@ Name[tr]=Deepin Sistem İzleyici
 Name[ug]=deepin سىستېما نازارەتچىسى
 Name[uk]=Монітор системи Deepin
 Name[lo]=deepin ເຄື່ອງຕິດຕາມລະບົບ
-Name[zh_CN]=深度系统监视器
-Name[zh_HK]=deepin 系統監視器
-Name[zh_TW]=deepin 系統監視器
+Name[zh_CN]=系统监视器
+Name[zh_HK]=系統監視器
+Name[zh_TW]=系統監視器
 


### PR DESCRIPTION
Remove "深度"/"deepin"/"Deepin" prefix from Name/Comment fields in zh_CN, zh_HK, zh_TW translations.

去除 desktop 文件中 zh_CN/zh_HK/zh_TW 翻译的"深度"/"deepin"前缀。

Log: 去除desktop文件中文翻译中的深度/deepin前缀
PMS: BUG-369185
Influence: 自研应用 desktop 文件中文翻译不再包含"深度"/"deepin"品牌前缀。

## Summary by Sourcery

Bug Fixes:
- Correct Chinese desktop file translations by removing misleading "深度"/"deepin" brand prefixes from Name and Comment fields.