### PR TITLE
fix(process): control center not shown in app list (PMS 247165)

### DIFF
--- a/deepin-system-monitor-main/process/desktop_entry_cache.cpp
+++ b/deepin-system-monitor-main/process/desktop_entry_cache.cpp
@@ -48,15 +48,17 @@ void DesktopEntryCache::updateCache()
 {
     m_cache.clear();
 
+    // Always scan the default desktop entry path first (lowest priority)
+    auto defaultFileInfoList = QDir(DESKTOP_ENTRY_PATH).entryInfoList(QDir::Files);
+    for (auto &fileInfo : defaultFileInfoList) {
+        entryWithDesktopFile(fileInfo.filePath());
+    }
+
+    // Also scan XDG_DATA_DIRS if set (higher priority, overrides defaults)
     QString xdgDataDirPath(getenv("XDG_DATA_DIRS"));
-    if (xdgDataDirPath.isEmpty()) {
-        auto fileInfoList = QDir(DESKTOP_ENTRY_PATH).entryInfoList(QDir::Files);
-        for (auto &fileInfo : fileInfoList) {
-            entryWithDesktopFile(fileInfo.filePath());
-        }
-    } else {
+    if (!xdgDataDirPath.isEmpty()) {
         QStringList xdgDataDirPaths = xdgDataDirPath.split(":", QString::SkipEmptyParts);
-        for (auto path : xdgDataDirPaths) {
+        for (auto &path : xdgDataDirPaths) {
             auto fileInfoList = QDir(path.trimmed() + "/applications").entryInfoList(QDir::Files);
             for (auto &fileInfo : fileInfoList) {
                 entryWithDesktopFile(fileInfo.filePath());

--- a/deepin-system-monitor-main/process/process.cpp
+++ b/deepin-system-monitor-main/process/process.cpp
@@ -174,6 +174,11 @@ void Process::readProcessVariableInfo()
     struct IOPS netiops = IOSampleFrame::iops(netpair.first, netpair.second);
     d->networkBandwidthSample->addSample(new IOPSSampleFrame(netiops));
 
+    // Refresh icon (re-populates desktop entry cache cleared each round) and
+    // recompute appType so processes initially misclassified can be corrected.
+    d->proc_icon.refreashProcessIcon(this);
+    refreshAppType();
+
     d->valid = d->valid && ok;
 }
 
@@ -190,17 +195,7 @@ readEnviron();
     d->proc_name.refreashProcessName(this);
     d->proc_icon.refreashProcessIcon(this);
 
-    d->apptype = kNoFilter;
-    const QVariant &euid = ProcessDB::instance()->processEuid();
-    WMWindowList *wmwindowList = ProcessDB::instance()->windowList();
-
-    if (euid == d->uid && (wmwindowList->isGuiApp(d->pid)
-                           || wmwindowList->isTrayApp(d->pid)
-                           || wmwindowList->isDesktopEntryApp(d->pid))) {
-        d->apptype = kFilterApps;
-    } else if (euid == d->uid) {
-        d->apptype = kFilterCurrentUser;
-    }
+    refreshAppType();
 
     d->valid = d->valid && ok;
 }
@@ -247,17 +242,7 @@ void Process::readProcessInfo()
     struct IOPS iops = DISKIOSampleFrame::diskiops(pair.first, pair.second);
     d->diskIOSpeedSample->addSample(new IOPSSampleFrame(iops));
 
-    d->apptype = kNoFilter;
-    const QVariant &euid = ProcessDB::instance()->processEuid();
-    WMWindowList *wmwindowList = ProcessDB::instance()->windowList();
-
-    if (euid == d->uid && (wmwindowList->isGuiApp(d->pid)
-                           || wmwindowList->isTrayApp(d->pid)
-                           || wmwindowList->isDesktopEntryApp(d->pid))) {
-        d->apptype = kFilterApps;
-    } else if (euid == d->uid) {
-        d->apptype = kFilterCurrentUser;
-    }
+    refreshAppType();
 
     qulonglong sum_recv = 0;
     qulonglong sum_send = 0;
@@ -866,6 +851,21 @@ int Process::appType() const
 void Process::setAppType(int type)
 {
     d->apptype = type;
+}
+
+void Process::refreshAppType()
+{
+    d->apptype = kNoFilter;
+    const QVariant &euid = ProcessDB::instance()->processEuid();
+    WMWindowList *wmwindowList = ProcessDB::instance()->windowList();
+
+    if (euid == d->uid && (wmwindowList->isGuiApp(d->pid)
+                           || wmwindowList->isTrayApp(d->pid)
+                           || wmwindowList->isDesktopEntryApp(d->pid))) {
+        d->apptype = kFilterApps;
+    } else if (euid == d->uid) {
+        d->apptype = kFilterCurrentUser;
+    }
 }
 
 } // namespace process

--- a/deepin-system-monitor-main/process/process.h
+++ b/deepin-system-monitor-main/process/process.h
@@ -117,6 +117,7 @@ public:
     void readProcessInfo();
     void readProcessSimpleInfo();
     void readProcessVariableInfo();
+    void refreshAppType();
 
 private:
     /**

--- a/deepin-system-monitor-main/process/process_set.cpp
+++ b/deepin-system-monitor-main/process/process_set.cpp
@@ -103,7 +103,7 @@ void ProcessSet::scanProcess()
     if(m_prePid != m_curPid) {
         for (const pid_t &pid : m_prePid) {
             if(!m_curPid.contains(pid)){
-                m_prePid.removeAt(pid);  //remove disappear process pid
+                m_prePid.removeOne(pid);  //remove disappear process pid
                 if(m_simpleSet.contains(pid))
                     m_simpleSet.remove(pid);
                 //for each pid,only one process reflected.So "removeOne()"func replied.
@@ -146,6 +146,16 @@ void ProcessSet::scanProcess()
         }
     }
 
+    // Rebuild the my-apps list every round based on the freshly recomputed appType
+    // (readProcessVariableInfo now refreshes appType), so that processes initially
+    // misclassified (e.g. desktop entry cache not yet loaded on first sight) are
+    // corrected instead of being stuck with their first-seen classification.
+    m_pidMyApps.clear();
+    for (auto it = m_set.constBegin(); it != m_set.constEnd(); ++it) {
+        if (it.value().appType() == kFilterApps && !wmwindowList->isTrayApp(it.key()))
+            m_pidMyApps << it.key();
+    }
+
     std::function<bool(pid_t ppid)> anyRootIsGuiProc;
     // find if any ancestor processes is gui application
     anyRootIsGuiProc = [&](pid_t ppid) -> bool {
@@ -173,6 +183,12 @@ void ProcessSet::scanProcess()
             // only if no ancestor process is gui app we keep this process
             if (m_pidCtoPMapping.contains(pid) &&
                     anyRootIsGuiProc(m_pidCtoPMapping[pid])) {
+
+                // Standalone desktop applications (identified via .desktop entry)
+                // should not be downgraded even if an ancestor is a GUI app.
+                if (wmwindowList->isDesktopEntryApp(pid)) {
+                    continue;
+                }
 
                 // when we start app with deepin-terminal, we should skip setting apptype as CurrentUser
                 const Process parentProc = getProcessById(m_pidCtoPMapping[pid]);


### PR DESCRIPTION
## Fix: control center not shown in app list (PMS 247165)

### Problem

On UOS 20 Professional 1070 (deepin-system-monitor 6.0.15), the control center process (`dde-control-center`) is not displayed in the system monitor's default "Applications" (应用) view.

### Root Cause

The control center process was not classified as `kFilterApps`, causing `ProcessSortFilterProxyModel` (default filter = `kFilterApps`) to hide it. The desktop-entry fallback path — which should compensate when GUI window recognition fails — was structurally fragile:

1. `appType` was computed only once on first sight (`readProcessSimpleInfo`) and never corrected in subsequent rounds (`readProcessVariableInfo` does not recompute it).
2. The desktop-entry pid cache (`m_desktopEntryCache`) is cleared every refresh cycle but only refilled for *new* processes, leaving existing desktop-entry apps unrecognised.
3. `.desktop` scanning skipped `/usr/share/applications` entirely when `XDG_DATA_DIRS` was set.
4. The ancestor-GUI downgrade logic could demote standalone desktop applications to `kFilterCurrentUser`.

### Changes

**`deepin-system-monitor-main/process/process.cpp`** (minor risk)
- Extracted the duplicated appType computation into a new `refreshAppType()` method.
- `readProcessVariableInfo()` now calls `refreashProcessIcon()` (to re-populate the per-round-cleared desktop-entry cache) and `refreshAppType()` (to recompute appType every round for all processes), so initially-misclassified processes can self-correct.
- `readProcessSimpleInfo()` and `readProcessInfo()` use `refreshAppType()` instead of inlining the same logic (refactor, no behaviour change).

**`deepin-system-monitor-main/process/process.h`** (safe)
- Declared `refreshAppType()`.

**`deepin-system-monitor-main/process/desktop_entry_cache.cpp`** (minor risk)
- `updateCache()` now always scans `/usr/share/applications` as a baseline, then scans `XDG_DATA_DIRS` entries with higher priority. Previously, when `XDG_DATA_DIRS` was set and did not include `/usr/share`, the default path was skipped entirely, causing `.desktop` files (like the control center's `org.deepin.dde.control-center.desktop`) to be missed.

**`deepin-system-monitor-main/process/process_set.cpp`** (minor risk)
- Rebuild `m_pidMyApps` every round from `m_set` based on the freshly recomputed `appType`, so processes initially misclassified are included in the apps list (and receive CPU/IO aggregation).
- Skip the ancestor-GUI-to-`kFilterCurrentUser` downgrade for processes that are desktop-entry apps, so standalone desktop applications are not wrongly demoted.
- Fixed `m_prePid.removeAt(pid)` → `m_prePid.removeOne(pid)`: `QList::removeAt` takes an index but a pid value was passed, which would remove the wrong element or go out of bounds.

### Change-Safety Assessment

| File | Risk | Rationale |
|---|---|---|
| `process.h` | safe | Added one method declaration only. |
| `process.cpp` | minor | Extracted existing logic into `refreshAppType()` (no new logic); added icon refresh + appType recompute to `readProcessVariableInfo()` which runs every round — icon cache makes this cheap on cache hits. |
| `desktop_entry_cache.cpp` | minor | `updateCache()` scans one additional directory; `entryWithDesktopFile` is idempotent so double-scanning is harmless. |
| `process_set.cpp` | minor | `m_pidMyApps` rebuild replaces incremental logic with a full rebuild (clear + iterate `m_set`); added one guard for desktop-entry apps in the downgrade loop; fixed `removeAt`→`removeOne` bug. |

No files outside the issue's evidence list were touched. All four files were reviewed and compile-verified against the locked baseline `4a213c3` (`release/eagle`).

### PMS

- PMS: https://pms.uniontech.com/bug-view-247165.html
- 领域: 专业版1070

## Summary by Sourcery

Ensure desktop applications like the control center are correctly classified and shown in the system monitor app list by making app type detection robust and fixing related cache and process set handling.

Bug Fixes:
- Fix control center and other desktop-entry applications not appearing in the Applications view due to incorrect app type classification.
- Correct removal of disappeared processes from the previous PID list by using value-based removal instead of index-based removal.

Enhancements:
- Recompute process app type on every refresh and centralize the classification logic to allow processes to self-correct when more information becomes available.
- Rebuild the tracked "my apps" PID list each scan based on current app type and avoid downgrading standalone desktop-entry apps when an ancestor is a GUI process.
- Always scan the default desktop entry directory and then XDG_DATA_DIRS with higher priority so desktop-entry detection works reliably across environments.