### PR TITLE
chore: update version to 6.5.46

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-system-monitor (6.5.46) unstable; urgency=medium
+
+  * chore: update version to 6.5.46
+
+ -- re2zero <yangwu@uniontech.com>  Thu, 30 Jul 2026 14:06:30 +0800
+
 deepin-system-monitor (6.5.45) unstable; urgency=medium
 
   * fix(test): disable unstable unit tests causing ASan crashes


### PR DESCRIPTION
- bump version to 6.5.46

Log : bump version to 6.5.46

## Summary by Sourcery

Build:
- Bump Debian package version and changelog entry to 6.5.46.