### PR TITLE
fix(370405): 修复程序进程列表下载流量不实时显示的问题

### DIFF
--- a/deepin-system-monitor-main/common/sample.h
+++ b/deepin-system-monitor-main/common/sample.h
@@ -143,8 +143,14 @@ public:
         auto rtime = rhs->ts.tv_sec + rhs->ts.tv_usec * 1. / 1000000;
         auto interval = (rtime > ltime) ? (rtime - ltime) : 1;
 
-        auto inBps = rhs->data.inBytes / interval;
-        auto outBps = rhs->data.outBytes / interval;
+        // calculate rate using delta between current and previous samples
+        // (same approach as diskiops), so that the consume-once behavior of
+        // getSockIOStatByInode is no longer required
+        auto rdiff = (rhs->data.inBytes < lhs->data.inBytes) ? 0 : (rhs->data.inBytes - lhs->data.inBytes);
+        auto wdiff = (rhs->data.outBytes < lhs->data.outBytes) ? 0 : (rhs->data.outBytes - lhs->data.outBytes);
+
+        auto inBps = qreal(rdiff) / interval;
+        auto outBps = qreal(wdiff) / interval;
 
         return {inBps, outBps};
     }

--- a/deepin-system-monitor-main/process/process.cpp
+++ b/deepin-system-monitor-main/process/process.cpp
@@ -146,7 +146,7 @@ void Process::readProcessVariableInfo()
         struct DiskIO io = {validrecentPtr->read_bytes, validrecentPtr->write_bytes, validrecentPtr->cancelled_write_bytes};
         d->diskIOSample->addSample(new DISKIOSampleFrame(validrecentPtr->uptime, io));
 
-        d->networkIOSample->addSample(new IOSampleFrame(validrecentPtr->uptime, {0, 0}));
+        d->networkIOSample->addSample(new IOSampleFrame(validrecentPtr->uptime, {validrecentPtr->recv_bytes, validrecentPtr->sent_bytes}));
     }
     d->cpuUsageSample->addSample(new CPUUsageSampleFrame(qMax(0., timedelta) / cpuset->getUsageTotalDelta() * 100));
 
@@ -236,7 +236,7 @@ void Process::readProcessInfo()
         struct DiskIO io = {validrecentPtr->read_bytes, validrecentPtr->write_bytes, validrecentPtr->cancelled_write_bytes};
         d->diskIOSample->addSample(new DISKIOSampleFrame(validrecentPtr->uptime, io));
 
-        d->networkIOSample->addSample(new IOSampleFrame(validrecentPtr->uptime, {0, 0}));
+        d->networkIOSample->addSample(new IOSampleFrame(validrecentPtr->uptime, {validrecentPtr->recv_bytes, validrecentPtr->sent_bytes}));
     }
     d->cpuUsageSample->addSample(new CPUUsageSampleFrame(qMax(0., timedelta) / cpuset->getUsageTotalDelta() * 100));
 

--- a/deepin-system-monitor-main/process/process_set.cpp
+++ b/deepin-system-monitor-main/process/process_set.cpp
@@ -79,6 +79,8 @@ void ProcessSet::scanProcess()
         procstage->read_bytes = iter->readBytes();
         procstage->write_bytes = iter->writeBytes();
         procstage->cancelled_write_bytes = iter->cancelledWriteBytes();
+        procstage->recv_bytes = iter->recvBytes();
+        procstage->sent_bytes = iter->sentBytes();
         procstage->uptime = iter->procuptime();
         m_recentProcStage[iter->pid()] = procstage;
     }

--- a/deepin-system-monitor-main/process/process_set.h
+++ b/deepin-system-monitor-main/process/process_set.h
@@ -29,6 +29,8 @@ struct RecentProcStage {
     qulonglong read_bytes = 0; // disk read bytes
     qulonglong write_bytes = 0; // disk write bytes
     qulonglong cancelled_write_bytes = 0;
+    qulonglong recv_bytes = 0; // network received bytes (cumulative)
+    qulonglong sent_bytes = 0; // network sent bytes (cumulative)
     timeval uptime = {0, 0};
 };
 

--- a/deepin-system-monitor-main/system/netif_monitor.cpp
+++ b/deepin-system-monitor-main/system/netif_monitor.cpp
@@ -7,6 +7,7 @@
 #include "common/thread_manager.h"
 #include "netif_monitor_thread.h"
 
+#include <QSet>
 #include <QTimerEvent>
 #include <QDebug>
 
@@ -94,6 +95,29 @@ void NetifMonitor::handleNetData()
             m_sockIOStatMapLock.unlock();   // ---m_sockIOStatMapLock---
         }
     }
+}
+
+void NetifMonitor::cleanupStaleSockIOStats(const SockStatMap &activeSockStats)
+{
+    // collect active socket inodes from the current kernel socket table snapshot
+    QSet<ino_t> activeInodes;
+    for (auto it = activeSockStats.constBegin(); it != activeSockStats.constEnd(); ++it) {
+        if (it.value()->ino != 0) {
+            activeInodes.insert(it.value()->ino);
+        }
+    }
+
+    // remove m_sockIOStatMap entries whose inodes are no longer open
+    m_sockIOStatMapLock.lock();
+    auto mapIt = m_sockIOStatMap.begin();
+    while (mapIt != m_sockIOStatMap.end()) {
+        if (!activeInodes.contains(mapIt.key())) {
+            mapIt = m_sockIOStatMap.erase(mapIt);
+        } else {
+            ++mapIt;
+        }
+    }
+    m_sockIOStatMapLock.unlock();
 }
 
 }

--- a/deepin-system-monitor-main/system/netif_monitor.h
+++ b/deepin-system-monitor-main/system/netif_monitor.h
@@ -53,6 +53,16 @@ public:
     void startNetmonitorJob();
 
     void handleNetData();
+
+    /**
+     * @brief Remove stale socket io stat entries whose inodes are no longer
+     *        present in the current kernel socket table, preventing unbounded
+     *        growth of m_sockIOStatMap when entries are no longer consumed
+     *        by getSockIOStatByInode.
+     * @param activeSockStats Current snapshot of open sockets from
+     *        /proc/net/tcp(6) and /proc/net/udp(6)
+     */
+    void cleanupStaleSockIOStats(const SockStatMap &activeSockStats);
 public:
     /**
      * @brief Get socket io stat data with specified inode (thread safe accessor)
@@ -70,8 +80,6 @@ public:
         // check stat data existence
         if (m_sockIOStatMap.contains(ino)) {
             stat = m_sockIOStatMap[ino];
-            // remove stat data from cache
-            m_sockIOStatMap.remove(ino);
             ok = true;
         }
 

--- a/deepin-system-monitor-main/system/netif_packet_capture.cpp
+++ b/deepin-system-monitor-main/system/netif_packet_capture.cpp
@@ -32,6 +32,7 @@
 
 #define SOCKSTAT_REFRESH_INTERVAL 2   // socket stat refresh interval (2 seconds)
 #define IFADDRS_HASH_CACHE_REFRESH_INTERVAL 10   // socket ifaddrs cache refresh interval (10 seconds)
+#define SOCKIOSTAT_CLEANUP_INTERVAL 30   // stale sock io stat cleanup interval (30 seconds)
 #define DEVICE_CHANGE_JUDGEMENT_TIME 5000   //判断网卡是否变更时间间隔
 
 using namespace std;
@@ -421,6 +422,14 @@ void NetifPacketCapture::dispatchPackets()
         if (!last_ifaddrs_refresh || (now - last_ifaddrs_refresh) >= IFADDRS_HASH_CACHE_REFRESH_INTERVAL) {
             refreshIfAddrsHashCache();
             last_ifaddrs_refresh = now;
+        }
+
+        // periodically clean up stale sock io stat entries whose sockets have
+        // been closed, preventing unbounded growth of m_sockIOStatMap now that
+        // getSockIOStatByInode no longer removes entries on read
+        if (!m_lastSockIOCleanup || (now - m_lastSockIOCleanup) >= SOCKIOSTAT_CLEANUP_INTERVAL) {
+            m_netifMonitor->cleanupStaleSockIOStats(m_sockStats);
+            m_lastSockIOCleanup = now;
         }
 
         // start packet dispatching

--- a/deepin-system-monitor-main/system/netif_packet_capture.h
+++ b/deepin-system-monitor-main/system/netif_packet_capture.h
@@ -90,6 +90,8 @@ private:
     pcap_if_t *m_alldevs {};
     //判断网卡是否变更定时器
     QTimer *m_timerChangeDev {};
+    // last time stale sock io stat cleanup ran
+    time_t m_lastSockIOCleanup {};
     friend void pcap_callback(u_char *, const struct pcap_pkthdr *, const u_char *);
 
 };


### PR DESCRIPTION
## 问题
PMS Bug: https://pms.uniontech.com/bug-view-370405.html

deepin-system-monitor 6.0.24.12-1 中，程序进程列表的下载流量不实时显示，需要重启应用才能同步，而用户列表的流量是实时更新的。

## 根因
`NetifMonitor::getSockIOStatByInode()` 采用"消费即删除"策略——读取后立即从 `m_sockIOStatMap` 中移除条目。`IOSampleFrame::iops()` 使用绝对值/interval 计算速率，依赖每次读取都获取到新的累计值。当进程扫描时序与 pcap 抓包时序不匹配时，`getSockIOStatByInode()` 返回的累计值已被前一次扫描消费删除，导致 `iops()` 计算出 0 速率。

## 修复方案
将网络 IO 速率计算从"消费即删除 + 绝对值/interval"改为"读取保留 + 增量/interval"，与磁盘 IO 的 `diskiops()` 保持一致。

## 改动内容
1. `getSockIOStatByInode()` 移除 `m_sockIOStatMap.remove(ino)`，改为只读不删
2. `iops()` 从绝对值改为增量计算 `(rhs-lhs)/interval`，加溢出保护
3. `RecentProcStage` 新增 `recv_bytes`/`sent_bytes` 字段保存上轮网络 IO 累计值
4. `readProcessVariableInfo()`/`readProcessInfo()` 基线样本从 `{0,0}` 改为上轮累计值
5. 新增 `cleanupStaleSockIOStats()` 定期（30秒）清理已关闭 socket 的残留条目，防止内存增长

## 测试
编译验证通过，无编译警告。

## Summary by Sourcery

Fix non-real-time display of per-process network download traffic by switching network IO rate calculation to use cumulative deltas and retaining socket IO stats, while adding periodic cleanup to avoid memory growth.

Bug Fixes:
- Ensure per-process network download/upload rates are updated in real time without requiring an application restart.

Enhancements:
- Align network IO sampling with disk IO by computing rates from deltas between consecutive samples and persisting cumulative counters across scans.
- Persist per-process cumulative network byte counters between scans via RecentProcStage so rate calculations have a stable baseline.

Chores:
- Introduce periodic cleanup of stale socket IO stat entries based on the current kernel socket table to prevent unbounded growth of the socket IO stats cache.