### PR TITLE
fix: 分屏时搜索框宽度未自适应 (PMS-243527)

### DIFF
--- a/deepin-system-monitor-main/gui/toolbar.cpp
+++ b/deepin-system-monitor-main/gui/toolbar.cpp
@@ -37,7 +37,7 @@ Toolbar::Toolbar(QWidget *parent)
 
     // tab button group
     m_switchFuncTabBtnGrp = new CustomButtonBox(this);
-    m_switchFuncTabBtnGrp->setFixedWidth(240);
+    m_switchFuncTabBtnGrp->setMinimumWidth(240);
     // process tab button instance
     m_procBtn = new DButtonBoxButton(
         DApplication::translate("Title.Bar.Switch", "Processes"), m_switchFuncTabBtnGrp);
@@ -80,7 +80,8 @@ Toolbar::Toolbar(QWidget *parent)
     searchEdit = new DSearchEdit(this);
     // set the search edit text max length
     searchEdit->lineEdit()->setMaxLength(MAX_TEXT_LEN);
-    searchEdit->setFixedWidth(360);
+    searchEdit->setMinimumWidth(200);
+    searchEdit->setMaximumWidth(360);
     searchEdit->setPlaceHolder(DApplication::translate("Title.Bar.Search", "Search"));
 
     // add widgets into layout


### PR DESCRIPTION
## 修复 PMS-243527：分屏时搜索框宽度未自适应

### 问题
系统监视器在分屏（窗口缩窄）时，工具栏搜索框宽度未自适应，出现溢出/截断。

### 根因
`toolbar.cpp` 中两处 `setFixedWidth()` 调用同时锁定了控件的最小/最大宽度，Qt 布局系统无法在窗口缩窄时收缩控件：
- `toolbar.cpp:40` — `m_switchFuncTabBtnGrp->setFixedWidth(240)` 按钮组固定 240px
- `toolbar.cpp:83` — `searchEdit->setFixedWidth(360)` 搜索框固定 360px

### 修复方案
将 `setFixedWidth` 替换为弹性宽度策略，使控件在窗口缩窄时可自适应收缩：

| 位置 | 原代码 | 新代码 |
|------|--------|--------|
| toolbar.cpp:40 | `setFixedWidth(240)` | `setMinimumWidth(240)` |
| toolbar.cpp:83 | `setFixedWidth(360)` | `setMinimumWidth(200)` + `setMaximumWidth(360)` |

- 搜索框最大宽度仍为 360px，全屏时行为不变；缩窄时可收缩至 200px
- 按钮组改为最小宽度约束，不再锁定最大值

### 改动范围
- 文件：`deepin-system-monitor-main/gui/toolbar.cpp`
- 改动行数：3 行（2 处修改，+3 -2）

### 安全评估
低风险：仅修改控件宽度约束策略，不涉及业务逻辑、信号槽连接或布局结构变更。

Log: 搜索框宽度改为弹性策略，分屏缩窄时可自适应收缩
Bug: https://pms.uniontech.com/bug-view-243527.html

## Summary by Sourcery

Bug Fixes:
- Allow the system monitor toolbar search field and tab button group to adapt to narrower split-screen windows without overflow or truncation.