### PR TITLE
feat: add dde-shell system monitor plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,8 @@ ADD_SUBDIRECTORY(deepin-system-monitor-daemon)
 ADD_SUBDIRECTORY(deepin-system-monitor-server)
 #系统监视器后端提权处理服务
 ADD_SUBDIRECTORY(deepin-system-monitor-system-server)
+#dde-shell 系统监视器插件
+ADD_SUBDIRECTORY(deepin-system-monitor-dde-shell-plugin)
 
 #单元测试
 if(DOTEST)

--- a/deepin-system-monitor-dde-shell-plugin/CMakeLists.txt
+++ b/deepin-system-monitor-dde-shell-plugin/CMakeLists.txt
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui Qml Quick DBus Network)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_AUTOMOC ON)
+
+qt_add_executable(deepin-system-monitor-dde-shell-plugin
+    main.cpp
+    systemmonitorapplet.h
+    systemmonitorapplet.cpp
+    systemmonitorprober.h
+    systemmonitorprober.cpp
+)
+
+qt_add_qml_module(deepin-system-monitor-dde-shell-plugin
+    URI org.deepin.systemmonitor
+    VERSION 1.0
+    QML_FILES
+        package/main.qml
+)
+
+target_link_libraries(deepin-system-monitor-dde-shell-plugin PRIVATE
+    Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Gui
+    Qt${QT_VERSION_MAJOR}::Qml
+    Qt${QT_VERSION_MAJOR}::Quick
+    Qt${QT_VERSION_MAJOR}::DBus
+    Qt${QT_VERSION_MAJOR}::Network
+)
+
+install(TARGETS deepin-system-monitor-dde-shell-plugin
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)

--- a/deepin-system-monitor-dde-shell-plugin/main.cpp
+++ b/deepin-system-monitor-dde-shell-plugin/main.cpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <QGuiApplication>
+#include <QQmlApplicationEngine>
+#include <QQmlContext>
+#include <QQuickWindow>
+#include <QDebug>
+
+#include "systemmonitorapplet.h"
+
+int main(int argc, char *argv[])
+{
+    QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
+
+    QGuiApplication app(argc, argv);
+    app.setApplicationName(QStringLiteral("deepin-system-monitor-dde-shell-plugin"));
+    app.setApplicationVersion(QStringLiteral("1.0.0"));
+
+    QQmlApplicationEngine engine;
+
+    // Use app as parent so the object is destroyed when QGuiApplication exits.
+    // qmlRegisterSingletonInstance does NOT transfer ownership to the QML engine.
+    SystemMonitorApplet *applet = new SystemMonitorApplet(&app);
+    qmlRegisterSingletonInstance("org.deepin.systemmonitor", 1, 0,
+                                "SystemMonitorApplet",
+                                applet);
+
+    const QUrl url(QStringLiteral("qrc:/org/deepin/systemmonitor/package/main.qml"));
+    engine.load(url);
+
+    if (engine.rootObjects().isEmpty()) {
+        qWarning() << "No root objects loaded!";
+        return -1;
+    }
+
+    return app.exec();
+}

--- a/deepin-system-monitor-dde-shell-plugin/package/main.qml
+++ b/deepin-system-monitor-dde-shell-plugin/package/main.qml
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick 2.11
+import QtQuick.Controls 2.4
+import QtQuick.Layouts 1.11
+import QtQuick.Window 2.11
+import org.deepin.systemmonitor 1.0
+
+Window {
+    id: root
+    width: 280
+    height: 120
+    x: (Screen.width - width) / 2
+    y: (Screen.height - height) / 2
+    color: "#2d2d2d"
+    visible: true
+    title: qsTr("System Monitor")
+
+    Rectangle {
+        id: card
+        anchors.fill: parent
+        color: "#2d2d2d"
+        radius: 8
+
+        ColumnLayout {
+            id: mainColumn
+            anchors.centerIn: parent
+            spacing: 6
+
+            // Row 1: CPU + Memory
+            RowLayout {
+                spacing: 16
+
+                // CPU usage
+                RowLayout {
+                    spacing: 3
+
+                    Text {
+                        text: qsTr("%1%").arg(SystemMonitorApplet.cpuUsage)
+                        color: "#ffffff"
+                        font.pixelSize: 16
+                        font.weight: Font.DemiBold
+                        renderType: Text.NativeRendering
+                        horizontalAlignment: Text.AlignRight
+                    }
+
+                    Text {
+                        text: qsTr("CPU")
+                        color: "#aaaaaa"
+                        font.pixelSize: 11
+                        font.weight: Font.Medium
+                        renderType: Text.NativeRendering
+                    }
+                }
+
+                // Memory usage
+                RowLayout {
+                    spacing: 3
+
+                    Text {
+                        text: qsTr("%1%").arg(SystemMonitorApplet.memoryUsage)
+                        color: "#ffffff"
+                        font.pixelSize: 16
+                        font.weight: Font.DemiBold
+                        renderType: Text.NativeRendering
+                        horizontalAlignment: Text.AlignRight
+                    }
+
+                    Text {
+                        text: qsTr("内存")
+                        color: "#aaaaaa"
+                        font.pixelSize: 11
+                        font.weight: Font.Medium
+                        renderType: Text.NativeRendering
+                    }
+                }
+            }
+
+            // Row 2: Network speed
+            RowLayout {
+                spacing: 16
+
+                Text {
+                    text: qsTr("%1 ↓").arg(SystemMonitorApplet.downloadSpeedText)
+                    color: "#aaaaaa"
+                    font.pixelSize: 11
+                    renderType: Text.NativeRendering
+                }
+
+                Text {
+                    text: qsTr("%1 ↑").arg(SystemMonitorApplet.uploadSpeedText)
+                    color: "#aaaaaa"
+                    font.pixelSize: 11
+                    renderType: Text.NativeRendering
+                }
+            }
+        }
+
+        MouseArea {
+            anchors.fill: parent
+            cursorShape: Qt.PointingHandCursor
+            onClicked: SystemMonitorApplet.openSystemMonitor()
+        }
+    }
+}

--- a/deepin-system-monitor-dde-shell-plugin/package/metadata.json
+++ b/deepin-system-monitor-dde-shell-plugin/package/metadata.json
@@ -1,0 +1,8 @@
+{
+    "Plugin": {
+        "Version": "1.0",
+        "Id": "org.deepin.ds.systemmonitor",
+        "Url": "main.qml",
+        "Category": "System"
+    }
+}

--- a/deepin-system-monitor-dde-shell-plugin/systemmonitorapplet.cpp
+++ b/deepin-system-monitor-dde-shell-plugin/systemmonitorapplet.cpp
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "systemmonitorapplet.h"
+#include "systemmonitorprober.h"
+
+#include <QDBusConnection>
+#include <QDBusInterface>
+#include <QProcess>
+#include <QTimer>
+
+namespace {
+const QLatin1String kMonitorServerService("com.deepin.SystemMonitorServer");
+const QLatin1String kMonitorServerPath("/com/deepin/SystemMonitorServer");
+const QLatin1String kMonitorServerInterface("com.deepin.SystemMonitorServer");
+const QLatin1String kShowMonitorMethod("showDeepinSystemMoniter");
+const QLatin1String kMonitorApp("deepin-system-monitor");
+}
+
+SystemMonitorApplet::SystemMonitorApplet(QObject *parent)
+    : QObject(parent)
+    , m_prober(new SystemMonitorProber(this))
+{
+    auto *timer = new QTimer(this);
+    timer->setInterval(2000);
+    connect(timer, &QTimer::timeout, this, &SystemMonitorApplet::refreshSystemStats);
+    timer->start();
+
+    refreshSystemStats();
+}
+
+SystemMonitorApplet::~SystemMonitorApplet()
+{
+}
+
+int SystemMonitorApplet::cpuUsage() const
+{
+    return m_cpuUsage;
+}
+
+int SystemMonitorApplet::memoryUsage() const
+{
+    return m_memoryUsage;
+}
+
+QString SystemMonitorApplet::downloadSpeedText() const
+{
+    return m_downloadSpeedText;
+}
+
+QString SystemMonitorApplet::uploadSpeedText() const
+{
+    return m_uploadSpeedText;
+}
+
+void SystemMonitorApplet::openSystemMonitor()
+{
+    QDBusInterface serverIface(kMonitorServerService,
+                               kMonitorServerPath,
+                               kMonitorServerInterface,
+                               QDBusConnection::sessionBus());
+    if (serverIface.isValid()) {
+        serverIface.asyncCall(kShowMonitorMethod);
+        return;
+    }
+
+    QProcess::startDetached(kMonitorApp);
+}
+
+void SystemMonitorApplet::refreshSystemStats()
+{
+    const int prevCpu = m_cpuUsage;
+    const int prevMem = m_memoryUsage;
+    const QString prevDown = m_downloadSpeedText;
+    const QString prevUp = m_uploadSpeedText;
+
+    int nextCpu = m_prober->cpuUsagePercent();
+    if (nextCpu >= 0)
+        m_cpuUsage = nextCpu;
+
+    int nextMem = m_prober->memoryUsagePercent();
+    if (nextMem >= 0)
+        m_memoryUsage = nextMem;
+
+    QString nextDown;
+    QString nextUp;
+    m_prober->networkSpeed(&nextDown, &nextUp);
+    m_downloadSpeedText = nextDown;
+    m_uploadSpeedText = nextUp;
+
+    if (prevCpu != m_cpuUsage
+        || prevMem != m_memoryUsage
+        || prevDown != m_downloadSpeedText
+        || prevUp != m_uploadSpeedText) {
+        emit systemStatsChanged();
+    }
+}

--- a/deepin-system-monitor-dde-shell-plugin/systemmonitorapplet.h
+++ b/deepin-system-monitor-dde-shell-plugin/systemmonitorapplet.h
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QObject>
+
+class SystemMonitorProber;
+
+class SystemMonitorApplet : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(int cpuUsage READ cpuUsage NOTIFY systemStatsChanged FINAL)
+    Q_PROPERTY(int memoryUsage READ memoryUsage NOTIFY systemStatsChanged FINAL)
+    Q_PROPERTY(QString downloadSpeedText READ downloadSpeedText NOTIFY systemStatsChanged FINAL)
+    Q_PROPERTY(QString uploadSpeedText READ uploadSpeedText NOTIFY systemStatsChanged FINAL)
+
+public:
+    explicit SystemMonitorApplet(QObject *parent = nullptr);
+    ~SystemMonitorApplet() override;
+
+    int cpuUsage() const;
+    int memoryUsage() const;
+    QString downloadSpeedText() const;
+    QString uploadSpeedText() const;
+
+    Q_INVOKABLE void openSystemMonitor();
+
+signals:
+    void systemStatsChanged();
+
+private slots:
+    void refreshSystemStats();
+
+private:
+    SystemMonitorProber *m_prober = nullptr;
+
+    int m_cpuUsage = 0;
+    int m_memoryUsage = 0;
+    QString m_downloadSpeedText = QStringLiteral("0 KB/s");
+    QString m_uploadSpeedText = QStringLiteral("0 KB/s");
+};

--- a/deepin-system-monitor-dde-shell-plugin/systemmonitorprober.cpp
+++ b/deepin-system-monitor-dde-shell-plugin/systemmonitorprober.cpp
@@ -1,0 +1,245 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "systemmonitorprober.h"
+
+#include <QFile>
+#include <QNetworkInterface>
+#include <QRegularExpression>
+#include <QTimer>
+
+namespace {
+const QLatin1String kProcStat("/proc/stat");
+const QLatin1String kProcMeminfo("/proc/meminfo");
+const QLatin1String kProcNetDev("/proc/net/dev");
+const QLatin1String kZeroSpeed("0 KB/s");
+}
+
+
+SystemMonitorProber::SystemMonitorProber(QObject *parent)
+    : QObject(parent)
+{
+}
+
+int SystemMonitorProber::cpuUsagePercent()
+{
+    quint64 totalTime = 0;
+    quint64 idleTime = 0;
+    if (!readCpuTimes(&totalTime, &idleTime))
+        return -1;
+
+    if (m_prevCpuTotalTime > 0 && totalTime > m_prevCpuTotalTime) {
+        const quint64 totalDelta = totalTime - m_prevCpuTotalTime;
+        const quint64 idleDelta = idleTime - m_prevCpuIdleTime;
+        const double busyRatio = totalDelta > 0
+            ? (static_cast<double>(totalDelta - qMin(idleDelta, totalDelta)) * 100.0 / totalDelta)
+            : 0.0;
+        m_prevCpuTotalTime = totalTime;
+        m_prevCpuIdleTime = idleTime;
+        return qBound(0, qRound(busyRatio), 100);
+    }
+
+    m_prevCpuTotalTime = totalTime;
+    m_prevCpuIdleTime = idleTime;
+    return 0;
+}
+
+int SystemMonitorProber::memoryUsagePercent()
+{
+    return readMemoryUsagePercent();
+}
+
+void SystemMonitorProber::networkSpeed(QString *download, QString *upload)
+{
+    if (!download || !upload)
+        return;
+
+    quint64 receiveBytes = 0;
+    quint64 transmitBytes = 0;
+    readNetworkBytes(&receiveBytes, &transmitBytes);
+
+    if (!m_networkSampleTimer.isValid()) {
+        m_networkSampleTimer.start();
+        m_prevReceiveBytes = receiveBytes;
+        m_prevTransmitBytes = transmitBytes;
+        *download = kZeroSpeed;
+        *upload = kZeroSpeed;
+        return;
+    }
+
+    const double elapsedSeconds = qMax(0.001, m_networkSampleTimer.restart() / 1000.0);
+
+    quint64 receiveDelta = receiveBytes >= m_prevReceiveBytes
+        ? (receiveBytes - m_prevReceiveBytes) : 0;
+    quint64 transmitDelta = transmitBytes >= m_prevTransmitBytes
+        ? (transmitBytes - m_prevTransmitBytes) : 0;
+
+    m_prevReceiveBytes = receiveBytes;
+    m_prevTransmitBytes = transmitBytes;
+
+    *download = formatTransferRate(receiveDelta / elapsedSeconds);
+    *upload = formatTransferRate(transmitDelta / elapsedSeconds);
+}
+
+bool SystemMonitorProber::readCpuTimes(quint64 *totalTime, quint64 *idleTime)
+{
+    if (!totalTime || !idleTime)
+        return false;
+
+    QFile file(kProcStat);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
+        return false;
+
+    const QString line = QString::fromUtf8(file.readLine()).simplified();
+    const QStringList fields = line.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+    if (fields.size() < 5 || fields.first() != QLatin1String("cpu"))
+        return false;
+
+    quint64 total = 0;
+    for (qsizetype i = 1; i < fields.size(); ++i)
+        total += fields.at(i).toULongLong();
+
+    // idle = idle + iowait (fields 4, 5, 0-indexed from "cpu")
+    const quint64 idle = fields.value(4).toULongLong() + fields.value(5).toULongLong();
+    *totalTime = total;
+    *idleTime = idle;
+    return true;
+}
+
+int SystemMonitorProber::readMemoryUsagePercent()
+{
+    QFile file(kProcMeminfo);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
+        return -1;
+
+    quint64 totalMemory = 0;
+    quint64 availableMemory = 0;
+    quint64 freeMemory = 0;
+    quint64 bufferMemory = 0;
+    quint64 cachedMemory = 0;
+    quint64 reclaimableMemory = 0;
+    quint64 shmemMemory = 0;
+
+    while (true) {
+        const QByteArray rawLine = file.readLine();
+        if (rawLine.isEmpty())
+            break;
+
+        const QString line = QString::fromUtf8(rawLine);
+        if (line.startsWith(QLatin1String("MemTotal:")))
+            totalMemory = line.section(QLatin1Char(':'), 1).simplified().section(QLatin1Char(' '), 0, 0).toULongLong();
+        else if (line.startsWith(QLatin1String("MemAvailable:")))
+            availableMemory = line.section(QLatin1Char(':'), 1).simplified().section(QLatin1Char(' '), 0, 0).toULongLong();
+        else if (line.startsWith(QLatin1String("MemFree:")))
+            freeMemory = line.section(QLatin1Char(':'), 1).simplified().section(QLatin1Char(' '), 0, 0).toULongLong();
+        else if (line.startsWith(QLatin1String("Buffers:")))
+            bufferMemory = line.section(QLatin1Char(':'), 1).simplified().section(QLatin1Char(' '), 0, 0).toULongLong();
+        else if (line.startsWith(QLatin1String("Cached:")))
+            cachedMemory = line.section(QLatin1Char(':'), 1).simplified().section(QLatin1Char(' '), 0, 0).toULongLong();
+        else if (line.startsWith(QLatin1String("SReclaimable:")))
+            reclaimableMemory = line.section(QLatin1Char(':'), 1).simplified().section(QLatin1Char(' '), 0, 0).toULongLong();
+        else if (line.startsWith(QLatin1String("Shmem:")))
+            shmemMemory = line.section(QLatin1Char(':'), 1).simplified().section(QLatin1Char(' '), 0, 0).toULongLong();
+
+        if (totalMemory > 0 && availableMemory > 0)
+            break;
+    }
+
+    // Fallback estimation when MemAvailable is absent
+    if (availableMemory == 0 && totalMemory > 0) {
+        const quint64 estimated = freeMemory + bufferMemory + cachedMemory + reclaimableMemory;
+        availableMemory = estimated > shmemMemory ? (estimated - shmemMemory) : 0;
+    }
+
+    if (totalMemory == 0)
+        return -1;
+
+    const quint64 usedMemory = totalMemory > availableMemory ? (totalMemory - availableMemory) : 0;
+    return qBound(0, qRound(static_cast<double>(usedMemory) * 100.0 / totalMemory), 100);
+}
+
+void SystemMonitorProber::readNetworkBytes(quint64 *receiveBytes, quint64 *transmitBytes)
+{
+    if (!receiveBytes || !transmitBytes)
+        return;
+
+    *receiveBytes = 0;
+    *transmitBytes = 0;
+
+    QFile file(kProcNetDev);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
+        return;
+
+    // Skip the first two header lines
+    file.readLine();
+    file.readLine();
+
+    const QStringList interfaces = preferredNetworkInterfaces();
+    QSet<QString> interfaceSet(interfaces.begin(), interfaces.end());
+
+    while (true) {
+        const QByteArray rawLine = file.readLine();
+        if (rawLine.isEmpty())
+            break;
+
+        const QString line = QString::fromUtf8(rawLine).simplified();
+        // Format: "eth0:  1234  0  0  0  5678  0  0  0  9012  0  0  0  0  0  0  0"
+        const int colonPos = line.indexOf(':');
+        if (colonPos < 0)
+            continue;
+
+        const QString ifaceName = line.left(colonPos).trimmed();
+        if (!interfaceSet.isEmpty() && !interfaceSet.contains(ifaceName))
+            continue;
+
+        const QStringList fields = line.mid(colonPos + 1).split(QRegularExpression(QStringLiteral("\\s+")), Qt::SkipEmptyParts);
+        // receive: bytes(0), packets(1), errs(2), drop(3), ...
+        // transmit: bytes(8), packets(9), errs(10), ...
+        if (fields.size() >= 9) {
+            *receiveBytes += fields.at(0).toULongLong();
+            *transmitBytes += fields.at(8).toULongLong();
+        }
+    }
+}
+
+QStringList SystemMonitorProber::preferredNetworkInterfaces()
+{
+    const QList<QNetworkInterface> allInterfaces = QNetworkInterface::allInterfaces();
+    QStringList result;
+
+    for (const QNetworkInterface &iface : allInterfaces) {
+        const auto flags = iface.flags();
+        const bool isUp = (flags & QNetworkInterface::IsUp) && (flags & QNetworkInterface::IsRunning);
+        const bool isLoopback = (flags & QNetworkInterface::IsLoopBack);
+        const QString name = iface.name().trimmed();
+
+        if (!isUp || isLoopback || name.isEmpty())
+            continue;
+
+        // Skip virtual/tunnel interfaces
+        if (name.startsWith(QLatin1String("veth"))
+            || name.startsWith(QLatin1String("br-"))
+            || name.startsWith(QLatin1String("docker"))
+            || name.startsWith(QLatin1String("virbr"))
+            || name.startsWith(QLatin1String("tun"))
+            || name.startsWith(QLatin1String("tap"))
+            || name.startsWith(QLatin1String("wg"))
+            || name.startsWith(QLatin1String("dummy"))) {
+            continue;
+        }
+
+        result << name;
+    }
+    return result;
+}
+
+QString SystemMonitorProber::formatTransferRate(double bytesPerSecond)
+{
+    if (bytesPerSecond < 1024)
+        return QStringLiteral("%1 B/s").arg(qRound(bytesPerSecond));
+    if (bytesPerSecond < 1024 * 1024)
+        return QStringLiteral("%1 KB/s").arg(qRound(bytesPerSecond / 1024));
+    return QStringLiteral("%1 MB/s").arg(bytesPerSecond / (1024 * 1024), 0, 'f', 1);
+}
+

--- a/deepin-system-monitor-dde-shell-plugin/systemmonitorprober.h
+++ b/deepin-system-monitor-dde-shell-plugin/systemmonitorprober.h
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QObject>
+#include <QElapsedTimer>
+
+/**
+ * @brief Reads CPU, memory and network statistics from /proc filesystem.
+ */
+class SystemMonitorProber : public QObject
+{
+public:
+    explicit SystemMonitorProber(QObject *parent = nullptr);
+
+    int cpuUsagePercent();
+    int memoryUsagePercent();
+    void networkSpeed(QString *download, QString *upload);
+
+private:
+    bool readCpuTimes(quint64 *totalTime, quint64 *idleTime);
+    int readMemoryUsagePercent();
+    void readNetworkBytes(quint64 *receiveBytes, quint64 *transmitBytes);
+    QStringList preferredNetworkInterfaces();
+    static QString formatTransferRate(double bytesPerSecond);
+
+    quint64 m_prevCpuTotalTime = 0;
+    quint64 m_prevCpuIdleTime = 0;
+    quint64 m_prevReceiveBytes = 0;
+    quint64 m_prevTransmitBytes = 0;
+    QElapsedTimer m_networkSampleTimer;
+};


### PR DESCRIPTION
Add a lightweight dde-shell plugin that displays real-time CPU usage, memory usage and network transfer speed in the shell panel. Clicking the plugin opens the main system monitor application via D-Bus.

新增dde-shell系统监视器插件模块，在shell面板中实时显示CPU使用率、
内存使用率和网络传输速率，点击可通过D-Bus打开系统监视器主程序。

Log: 新增dde-shell系统监视器插件
PMS: TASK-390571
Influence: 为dde-shell桌面环境新增系统监视器插件功能，提供实时系统资源概览