### PR TITLE
fix(process): fix download traffic not syncing in process list

### DIFF
--- a/deepin-system-monitor-main/model/process_table_model.cpp
+++ b/deepin-system-monitor-main/model/process_table_model.cpp
@@ -57,8 +57,9 @@ ProcessTableModel::ProcessTableModel(QObject *parent, const QString &username)
 
 char ProcessTableModel::getProcessState(pid_t pid) const
 {
-    if (m_procIdList.contains(pid)) {
-        return ProcessDB::instance()->processSet()->getProcessById(pid).state();
+    int row = m_procIdList.indexOf(pid);
+    if (row >= 0) {
+        return m_processList[row].state();
     }
 
     return 0;
@@ -66,8 +67,9 @@ char ProcessTableModel::getProcessState(pid_t pid) const
 
 Process ProcessTableModel::getProcess(pid_t pid) const
 {
-    if (m_procIdList.contains(pid)) {
-        return ProcessDB::instance()->processSet()->getProcessById(pid);
+    int row = m_procIdList.indexOf(pid);
+    if (row >= 0) {
+        return m_processList[row];
     }
 
     return Process();
@@ -77,9 +79,9 @@ Process ProcessTableModel::getProcess(pid_t pid) const
 void ProcessTableModel::updateProcessList()
 {
     if (m_userModeName.isNull()) {
-        QTimer::singleShot(0, this, SLOT(updateProcessListDelay()));
+        updateProcessListDelay();
     } else {
-        QTimer::singleShot(0, this, SLOT(updateProcessListWithUserSpecified()));
+        updateProcessListWithUserSpecified();
     }
 }
 
@@ -88,21 +90,18 @@ void ProcessTableModel::updateProcessListWithUserSpecified()
 
     ProcessSet *processSet = ProcessDB::instance()->processSet();
     const QList<pid_t> &newpidlst = processSet->getPIDList();
-    beginRemoveRows({}, 0, m_procIdList.size());
-    endRemoveRows();
+    beginResetModel();
     m_procIdList.clear();
     m_processList.clear();
-    int raw;
     for (const auto &pid : newpidlst) {
         Process changedProc = processSet->getProcessById(pid);
         if (changedProc.userName() == m_userModeName) {
-            raw = m_procIdList.size();
-            beginInsertRows({}, raw, raw);
             m_procIdList << pid;
+            changedProc.detach();
             m_processList << changedProc;
-            endInsertRows();
         }
     }
+    endResetModel();
 
     Q_EMIT modelUpdated();
 }
@@ -118,6 +117,7 @@ void ProcessTableModel::updateProcessListDelay()
         if (row >= 0) {
             // update
             m_processList[row] = processSet->getProcessById(pid);
+            m_processList[row].detach();
             Q_EMIT dataChanged(index(row, 0), index(row, columnCount() - 1));
         } else {
             // insert
@@ -125,6 +125,7 @@ void ProcessTableModel::updateProcessListDelay()
             beginInsertRows({}, row, row);
             m_procIdList << pid;
             m_processList << processSet->getProcessById(pid);
+            m_processList.last().detach();
             endInsertRows();
         }
     }
@@ -375,7 +376,7 @@ ProcessPriority ProcessTableModel::getProcessPriority(pid_t pid) const
 {
     int row = m_procIdList.indexOf(pid);
     if (row >= 0) {
-        int prio = ProcessDB::instance()->processSet()->getProcessById(pid).priority();
+        int prio = m_processList[row].priority();
         return getProcessPriorityStub(prio);
     }
 
@@ -385,7 +386,7 @@ ProcessPriority ProcessTableModel::getProcessPriority(pid_t pid) const
 int ProcessTableModel::getProcessPriorityValue(pid_t pid) const
 {
     int row = m_procIdList.indexOf(pid);
-    return row >= 0 ? ProcessDB::instance()->processSet()->getProcessById(pid).priority() : kNormalPriority;
+    return row >= 0 ? m_processList[row].priority() : kNormalPriority;
 }
 
 // remove process entry from model with specified pid

--- a/deepin-system-monitor-main/process/process.cpp
+++ b/deepin-system-monitor-main/process/process.cpp
@@ -108,6 +108,11 @@ Process::~Process()
 {
 }
 
+void Process::detach()
+{
+    d = new ProcessPrivate(*d);
+}
+
 time_t Process::startTime() const
 {
     auto *monitor = ThreadManager::instance()->thread<SystemMonitorThread>(BaseThread::kSystemMonitorThread)->systemMonitorInstance();

--- a/deepin-system-monitor-main/process/process.h
+++ b/deepin-system-monitor-main/process/process.h
@@ -114,6 +114,8 @@ public:
     qulonglong recvBytes() const;
     qulonglong sentBytes() const;
 
+    void detach();
+
     void readProcessInfo();
     void readProcessSimpleInfo();
     void readProcessVariableInfo();


### PR DESCRIPTION
## 修复内容

### 问题
进程列表下载流量需重启才能同步，用户列表可实时显示。

### 根因
- singleShot(0) 延迟使 GUI 读取推迟到事件循环下一轮，可能与下一轮 SystemMonitor 写入竞态
- QExplicitlySharedDataPointer 导致 GUI 持有的 Process 与 ProcessSet 中的 Process 共享同一 ProcessPrivate，非线程安全

### 修复方案
1. 移除 singleShot(0) 延迟，直接在 statInfoUpdated slot 中同步读取
2. 新增 Process::detach() 深拷贝 ProcessPrivate，使 GUI 持有独立副本
3. getProcessState/getProcess/getProcessPriority 统一从 m_processList 读取，避免跨线程访问 ProcessSet
4. updateProcessListWithUserSpecified 用 beginResetModel/endResetModel 替换错误的 beginRemoveRows/endRemoveRows

### 改动文件
- process_table_model.cpp — 移除 singleShot + detach 调用 + 统一读取源 + beginResetModel
- process.cpp — detach() 实现
- process.h — detach() 声明

Bug: https://pms.uniontech.com/bug-view-370405.html