### PR TITLE
chore: update cppcheck checkout to v7 for Node.js 24

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -14,10 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: export
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
       - uses: linuxdeepin/action-cppcheck@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
GitHub deprecated Node.js 20 on actions runners. Add allow-unsafe-pr-checkout for pull_request_target to fix fork PR checkout, matching deepin-camera #501 fix.

Log: 升级cppcheck CI的checkout到v7适配Node.js 24
Influence: cppcheck CI可正常在fork PR上运行

## Summary by Sourcery

CI:
- Switch cppcheck workflow to use actions/checkout v7 with unsafe PR checkout enabled for pull_request_target events.