### PR TITLE
fix: add X-Deepin-Singleton flag to desktop file (#392841)

### DIFF
--- a/deepin-system-monitor-main/translations/desktop/deepin-system-monitor.desktop
+++ b/deepin-system-monitor-main/translations/desktop/deepin-system-monitor.desktop
@@ -7,6 +7,7 @@ Icon=deepin-system-monitor
 Name=deepin System Monitor
 Type=Application
 X-Deepin-Vendor=deepin
+X-Deepin-Singleton=true
 
 # Translations:
 # Do not manually modify!


### PR DESCRIPTION
Add X-Deepin-Singleton=true to desktop file to mark the application as a singleton app. This allows AM to identify singleton apps and inform Treeland to skip the splash screen for these apps.

Refs: https://pms.uniontech.com/task-view-392841.html

## Summary by Sourcery

Bug Fixes:
- Mark deepin-system-monitor as a singleton application via the X-Deepin-Singleton flag in its desktop file to avoid showing a splash screen.