### PR TITLE
fix: adapt search box width to window resize/split-screen

### DIFF
--- a/deepin-system-monitor-main/gui/toolbar.cpp
+++ b/deepin-system-monitor-main/gui/toolbar.cpp
@@ -15,6 +15,7 @@
 
 #include <QDebug>
 #include <QEvent>
+#include <QResizeEvent>
 #include <QHBoxLayout>
 #include <QKeyEvent>
 #include <QTimer>
@@ -162,6 +163,16 @@ bool Toolbar::eventFilter(QObject *obj, QEvent *event)
 
     // propogate other events to base handler
     return DWidget::eventFilter(obj, event);
+}
+
+void Toolbar::resizeEvent(QResizeEvent *event)
+{
+    DWidget::resizeEvent(event);
+
+    const int maxWidth = 360;
+    const int minWidth = 200;
+    int searchWidth = qBound(minWidth, width() / 3, maxWidth);
+    searchEdit->setFixedWidth(searchWidth);
 }
 
 // emit search signal only after timed out, and current search input's text same as cached one

--- a/deepin-system-monitor-main/gui/toolbar.h
+++ b/deepin-system-monitor-main/gui/toolbar.h
@@ -15,6 +15,7 @@ DWIDGET_USE_NAMESPACE
 
 class MainWindow;
 class QTimer;
+class QResizeEvent;
 class QAction;
 
 /**
@@ -109,6 +110,9 @@ Q_SIGNALS:
      * @brief User Procss tab button triggered signal
      */
     void accountProcTabButtonClicked();
+
+protected:
+    void resizeEvent(QResizeEvent *event) override;
 
 private:
     // Button group


### PR DESCRIPTION
## 修复说明

PMS #243527 — 【专业版1070】系统监视器 分屏时搜索框宽度未自适应

### 问题

`Toolbar::resizeEvent` 未重载，搜索框宽度被写死为 `setFixedWidth(360)`，分屏/窗口缩窄时搜索框宽度不跟随自适应。

### 方案

重载 `Toolbar::resizeEvent`，按工具栏宽度动态计算搜索框宽度，替代写死的 `setFixedWidth(360)`。

搜索框宽度 = 工具栏宽度 / 3，钳制在 [200, 360]：
- 窗口 ≥1080px 时维持 360px（与原行为一致）
- 分屏缩窄时按比例缩小（最低 200px）
- 居中布局（addStretch + AlignHCenter + addStretch）与 240px 按钮组不变

### 改动文件

- `deepin-system-monitor-main/gui/toolbar.h`：新增 `QResizeEvent` 前向声明 + `protected: void resizeEvent(QResizeEvent*) override;`
- `deepin-system-monitor-main/gui/toolbar.cpp`：新增 `#include <QResizeEvent>` + `Toolbar::resizeEvent` 实现

### 验证方式

正常窗口下搜索框 ≈360px 居中 → 拖窄窗口确认搜索框自适应缩小且居中不破 → 极窄时不低于 200px → 拉宽不超过 360px。

PMS: #243527

## Summary by Sourcery

Bug Fixes:
- Adapt the toolbar search box width during window resizing so it remains usable and centered in split-screen layouts.