### PR TITLE
fix(process): aggregate resources for split application processes

### DIFF
--- a/deepin-system-monitor-main/gui/process_table_view.cpp
+++ b/deepin-system-monitor-main/gui/process_table_view.cpp
@@ -365,7 +365,7 @@ void ProcessTableView::search(const QString &text)
 // switch process table view display mode
 void ProcessTableView::switchDisplayMode(FilterType type)
 {
-
+    m_model->setDisplayMode(type);
     m_proxyModel->setFilterType(type);
 }
 

--- a/deepin-system-monitor-main/model/process_table_model.cpp
+++ b/deepin-system-monitor-main/model/process_table_model.cpp
@@ -111,6 +111,7 @@ void ProcessTableModel::updateProcessListDelay()
 {
     ProcessSet *processSet = ProcessDB::instance()->processSet();
     const QList<pid_t> &newpidlst = processSet->getPIDList();
+    m_applicationResources = processSet->getApplicationResources();
     QList<pid_t> oldpidlst = m_procIdList;
 
     for (const auto &pid : newpidlst) {
@@ -229,9 +230,20 @@ QVariant ProcessTableModel::data(const QModelIndex &index, int role) const
     if (!proc.isValid())
         return {};
 
+    const int column = index.column();
+    const bool resourceColumn = column == kProcessCPUColumn
+            || column == kProcessMemoryColumn
+            || column == kProcessUploadColumn
+            || column == kProcessDownloadColumn;
+    ApplicationResource appResource;
+    const bool useAppResource = m_displayMode == kFilterApps && resourceColumn
+            && m_applicationResources.contains(proc.pid());
+    if (useAppResource)
+        appResource = m_applicationResources.value(proc.pid());
+
     if (role == Qt::DisplayRole || role == Qt::AccessibleTextRole) {
         QString name;
-        switch (index.column()) {
+        switch (column) {
         case kProcessNameColumn: {
             // prepended tag based on process state
             name = proc.displayName();
@@ -251,13 +263,13 @@ QVariant ProcessTableModel::data(const QModelIndex &index, int role) const
         }
         case kProcessCPUColumn:
             // formated cpu percent utilization
-            return QString("%1%").arg(proc.cpu(), 0, 'f', 1);
+            return QString("%1%").arg(useAppResource ? appResource.cpu : proc.cpu(), 0, 'f', 1);
         case kProcessUserColumn:
             // process's user name
             return proc.userName();
         case kProcessMemoryColumn:
             // formatted memory usage
-            return formatUnit_memory_disk(proc.memory(), KB);
+            return formatUnit_memory_disk(useAppResource ? appResource.memory : proc.memory(), KB);
         case kProcessShareMemoryColumn:
             // formatted memory usage
             return formatUnit_memory_disk(proc.sharememory(), KB);
@@ -266,10 +278,12 @@ QVariant ProcessTableModel::data(const QModelIndex &index, int role) const
             return formatUnit_memory_disk(proc.vtrmemory(), KB);
         case kProcessUploadColumn:
             // formatted upload speed text
-            return formatUnit_net(8 * proc.sentBps(), B, 1, true);
+            return formatUnit_net(8 * (useAppResource ? appResource.sentBps : proc.sentBps()),
+                                  B, 1, true);
         case kProcessDownloadColumn:
             // formated download speed text
-            return formatUnit_net(8 * proc.recvBps(), B, 1, true);
+            return formatUnit_net(8 * (useAppResource ? appResource.recvBps : proc.recvBps()),
+                                  B, 1, true);
         case kProcessDiskReadColumn:
             // formatted disk read speed text
             return formatUnit_memory_disk(proc.readBps(), B, 1, true);
@@ -292,7 +306,7 @@ QVariant ProcessTableModel::data(const QModelIndex &index, int role) const
             break;
         }
     } else if (role == Qt::DecorationRole) {
-        switch (index.column()) {
+        switch (column) {
         case kProcessNameColumn:
             // process icon
             return proc.icon();
@@ -300,22 +314,22 @@ QVariant ProcessTableModel::data(const QModelIndex &index, int role) const
             return {};
         }
     } else if (role == Qt::UserRole) {
-        // get process's raw data
-        switch (index.column()) {
+        // get numeric data used by sorting
+        switch (column) {
         case kProcessNameColumn:
             return proc.name();
         case kProcessMemoryColumn:
-            return proc.memory();
+            return useAppResource ? appResource.memory : proc.memory();
         case kProcessShareMemoryColumn:
             return proc.sharememory();
         case kProcessVTRMemoryColumn:
             return proc.vtrmemory();
         case kProcessCPUColumn:
-            return proc.cpu();
+            return useAppResource ? appResource.cpu : proc.cpu();
         case kProcessUploadColumn:
-            return proc.sentBps();
+            return useAppResource ? appResource.sentBps : proc.sentBps();
         case kProcessDownloadColumn:
-            return proc.recvBps();
+            return useAppResource ? appResource.recvBps : proc.recvBps();
         case kProcessPIDColumn:
             return proc.pid();
         case kProcessDiskReadColumn:
@@ -329,11 +343,11 @@ QVariant ProcessTableModel::data(const QModelIndex &index, int role) const
         }
     } else if (role == (Qt::UserRole + 1)) {
         // get process's extra data
-        switch (index.column()) {
+        switch (column) {
         case kProcessUploadColumn:
-            return proc.sentBps();
+            return useAppResource ? appResource.sentBps : proc.sentBps();
         case kProcessDownloadColumn:
-            return proc.recvBps();
+            return useAppResource ? appResource.recvBps : proc.recvBps();
         default:
             return {};
         }
@@ -342,7 +356,7 @@ QVariant ProcessTableModel::data(const QModelIndex &index, int role) const
         return QVariant(Qt::AlignLeft | Qt::AlignVCenter);
     } else if (role == Qt::UserRole + 2) {
         // text color role based on process's state
-        if (index.column() == kProcessNameColumn) {
+        if (column == kProcessNameColumn) {
             char state = proc.state();
             if (state == 'Z' || state == 'T') {
                 return QVariant(int(Dtk::Gui::DPalette::TextWarning));
@@ -426,6 +440,18 @@ void ProcessTableModel::setUserModeName(const QString &userName)
     if (userName != m_userModeName) {
         m_userModeName = userName;
         updateProcessListWithUserSpecified();
+    }
+}
+
+void ProcessTableModel::setDisplayMode(FilterType type)
+{
+    if (m_displayMode == type)
+        return;
+
+    m_displayMode = type;
+    if (!m_processList.isEmpty()) {
+        Q_EMIT dataChanged(index(0, kProcessCPUColumn),
+                           index(m_processList.size() - 1, kProcessDownloadColumn));
     }
 }
 

--- a/deepin-system-monitor-main/model/process_table_model.h
+++ b/deepin-system-monitor-main/model/process_table_model.h
@@ -141,7 +141,8 @@ public:
      * @return Process entry item
      */
     Process getProcess(pid_t pid) const;
-   void setUserModeName(const QString &userName);
+    void setUserModeName(const QString &userName);
+    void setDisplayMode(FilterType type);
     qreal getTotalCPUUsage();
     qreal getTotalMemoryUsage();
     qreal getTotalDownload();
@@ -182,8 +183,10 @@ private Q_SLOTS:
 private:
     QList<pid_t> m_procIdList; // pid list
     QList<Process> m_processList; // pid list
+    QMap<pid_t, ApplicationResource> m_applicationResources;
 
     QString m_userModeName {};
+    FilterType m_displayMode = kNoFilter;
 };
 
 #endif  // PROCESS_TABLE_MODEL_H

--- a/deepin-system-monitor-main/process/process_set.cpp
+++ b/deepin-system-monitor-main/process/process_set.cpp
@@ -10,7 +10,9 @@
 // #include "settings.h"
 
 #include <QDebug>
+#include <QSet>
 
+#include <algorithm>
 #include <errno.h>
 
 #define PROC_PATH "/proc"
@@ -30,6 +32,7 @@ ProcessSet::ProcessSet()
 
 ProcessSet::ProcessSet(const ProcessSet &other)
     : m_set(other.m_set)
+    , m_applicationResources(other.m_applicationResources)
     , m_recentProcStage(other.m_recentProcStage)
     , m_pidCtoPMapping(other.m_pidCtoPMapping)
     , m_pidPtoCMapping(other.m_pidPtoCMapping)
@@ -66,6 +69,152 @@ void ProcessSet::mergeSubProcCpu(pid_t ppid, qreal &cpu)
     cpu += proc.cpu();
 }
 
+void ProcessSet::mergeSubProcMemory(pid_t ppid, qulonglong &memory)
+{
+    auto it = m_pidPtoCMapping.find(ppid);
+    while (it != m_pidPtoCMapping.end() && it.key() == ppid) {
+        mergeSubProcMemory(it.value(), memory);
+        ++it;
+    }
+
+    memory += m_set[ppid].memory();
+}
+
+QMap<pid_t, QList<pid_t>> ProcessSet::collapseDesktopLaunchGroups(WMWindowList *windowList,
+                                                                  uid_t euid)
+{
+    using LaunchIdentity = QPair<QString, qlonglong>;
+
+    auto launchIdentity = [](const Process &proc, LaunchIdentity &identity) -> bool {
+        const QHash<QString, QString> environ = proc.environ();
+        const QString desktopFile = environ.value("GIO_LAUNCHED_DESKTOP_FILE").trimmed();
+        bool ok = false;
+        const qlonglong launchPid =
+                environ.value("GIO_LAUNCHED_DESKTOP_FILE_PID").toLongLong(&ok);
+        if (desktopFile.isEmpty() || !ok || launchPid <= 0)
+            return false;
+
+        identity = qMakePair(desktopFile, launchPid);
+        return true;
+    };
+
+    QMap<LaunchIdentity, QList<pid_t>> membersByLaunch;
+    for (auto it = m_set.cbegin(); it != m_set.cend(); ++it) {
+        if (it.value().uid() != euid)
+            continue;
+
+        LaunchIdentity identity;
+        if (launchIdentity(it.value(), identity)) {
+            // The desktop file and launcher PID identify one GIO launch while
+            // keeping separate launches of the same application independent.
+            membersByLaunch[identity].append(it.key());
+        }
+    }
+
+    QMap<pid_t, QList<pid_t>> groups;
+    for (auto groupIt = membersByLaunch.cbegin(); groupIt != membersByLaunch.cend(); ++groupIt) {
+        QSet<pid_t> memberPids;
+        QList<pid_t> pending = groupIt.value();
+        while (!pending.isEmpty()) {
+            const pid_t pid = pending.takeLast();
+            if (memberPids.contains(pid) || !m_set.contains(pid))
+                continue;
+
+            const Process &proc = m_set[pid];
+            if (proc.uid() != euid)
+                continue;
+
+            LaunchIdentity identity;
+            if (launchIdentity(proc, identity) && identity != groupIt.key())
+                continue;
+
+            memberPids.insert(pid);
+
+            auto childIt = m_pidPtoCMapping.find(pid);
+            while (childIt != m_pidPtoCMapping.end() && childIt.key() == pid) {
+                pending.append(childIt.value());
+                ++childIt;
+            }
+        }
+
+        QList<pid_t> members = memberPids.values();
+        std::sort(members.begin(), members.end());
+
+        int rootCount = 0;
+        QList<pid_t> appCandidates;
+        for (pid_t pid : members) {
+            if (!memberPids.contains(m_set[pid].ppid()))
+                ++rootCount;
+            if (m_set[pid].appType() == kFilterApps)
+                appCandidates.append(pid);
+        }
+
+        // Group re-parented trees, and also collapse duplicate application rows
+        // found inside one launch tree. A single application row in one tree is
+        // handled by the normal recursive aggregation path.
+        if (appCandidates.isEmpty() || (rootCount < 2 && appCandidates.size() < 2))
+            continue;
+
+        pid_t representativePid = -1;
+        int representativeScore = -1;
+
+        for (pid_t pid : appCandidates) {
+            int score = 0;
+            if (windowList->isGuiApp(pid))
+                score = 3;
+            else if (windowList->isDesktopEntryApp(pid))
+                score = 2;
+            else if (windowList->isTrayApp(pid))
+                score = 1;
+
+            if (score > representativeScore
+                    || (score == representativeScore
+                        && (representativePid < 0 || pid < representativePid))) {
+                representativePid = pid;
+                representativeScore = score;
+            }
+        }
+
+        if (representativePid < 0)
+            continue;
+
+        m_set[representativePid].setAppType(kFilterApps);
+        groups.insert(representativePid, members);
+        for (pid_t pid : appCandidates) {
+            if (pid == representativePid || m_set[pid].appType() != kFilterApps)
+                continue;
+
+            m_set[pid].setAppType(kFilterCurrentUser);
+            windowList->removeDesktopEntryApp(pid);
+        }
+    }
+
+    return groups;
+}
+
+void ProcessSet::aggregateProcessGroup(pid_t representativePid, const QList<pid_t> &memberPids)
+{
+    if (!m_set.contains(representativePid))
+        return;
+
+    ApplicationResource resource;
+    QSet<pid_t> visited;
+
+    for (pid_t pid : memberPids) {
+        if (visited.contains(pid) || !m_set.contains(pid))
+            continue;
+        visited.insert(pid);
+
+        const Process &proc = m_set[pid];
+        resource.cpu += proc.cpu();
+        resource.recvBps += proc.recvBps();
+        resource.sentBps += proc.sentBps();
+        resource.memory += proc.memory();
+    }
+
+    m_applicationResources.insert(representativePid, resource);
+}
+
 void ProcessSet::refresh()
 {
     scanProcess();
@@ -86,12 +235,12 @@ void ProcessSet::scanProcess()
     }
     m_curPid.clear();
     m_set.clear();
+    m_applicationResources.clear();
     m_pidPtoCMapping.clear();
     m_pidCtoPMapping.clear();
     WMWindowList *wmwindowList = ProcessDB::instance()->windowList();
 
     Iterator iter;
-    QList<pid_t> appLst;
     while (iter.hasNext()) {
         Process proc = iter.next();
 
@@ -103,12 +252,9 @@ void ProcessSet::scanProcess()
     if(m_prePid != m_curPid) {
         for (const pid_t &pid : m_prePid) {
             if(!m_curPid.contains(pid)){
-                m_prePid.removeAt(pid);  //remove disappear process pid
                 if(m_simpleSet.contains(pid))
                     m_simpleSet.remove(pid);
-                //for each pid,only one process reflected.So "removeOne()"func replied.
-                if(m_pidMyApps.contains(pid))
-                    m_pidMyApps.removeOne(pid);
+                m_pidMyApps.removeOne(pid);
             }
         }
 
@@ -119,9 +265,8 @@ void ProcessSet::scanProcess()
                 if(!m_simpleSet.contains(pid))
                      m_simpleSet.insert(proc.pid(), proc);
 
-                if (proc.appType() == kFilterApps && !wmwindowList->isTrayApp(proc.pid())) {
-                     m_pidMyApps << proc.pid();
-                }
+                if (proc.appType() == kFilterApps && !wmwindowList->isTrayApp(proc.pid()))
+                    m_pidMyApps.append(proc.pid());
             }
         }
         m_prePid = m_curPid;
@@ -146,27 +291,47 @@ void ProcessSet::scanProcess()
         }
     }
 
-    std::function<bool(pid_t ppid)> anyRootIsGuiProc;
+    const QMap<pid_t, QList<pid_t>> launchGroups =
+            collapseDesktopLaunchGroups(wmwindowList, ProcessDB::instance()->processEuid());
+
+    // A split launch can choose a tray process or a previously hidden member
+    // as its representative, neither of which is guaranteed to be in this list.
+    for (auto it = launchGroups.cbegin(); it != launchGroups.cend(); ++it) {
+        if (!m_pidMyApps.contains(it.key()))
+            m_pidMyApps.append(it.key());
+    }
+
     // find if any ancestor processes is gui application
-    anyRootIsGuiProc = [&](pid_t ppid) -> bool {
-        bool b;
-        b = wmwindowList->isGuiApp(ppid);
-        if (!b && m_pidCtoPMapping.contains(ppid))
-        {
-            b = anyRootIsGuiProc(m_pidCtoPMapping[ppid]);
+    auto anyRootIsGuiProc = [&](pid_t ppid) -> bool {
+        QSet<pid_t> visited;
+        while (!visited.contains(ppid)) {
+            visited.insert(ppid);
+            if (wmwindowList->isGuiApp(ppid))
+                return true;
+            if (!m_pidCtoPMapping.contains(ppid))
+                break;
+            ppid = m_pidCtoPMapping.value(ppid);
         }
-        return b;
+        return false;
     };
 
     for (const pid_t &pid : m_pidMyApps) {
-        qreal recvBps = 0;
-        qreal sendBps = 0;
-        mergeSubProcNetIO(pid, recvBps, sendBps);
-        m_set[pid].setNetIoBps(recvBps, sendBps);
+        if (!m_set.contains(pid) || m_set[pid].appType() != kFilterApps)
+            continue;
 
-        qreal ptotalCpu = 0.;
-        mergeSubProcCpu(pid, ptotalCpu);
-        m_set[pid].setCpu(ptotalCpu);
+        if (launchGroups.contains(pid)) {
+            aggregateProcessGroup(pid, launchGroups.value(pid));
+        } else {
+            ApplicationResource resource;
+            mergeSubProcNetIO(pid, resource.recvBps, resource.sentBps);
+            mergeSubProcCpu(pid, resource.cpu);
+            mergeSubProcMemory(pid, resource.memory);
+            m_applicationResources.insert(pid, resource);
+        }
+
+        // A split launch is already represented by this single selected PID.
+        if (launchGroups.contains(pid))
+            continue;
 
         if (!wmwindowList->isGuiApp(pid))
         {
@@ -241,6 +406,11 @@ std::weak_ptr<RecentProcStage> ProcessSet::getRecentProcStage(pid_t pid) const
     return m_recentProcStage[pid];
 }
 
+QMap<pid_t, ApplicationResource> ProcessSet::getApplicationResources() const
+{
+    return m_applicationResources;
+}
+
 const Process ProcessSet::getProcessById(pid_t pid) const
 {
     return m_set[pid];
@@ -266,6 +436,7 @@ QList<pid_t> ProcessSet::getPIDList() const
 void ProcessSet::removeProcess(pid_t pid)
 {
     m_set.remove(pid);
+    m_applicationResources.remove(pid);
 }
 
 void ProcessSet::updateProcessState(pid_t pid, char state)

--- a/deepin-system-monitor-main/process/process_set.h
+++ b/deepin-system-monitor-main/process/process_set.h
@@ -17,6 +17,10 @@ using namespace common::alloc;
 
 // class Settings;
 namespace core {
+namespace wm {
+class WMWindowList;
+}
+
 namespace process {
 
 enum FilterType { kFilterApps,
@@ -34,6 +38,13 @@ struct RecentProcStage {
     timeval uptime = {0, 0};
 };
 
+struct ApplicationResource {
+    qreal cpu = 0;
+    qreal recvBps = 0;
+    qreal sentBps = 0;
+    qulonglong memory = 0;
+};
+
 class ProcessSet
 {
 public:
@@ -47,6 +58,7 @@ public:
     void updateProcessState(pid_t pid, char state);
     void updateProcessPriority(pid_t pid, int priority);
     std::weak_ptr<RecentProcStage> getRecentProcStage(pid_t pid) const;
+    QMap<pid_t, ApplicationResource> getApplicationResources() const;
 
     void refresh();
 
@@ -54,6 +66,10 @@ private:
     void scanProcess();
     void mergeSubProcNetIO(pid_t ppid, qreal &recvBps, qreal &sendBps);
     void mergeSubProcCpu(pid_t ppid, qreal &cpu);
+    void mergeSubProcMemory(pid_t ppid, qulonglong &memory);
+    QMap<pid_t, QList<pid_t>> collapseDesktopLaunchGroups(
+            core::wm::WMWindowList *windowList, uid_t euid);
+    void aggregateProcessGroup(pid_t representativePid, const QList<pid_t> &memberPids);
 
     class Iterator
     {
@@ -74,6 +90,7 @@ private:
     // Settings *m_settings = nullptr;
     QMap<pid_t, Process> m_simpleSet;
     QMap<pid_t, Process> m_set;
+    QMap<pid_t, ApplicationResource> m_applicationResources;
     QMap<pid_t, std::shared_ptr<RecentProcStage>> m_recentProcStage {};
 
     QMap<pid_t, pid_t> m_pidCtoPMapping {}; // child to parent pid mapping

--- a/tests/deepin-system-monitor-main/model/ut_process_table_model.cpp
+++ b/tests/deepin-system-monitor-main/model/ut_process_table_model.cpp
@@ -6,6 +6,7 @@
 //self
 #include "model/process_table_model.h"
 #include "process/process_db.h"
+#include "process/private/process_p.h"
 #include "common/common.h"
 //gtest
 #include "stub.h"
@@ -1094,5 +1095,51 @@ TEST_F(UT_ProcessTableModel, test_updateProcessPriority_001)
      m_tester->m_processList << proc;
 
      m_tester->updateProcessPriority(pid,priority);
+
+}
+
+TEST_F(UT_ProcessTableModel, test_applicationResourcesOnlyUsedInApplicationsMode)
+{
+    const pid_t pid = 401;
+    Process proc(pid);
+    proc.d->valid = true;
+    proc.d->rss = 13;
+    proc.setCpu(1);
+    proc.setNetIoBps(2, 3);
+
+    m_tester->m_procIdList << pid;
+    m_tester->m_processList << proc;
+
+    ApplicationResource resource;
+    resource.cpu = 6;
+    resource.recvBps = 12;
+    resource.sentBps = 15;
+    resource.memory = 50;
+    ProcessSet processSet;
+    processSet.m_applicationResources.insert(pid, resource);
+    m_tester->m_applicationResources = processSet.getApplicationResources();
+
+    m_tester->setDisplayMode(kFilterApps);
+    EXPECT_DOUBLE_EQ(m_tester->data(m_tester->index(0, ProcessTableModel::kProcessCPUColumn),
+                                    Qt::UserRole).toDouble(),
+                     6);
+    EXPECT_EQ(m_tester->data(m_tester->index(0, ProcessTableModel::kProcessMemoryColumn),
+                             Qt::UserRole).toULongLong(),
+              50U);
+    EXPECT_DOUBLE_EQ(m_tester->data(m_tester->index(0, ProcessTableModel::kProcessUploadColumn),
+                                    Qt::UserRole).toDouble(),
+                     15);
+    EXPECT_DOUBLE_EQ(m_tester->data(m_tester->index(0, ProcessTableModel::kProcessDownloadColumn),
+                                    Qt::UserRole).toDouble(),
+                     12);
+    EXPECT_DOUBLE_EQ(m_tester->getTotalMemoryUsage(), 13);
+
+    m_tester->setDisplayMode(kNoFilter);
+    EXPECT_DOUBLE_EQ(m_tester->data(m_tester->index(0, ProcessTableModel::kProcessCPUColumn),
+                                    Qt::UserRole).toDouble(),
+                     1);
+    EXPECT_EQ(m_tester->data(m_tester->index(0, ProcessTableModel::kProcessMemoryColumn),
+                             Qt::UserRole).toULongLong(),
+              13U);
 
 }

--- a/tests/deepin-system-monitor-main/process/ut_process_set.cpp
+++ b/tests/deepin-system-monitor-main/process/ut_process_set.cpp
@@ -6,6 +6,7 @@
 //self
 #include "process/process_set.h"
 #include "process/process_db.h"
+#include "process/private/process_p.h"
 #include "common/common.h"
 #include "wm/wm_window_list.h"
 
@@ -62,6 +63,211 @@ TEST_F(UT_ProcessSet, test_mergeSubProcCpu_001)
     qreal cpu = 0;
     m_tester->mergeSubProcCpu(ppid,cpu);
 
+}
+
+TEST_F(UT_ProcessSet, test_mergeSubProcMemory_001)
+{
+    Process root(101);
+    root.d->rss = 13;
+    Process child1(102);
+    child1.d->rss = 17;
+    Process child2(103);
+    child2.d->rss = 20;
+
+    m_tester->m_set.insert(101, root);
+    m_tester->m_set.insert(102, child1);
+    m_tester->m_set.insert(103, child2);
+    m_tester->m_pidPtoCMapping.insert(101, 102);
+    m_tester->m_pidPtoCMapping.insert(101, 103);
+
+    qulonglong memory = 0;
+    m_tester->mergeSubProcMemory(101, memory);
+
+    EXPECT_EQ(memory, 50U);
+}
+
+TEST_F(UT_ProcessSet, test_aggregateProcessGroup_001)
+{
+    Process representative(101);
+    representative.setCpu(1);
+    representative.setNetIoBps(2, 3);
+    representative.d->rss = 13;
+
+    Process child1(102);
+    child1.setCpu(2);
+    child1.setNetIoBps(4, 5);
+    child1.d->rss = 17;
+
+    Process child2(103);
+    child2.setCpu(3);
+    child2.setNetIoBps(6, 7);
+    child2.d->rss = 20;
+
+    m_tester->m_set.insert(representative.pid(), representative);
+    m_tester->m_set.insert(child1.pid(), child1);
+    m_tester->m_set.insert(child2.pid(), child2);
+
+    m_tester->aggregateProcessGroup(representative.pid(), {101, 102, 103, 103});
+
+    const Process result = m_tester->m_set.value(representative.pid());
+    EXPECT_DOUBLE_EQ(result.cpu(), 1);
+    EXPECT_DOUBLE_EQ(result.recvBps(), 2);
+    EXPECT_DOUBLE_EQ(result.sentBps(), 3);
+    EXPECT_EQ(result.memory(), 13U);
+
+    const QMap<pid_t, ApplicationResource> resources = m_tester->getApplicationResources();
+    ASSERT_TRUE(resources.contains(representative.pid()));
+    const ApplicationResource resource = resources.value(representative.pid());
+    EXPECT_DOUBLE_EQ(resource.cpu, 6);
+    EXPECT_DOUBLE_EQ(resource.recvBps, 12);
+    EXPECT_DOUBLE_EQ(resource.sentBps, 15);
+    EXPECT_EQ(resource.memory, 50U);
+}
+
+TEST_F(UT_ProcessSet, test_collapseDesktopLaunchGroups_001)
+{
+    WMWindowList windowList;
+    windowList.m_guiAppcache.emplace(102, WMWindow(new wm_window_t()));
+
+    for (pid_t pid : {101, 102, 103}) {
+        Process proc(pid);
+        proc.d->ppid = 1;
+        proc.d->uid = geteuid();
+        proc.d->environ.insert("GIO_LAUNCHED_DESKTOP_FILE", "/tmp/wxwork.desktop");
+        proc.d->environ.insert("GIO_LAUNCHED_DESKTOP_FILE_PID", "100");
+        proc.setAppType(kFilterApps);
+        m_tester->m_set.insert(pid, proc);
+    }
+
+    Process separateLaunch(104);
+    separateLaunch.d->ppid = 1;
+    separateLaunch.d->uid = geteuid();
+    separateLaunch.d->environ.insert("GIO_LAUNCHED_DESKTOP_FILE", "/tmp/wxwork.desktop");
+    separateLaunch.d->environ.insert("GIO_LAUNCHED_DESKTOP_FILE_PID", "200");
+    separateLaunch.setAppType(kFilterApps);
+    m_tester->m_set.insert(separateLaunch.pid(), separateLaunch);
+
+    const QMap<pid_t, QList<pid_t>> groups =
+            m_tester->collapseDesktopLaunchGroups(&windowList, geteuid());
+
+    ASSERT_EQ(groups.size(), 1);
+    ASSERT_TRUE(groups.contains(102));
+    EXPECT_EQ(groups.value(102).size(), 3);
+    EXPECT_FALSE(groups.value(102).contains(104));
+    EXPECT_EQ(m_tester->m_set.value(102).appType(), kFilterApps);
+    EXPECT_EQ(m_tester->m_set.value(101).appType(), kFilterCurrentUser);
+    EXPECT_EQ(m_tester->m_set.value(103).appType(), kFilterCurrentUser);
+}
+
+TEST_F(UT_ProcessSet, test_collapseDesktopLaunchGroups_collapsesDuplicateAppsInSingleTree)
+{
+    WMWindowList windowList;
+    windowList.m_guiAppcache.emplace(202, WMWindow(new wm_window_t()));
+    Process root(201);
+    root.d->ppid = 1;
+    root.d->uid = geteuid();
+    Process child(202);
+    child.d->ppid = 201;
+    child.d->uid = geteuid();
+
+    for (Process *proc : {&root, &child}) {
+        proc->d->environ.insert("GIO_LAUNCHED_DESKTOP_FILE", "/tmp/app.desktop");
+        proc->setAppType(kFilterApps);
+        m_tester->m_set.insert(proc->pid(), *proc);
+    }
+
+    // An incomplete launch identity must never be used for grouping.
+    EXPECT_TRUE(m_tester->collapseDesktopLaunchGroups(&windowList, geteuid()).isEmpty());
+
+    m_tester->m_set[201].d->environ.insert("GIO_LAUNCHED_DESKTOP_FILE_PID", "200");
+    m_tester->m_set[202].d->environ.insert("GIO_LAUNCHED_DESKTOP_FILE_PID", "200");
+    m_tester->m_pidPtoCMapping.insert(201, 202);
+
+    const QMap<pid_t, QList<pid_t>> groups =
+            m_tester->collapseDesktopLaunchGroups(&windowList, geteuid());
+
+    ASSERT_EQ(groups.size(), 1);
+    ASSERT_TRUE(groups.contains(202));
+    EXPECT_EQ(groups.value(202), QList<pid_t>({201, 202}));
+    EXPECT_EQ(m_tester->m_set.value(201).appType(), kFilterCurrentUser);
+    EXPECT_EQ(m_tester->m_set.value(202).appType(), kFilterApps);
+}
+
+TEST_F(UT_ProcessSet, test_collapseDesktopLaunchGroups_keepsOneAppCandidateInSingleTree)
+{
+    WMWindowList windowList;
+    Process root(201);
+    root.d->ppid = 1;
+    root.d->uid = geteuid();
+    root.setAppType(kFilterApps);
+    Process child(202);
+    child.d->ppid = 201;
+    child.d->uid = geteuid();
+    child.setAppType(kFilterCurrentUser);
+
+    for (Process *proc : {&root, &child}) {
+        proc->d->environ.insert("GIO_LAUNCHED_DESKTOP_FILE", "/tmp/app.desktop");
+        proc->d->environ.insert("GIO_LAUNCHED_DESKTOP_FILE_PID", "200");
+        m_tester->m_set.insert(proc->pid(), *proc);
+    }
+    m_tester->m_pidPtoCMapping.insert(201, 202);
+
+    EXPECT_TRUE(m_tester->collapseDesktopLaunchGroups(&windowList, geteuid()).isEmpty());
+    EXPECT_EQ(m_tester->m_set.value(201).appType(), kFilterApps);
+}
+
+TEST_F(UT_ProcessSet, test_collapseDesktopLaunchGroups_includesDescendantsWithoutLaunchIdentity)
+{
+    WMWindowList windowList;
+    Process root1(301);
+    root1.d->ppid = 1;
+    root1.d->uid = geteuid();
+    root1.d->rss = 13;
+    root1.setCpu(1);
+    root1.setNetIoBps(2, 3);
+    root1.setAppType(kFilterApps);
+
+    Process root2(302);
+    root2.d->ppid = 1;
+    root2.d->uid = geteuid();
+    root2.d->rss = 17;
+    root2.setCpu(2);
+    root2.setNetIoBps(4, 5);
+    root2.setAppType(kFilterCurrentUser);
+
+    for (Process *proc : {&root1, &root2}) {
+        proc->d->environ.insert("GIO_LAUNCHED_DESKTOP_FILE", "/tmp/app.desktop");
+        proc->d->environ.insert("GIO_LAUNCHED_DESKTOP_FILE_PID", "300");
+    }
+
+    Process child(303);
+    child.d->ppid = 301;
+    child.d->uid = geteuid();
+    child.d->rss = 20;
+    child.setCpu(3);
+    child.setNetIoBps(6, 7);
+    child.setAppType(kFilterCurrentUser);
+
+    m_tester->m_set.insert(root1.pid(), root1);
+    m_tester->m_set.insert(root2.pid(), root2);
+    m_tester->m_set.insert(child.pid(), child);
+    m_tester->m_pidPtoCMapping.insert(root1.pid(), child.pid());
+
+    const QMap<pid_t, QList<pid_t>> groups =
+            m_tester->collapseDesktopLaunchGroups(&windowList, geteuid());
+
+    ASSERT_EQ(groups.size(), 1);
+    ASSERT_TRUE(groups.contains(root1.pid()));
+    EXPECT_EQ(groups.value(root1.pid()), QList<pid_t>({301, 302, 303}));
+
+    m_tester->aggregateProcessGroup(root1.pid(), groups.value(root1.pid()));
+    const QMap<pid_t, ApplicationResource> resources = m_tester->getApplicationResources();
+    ASSERT_TRUE(resources.contains(root1.pid()));
+    const ApplicationResource resource = resources.value(root1.pid());
+    EXPECT_DOUBLE_EQ(resource.cpu, 6);
+    EXPECT_DOUBLE_EQ(resource.recvBps, 12);
+    EXPECT_DOUBLE_EQ(resource.sentBps, 15);
+    EXPECT_EQ(resource.memory, 50U);
 }
 
 TEST_F(UT_ProcessSet, test_refresh_001)


### PR DESCRIPTION
Keep per-PID metrics unchanged and expose aggregated resources only in app view.

保留单进程资源原值，仅在应用视图显示聚合后的资源。

Log: 修复分离应用进程资源漏算和重复统计
Bug: https://pms.uniontech.com/bug-view-374247.html Influence: 应用页聚合同一启动应用的 CPU、网络和内存，
用户页和所有进程页保持单 PID 统计。

## Summary by Sourcery

Fix resource accounting for split application processes by aggregating launch-level metrics exclusively in the application view.

Bug Fixes:
- Aggregate CPU, memory, and network resources for split application launches while preserving per-process metrics in process and user views.

Enhancements:
- Expose aggregated application resources only when the process table is in application mode and use them for display and sorting.
- Collapse duplicate processes from the same desktop application launch into a single representative application entry.

Tests:
- Add coverage for recursive memory aggregation, split-launch grouping, duplicate application collapsing, and application-only resource display.