### PR TITLE
fix(service): normalize service IDs before setting startup mode

### DIFF
--- a/deepin-system-monitor-main/service/service_manager.cpp
+++ b/deepin-system-monitor-main/service/service_manager.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -46,13 +46,15 @@ std::mutex ServiceManager::m_mutex;
 /**
    @brief 非开发者模式下，使用后端 DBus 服务设置 systemd 服务 \a serviceName 的启动模式
  */
-static bool setServiceEnable(const QString &servieName, bool enable, QString &errorString)
+bool ServiceManager::setServiceEnable(const QString &serviceName,
+                                      bool enable,
+                                      QString &errorString)
 {
     QDBusInterface interface("org.deepin.SystemMonitorSystemServer",
                              "/org/deepin/SystemMonitorSystemServer",
                              "org.deepin.SystemMonitorSystemServer",
                              QDBusConnection::systemBus());
-    QDBusReply<QString> retMsg = interface.call("setServiceEnable", servieName, enable);
+    QDBusReply<QString> retMsg = interface.call("setServiceEnable", serviceName, enable);
     errorString.clear();
     if (!retMsg.isValid()) {
         errorString = retMsg.error().message();
@@ -350,18 +352,19 @@ ErrorContext ServiceManager::setServiceStartupMode(const QString &id, bool autoS
     QProcess proc;
     proc.setProcessChannelMode(QProcess::MergedChannels);
     // {BIN_PKEXEC_PATH} {BIN_SYSTEMCTL_PATH} {enable/disable} {service}
-    QString action = autoStart ? "enable" : "disable";
+    const QString action = autoStart ? "enable" : "disable";
+    const QString serviceId = normalizeServiceId(id);
     bool useProcess = true;
     if (developerMode) {
-        proc.start(BIN_PKEXEC_PATH, { BIN_SYSTEMCTL_PATH, action, id });
+        proc.start(BIN_PKEXEC_PATH, { BIN_SYSTEMCTL_PATH, action, serviceId });
     } else {
         // Bug 241793 非开发者模式，使用后端DBus服务设置启动方式
 #if 0
-        proc.start(BIN_SYSTEMCTL_PATH, {action, id});
+        proc.start(BIN_SYSTEMCTL_PATH, {action, serviceId});
 #else
         useProcess = false;
         QString errorString;
-        bool dbusRet = setServiceEnable(id, autoStart, errorString);
+        bool dbusRet = setServiceEnable(serviceId, autoStart, errorString);
         if (!dbusRet) {
             errno = 0;
             ErrorContext errCtx {};
@@ -413,12 +416,11 @@ ErrorContext ServiceManager::setServiceStartupMode(const QString &id, bool autoS
         Systemd1ManagerInterface mgrIf(DBUS_SYSTEMD1_SERVICE,
                                        kSystemDObjectPath.path(),
                                        QDBusConnection::systemBus());
-        auto buf = normalizeServiceId(id, {});
-        auto re = mgrIf.GetUnit(buf);
+        auto re = mgrIf.GetUnit(serviceId);
         le = re.first;
         if (le) {
             if (le.getCode() == 3) {
-                auto o = Systemd1UnitInterface::normalizeUnitPath(buf);
+                auto o = Systemd1UnitInterface::normalizeUnitPath(serviceId);
                 updateServiceEntry(o.path());
             } else {
                 return le;

--- a/deepin-system-monitor-main/service/service_manager.h
+++ b/deepin-system-monitor-main/service/service_manager.h
@@ -92,6 +92,10 @@ public Q_SLOTS:
     ErrorContext setServiceStartupMode(const QString &id, bool autoStart);
 
 private:
+    static bool setServiceEnable(const QString &serviceName,
+                                 bool enable,
+                                 QString &errorString);
+
     explicit ServiceManager(QObject *parent = nullptr);
     ~ServiceManager();
 

--- a/tests/deepin-system-monitor-main/service/ut_service_manager.cpp
+++ b/tests/deepin-system-monitor-main/service/ut_service_manager.cpp
@@ -23,6 +23,14 @@
 
 /***************************************STUB begin*********************************************/
 
+static QString g_serviceName;
+
+bool stub_setServiceEnable(const QString &serviceName, bool, QString &errorString)
+{
+    g_serviceName = serviceName;
+    errorString = "stop after capturing service name";
+    return false;
+}
 
 /***************************************STUB end**********************************************/
 
@@ -75,8 +83,8 @@ TEST_F(UT_ServiceManager, test_updateServiceList_01)
 
 TEST_F(UT_ServiceManager, test_normalizeServiceID_01)
 {
-    m_tester->normalizeServiceId("id","param");
-    EXPECT_EQ(m_tester->normalizeServiceId("id").isEmpty(),false);
+    EXPECT_EQ(m_tester->normalizeServiceId("ssh"), QString("ssh.service"));
+    EXPECT_EQ(m_tester->normalizeServiceId("ssh.service"), QString("ssh.service"));
 }
 
 TEST_F(UT_ServiceManager, test_startService_01)
@@ -96,7 +104,16 @@ TEST_F(UT_ServiceManager, test_restartService_01)
 
 TEST_F(UT_ServiceManager, test_setServiceStartupMode_01)
 {
-    //m_tester->setServiceStartupMode("",false);
+    Stub stub;
+    stub.set(ADDR(ServiceManager, setServiceEnable), stub_setServiceEnable);
+
+    g_serviceName.clear();
+    m_tester->setServiceStartupMode("ssh", true);
+    EXPECT_EQ(g_serviceName, QString("ssh.service"));
+
+    g_serviceName.clear();
+    m_tester->setServiceStartupMode("ssh.service", false);
+    EXPECT_EQ(g_serviceName, QString("ssh.service"));
 }
 
 TEST_F(UT_ServiceManager, test_updateServiceEntry_01)


### PR DESCRIPTION
Normalize service IDs before DBus and pkexec startup mode operations.

在 DBus 和 pkexec 设置启动方式前统一补全 systemd 服务单元名称。

Log: 修复服务启动方式设置参数错误
Bug: https://pms.uniontech.com/bug-view-247287.html
Influence: 修复服务名称缺少 .service 后缀导致启动方式设置失败的问题。

## Summary by Sourcery

Ensure service startup-mode operations use complete systemd unit names.

Bug Fixes:
- Normalize service identifiers with the `.service` suffix before applying startup-mode changes through pkexec, DBus, or systemd interfaces.

Enhancements:
- Expose the DBus startup-mode helper as a ServiceManager method and reuse the normalized identifier across startup-mode operations.

Tests:
- Add coverage confirming service identifiers are normalized consistently for startup-mode operations.