### PR TITLE
test: fix two failing unit tests in chart view and sys info

### DIFF
--- a/tests/deepin-system-monitor-main/gui/ut_chart_view_widget.cpp
+++ b/tests/deepin-system-monitor-main/gui/ut_chart_view_widget.cpp
@@ -15,6 +15,9 @@
 #include <QSignalSpy>
 #include <QResizeEvent>
 #include <QPainter>
+#include <DFontSizeManager>
+
+DWIDGET_USE_NAMESPACE
 
 /***************************************STUB begin*********************************************/
 
@@ -180,8 +183,9 @@ TEST_F(UT_ChartViewWidget, test_changeFont_01)
     font.setPointSizeF(10.0);
     m_tester->changeFont(font);
 
-    EXPECT_EQ(m_tester->m_textfont.bold(), font.bold());
-    EXPECT_EQ(m_tester->m_textfont.pointSizeF(), font.pointSizeF() -2);
+    // changeFont() ignores the input font and assigns T8 from DFontSizeManager
+    const QFont expected = DFontSizeManager::instance()->get(DFontSizeManager::T8);
+    EXPECT_EQ(m_tester->m_textfont, expected);
 }
 
 TEST_F(UT_ChartViewWidget, test_changeTheme_01)

--- a/tests/deepin-system-monitor-main/system/ut_sys_info.cpp
+++ b/tests/deepin-system-monitor-main/system/ut_sys_info.cpp
@@ -60,6 +60,8 @@ TEST_F(UT_SysInfo, test_readSockStat)
 
 TEST_F(UT_SysInfo, test_readSysInfo)
 {
+    // version is populated by readSysInfoStatic() (readSysInfo() only refreshes dynamic fields)
+    m_tester->readSysInfoStatic();
     EXPECT_FALSE(m_tester->d->version.isEmpty());
 }
 


### PR DESCRIPTION
Align UT_ChartViewWidget::test_changeFont_01 with the actual changeFont() implementation that uses DFontSizeManager T8, and call readSysInfoStatic() in UT_SysInfo::test_readSysInfo before asserting version is non-empty.

修复两个失败的单元测试：changeFont 用例改用 DFontSizeManager
T8 作为期望值以匹配实现，readSysInfo 用例补充调用
readSysInfoStatic() 后再断言 version 非空。

Log: 修复两个UT失败用例
Influence: 修复后1634个单元测试全部通过，消除UT套件误报失败。

## Summary by Sourcery

Adjust unit tests for chart font handling and system info version to match current implementations and eliminate false failures.

Tests:
- Update chart view font test to expect DFontSizeManager T8 output instead of the input font parameters.
- Ensure system info version test invokes readSysInfoStatic() before asserting the version is non-empty.