### PR TITLE
fix: resolve CPU core usage rate mapping and drawTextMode lag issue

### DIFF
--- a/deepin-system-monitor-main/gui/cpu_detail_widget.cpp
+++ b/deepin-system-monitor-main/gui/cpu_detail_widget.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd
+// Copyright (C) 2019 ~ 2026 Uniontech Software Technology Co.,Ltd
 // SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -247,7 +247,7 @@ void CPUDetailGrapTableItem::drawTextMode(QPainter &painter)
     painter.drawRect(rect);
 
     painter.setPen(m_color);
-    painter.drawText(rect, Qt::AlignCenter, QString::number(m_cpuPercents.value(m_index) * 100, 'f', 1) + "%");
+    painter.drawText(rect, Qt::AlignCenter, QString::number(m_cpuPercents.value(0) * 100, 'f', 1) + "%");
 }
 
 void CPUDetailGrapTableItem::drawSingleCoreMode(QPainter &painter)

--- a/deepin-system-monitor-main/model/cpu_info_model.cpp
+++ b/deepin-system-monitor-main/model/cpu_info_model.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd
+// Copyright (C) 2019 ~ 2026 Uniontech Software Technology Co.,Ltd
 // SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -13,6 +13,13 @@
 #include "ddlog.h"
 
 #include <QApplication>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#include <QRegExp>
+#else
+#include <QRegularExpression>
+#endif
+
+#include <algorithm>
 
 using namespace DDLog;
 
@@ -101,8 +108,32 @@ QList<qreal> CPUInfoModel::cpuPercentList() const
 {
     qCDebug(app) << "CPUInfoModel::cpuPercentList()";
     QList<qreal> percentList;
-    const auto &usageSampleList = m_singleUsageSample.values();
-    for (const auto &sample : usageSampleList) {
+
+    // m_singleUsageSample is keyed by "cpuN"; QMap orders keys by byte-wise
+    // lexicographic order, so with 10+ cores "cpu10" sorts before "cpu2",
+    // mismatching the numeric order used by top / /proc/stat. Sort by N
+    // numerically so the returned index aligns with the CPU number.
+    QList<QByteArray> names = m_singleUsageSample.keys();
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    // Qt5: QRegExp is deprecated but available; use indexIn + cap to extract digits
+    static QRegExp re(R"(\d+)");
+    std::sort(names.begin(), names.end(), [](const QByteArray &a, const QByteArray &b) {
+        re.indexIn(QString::fromLatin1(a));
+        int na = re.cap(0).toInt();
+        re.indexIn(QString::fromLatin1(b));
+        int nb = re.cap(0).toInt();
+        return na < nb;
+    });
+#else
+    // Qt6: QRegularExpression, match + captured
+    static const QRegularExpression re(R"(\d+)");
+    std::sort(names.begin(), names.end(), [](const QByteArray &a, const QByteArray &b) {
+        return re.match(QString::fromLatin1(a)).captured(0).toInt()
+             < re.match(QString::fromLatin1(b)).captured(0).toInt();
+    });
+#endif
+    for (const auto &name : names) {
+        const auto &sample = m_singleUsageSample.value(name);
         const auto &pair = sample->recentSamplePair();
         percentList << CPUUsageSampleFrame::cpupc(pair.first, pair.second);
     }


### PR DESCRIPTION
- Fix cpuPercentList() lexicographical sorting using regex to match numeric core order
- Change drawTextMode to use m_cpuPercents.value(0) for latest sample value to avoid lag

Log: resolve CPU core usage rate mapping and drawTextMode lag issue
PMS: BUG-372011
Influence: 修复多核CPU使用率显示不正确及滞后问题，确保网格视图核心使用率与htop一致。

## Summary by Sourcery

Ensure multi-core CPU usage display uses correct core ordering and up-to-date samples to match system monitoring tools and remove lag in the text view.

Bug Fixes:
- Fix CPU core usage list ordering so per-core usage aligns numerically with core IDs rather than lexicographic key order.
- Update CPU detail text mode to show the latest usage sample instead of a delayed per-core index value to remove display lag.

Enhancements:
- Add Qt5/Qt6-compatible numeric core ID extraction to support correct CPU core sorting across Qt versions.