### PR TITLE
fix(process): align GIO environment check in name resolution with ico…

### DIFF
--- a/deepin-system-monitor-main/process/process_name.cpp
+++ b/deepin-system-monitor-main/process/process_name.cpp
@@ -143,9 +143,11 @@ QString ProcessName::getDisplayName(Process *proc)
             return QString(joined);
         }
 
-        if (proc->environ().contains("GIO_LAUNCHED_DESKTOP_FILE") && proc->environ().contains("GIO_LAUNCHED_DESKTOP_FILE_PID") && proc->environ()["GIO_LAUNCHED_DESKTOP_FILE_PID"].toInt() == proc->pid()) {
+        QHash<QString, QString> allEnviron = proc->environ();
+        if (allEnviron.contains("GIO_LAUNCHED_DESKTOP_FILE") && ((allEnviron.contains("XDG_DATA_DIRS") && !allEnviron["XDG_DATA_DIRS"].isEmpty())
+                                                                 || (allEnviron.contains("GIO_LAUNCHED_DESKTOP_FILE_PID") && allEnviron["GIO_LAUNCHED_DESKTOP_FILE_PID"].toInt() == proc->pid()))) {
             // has gio info set in environment
-            auto desktopFile = proc->environ()["GIO_LAUNCHED_DESKTOP_FILE"];
+            auto desktopFile = allEnviron["GIO_LAUNCHED_DESKTOP_FILE"];
             auto entry = desktopEntryCache->entryWithDesktopFile(desktopFile);
             if (entry && !entry->displayName.isEmpty())
                 return entry->displayName;


### PR DESCRIPTION
…n logic

Add XDG_DATA_DIRS as alternative condition in getDisplayName() GIO check, matching the same loose matching already present in process_icon.cpp since commit 7becc0fe.

进程名解析中的GIO环境变量检查与图标逻辑对齐，增加XDG_DATA_DIRS宽匹配条件，
修复子进程因PID不匹配无法获取正确显示名的问题。

Log: 修复子进程显示名无法正确匹配desktop条目
PMS: https://pms.uniontech.com/bug-view-370397.html Influence: Chrome等应用的子进程(如chrome_crashpad_handler)现在能通过GIO环境变量 正确匹配desktop条目，显示为应用名而非原始进程名。