### PR TITLE
fix: 分屏窄窗口下搜索框及 CPU 详情文字自适应 (PMS-243527)

### DIFF
--- a/deepin-system-monitor-main/gui/base/base_detail_view_widget.cpp
+++ b/deepin-system-monitor-main/gui/base/base_detail_view_widget.cpp
@@ -122,6 +122,7 @@ QString BaseDetailViewWidget::title()
 void BaseDetailViewWidget::setDetail(const QString &text)
 {
     m_detailText = text;
+    setToolTip(text);
     update();
 }
 
@@ -181,8 +182,15 @@ void BaseDetailViewWidget::paintEvent(QPaintEvent *event)
     if (!m_detailText.isEmpty()) {
         painter.setFont(m_contentFont);
         painter.setPen(palette.color(DPalette::TextTips));
-        QRect detailRect(m_arrowButton->width() + titleRect.right() + 12, titleRect.y(), painter.fontMetrics().width(m_detailText), titleRect.height());
-        painter.drawText(detailRect, Qt::AlignLeft | Qt::AlignVCenter, m_detailText);
+        int detailX = m_arrowButton->width() + titleRect.right() + 12;
+        // 计算右侧控件的左边界，避免详细信息文字与切换/隐藏详情按钮重叠遮挡
+        int rightBoundary = m_switchButton->isVisible() ? m_switchButton->x() : m_detailButton->x();
+        int maxDetailWidth = rightBoundary - detailX - 6;
+        if (maxDetailWidth > 0) {
+            QString elidedText = painter.fontMetrics().elidedText(m_detailText, Qt::ElideRight, maxDetailWidth);
+            QRect detailRect(detailX, titleRect.y(), painter.fontMetrics().width(elidedText), titleRect.height());
+            painter.drawText(detailRect, Qt::AlignLeft | Qt::AlignVCenter, elidedText);
+        }
     }
 }
 

--- a/deepin-system-monitor-main/gui/toolbar.cpp
+++ b/deepin-system-monitor-main/gui/toolbar.cpp
@@ -37,7 +37,7 @@ Toolbar::Toolbar(QWidget *parent)
 
     // tab button group
     m_switchFuncTabBtnGrp = new CustomButtonBox(this);
-    m_switchFuncTabBtnGrp->setFixedWidth(240);
+    m_switchFuncTabBtnGrp->setMinimumWidth(240);
     // process tab button instance
     m_procBtn = new DButtonBoxButton(
         DApplication::translate("Title.Bar.Switch", "Processes"), m_switchFuncTabBtnGrp);
@@ -80,7 +80,8 @@ Toolbar::Toolbar(QWidget *parent)
     searchEdit = new DSearchEdit(this);
     // set the search edit text max length
     searchEdit->lineEdit()->setMaxLength(MAX_TEXT_LEN);
-    searchEdit->setFixedWidth(360);
+    searchEdit->setMinimumWidth(200);
+    searchEdit->setMaximumWidth(360);
     searchEdit->setPlaceHolder(DApplication::translate("Title.Bar.Search", "Search"));
 
     // add widgets into layout


### PR DESCRIPTION
## 问题

系统监视器在分屏或窄窗口下存在两处布局问题：

- 工具栏按钮组和搜索框使用固定宽度，窗口缩窄时搜索框可能溢出或截断。
- CPU 型号等详情文字按自然宽度完整绘制，可能与右侧切换按钮、隐藏详情按钮重叠。

## 修复方案

- 将工具栏按钮组改为最小宽度约束。
- 将搜索框宽度限制为 200px 至 360px，使其可随窗口宽度收缩。
- 根据右侧控件位置计算详情文字的可用宽度，超出时使用省略号显示。
- 为详情区域设置 Tooltip，鼠标悬停时仍可查看完整文字。

## 改动范围

| 文件 | 改动 |
| --- | --- |
| `deepin-system-monitor-main/gui/toolbar.cpp` | 调整按钮组和搜索框的弹性宽度约束 |
| `deepin-system-monitor-main/gui/base/base_detail_view_widget.cpp` | 限制详情文字绘制宽度并补充完整文本 Tooltip |

## 验证

- [x] `git diff --check`
- [x] 本地编译及分屏场景验证
- [x] 相对 `release/eagle` 仅包含一个提交和两个目标文件

## 关联

- Bug: https://pms.uniontech.com/bug-view-243527.html
- 包含并替代 #565 中的搜索框自适应改动。

## Summary by Sourcery

Improve narrow-window and split-screen layout behavior for toolbar search and CPU detail displays.

Bug Fixes:
- Prevent toolbar search and CPU detail text from overflowing or overlapping controls in split-screen and narrow-window layouts.

Enhancements:
- Make toolbar controls responsive by allowing the tab button group and search field to adapt within defined width limits.
- Ellipsize detail text based on available space while preserving access to the full value through tooltips.