### PR TITLE
fix: update Arabic (ar) translations

### DIFF
--- a/deepin-system-monitor-main/translations/deepin-system-monitor_ar.ts
+++ b/deepin-system-monitor-main/translations/deepin-system-monitor_ar.ts
@@ -78,12 +78,12 @@
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="98"/>
         <source>Max frequency</source>
-        <translation>Frequency</translation>
+        <translation>أقصى تردد</translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="100"/>
         <source>Average frequency</source>
-        <translation type="unfinished"/>
+        <translation>متوسط التردد</translation>
     </message>
     <message>
         <location filename="../gui/cpu_summary_view_widget.h" line="104"/>

--- a/deepin-system-monitor-main/translations/policy/policy_ar.ts
+++ b/deepin-system-monitor-main/translations/policy/policy_ar.ts
@@ -31,5 +31,15 @@
 			<source>Set service startup type</source>
 			<translation>تعيين نوع بدء تشغيل الخدمة</translation>
 		</message>
+		<message>
+			<location filename="com.deepin.pkexec.deepin-system-monitor.logout!message" line="0" />
+			<source>Logging out other users is required to change process priority</source>
+			<translation>يلزم تسجيل خروج المستخدمين الآخرين لتغيير أولوية العملية</translation>
+		</message>
+		<message>
+			<location filename="com.deepin.pkexec.deepin-system-monitor.logout!description" line="0" />
+			<source>Logout other users</source>
+			<translation>تسجيل خروج المستخدمين الآخرين</translation>
+		</message>
 	</context>
 </TS>


### PR DESCRIPTION
Complete missing Arabic translations in deepin-system-monitor:

1. `deepin-system-monitor_ar.ts`:
   - Fix "Max frequency" translation (was incorrectly set to "Frequency")
   - Complete "Average frequency" translation (was unfinished)

2. `policy/policy_ar.ts`:
   - Add missing "Logout other users" message translation
   - Add missing "Logging out other users is required to change process priority" message translation

## Summary by Sourcery

Complete and correct Arabic localization for CPU frequency and user logout policy messages.

Bug Fixes:
- Correct Arabic translations for maximum and average CPU frequency labels.
- Add Arabic translations for logging out other users and the related process-priority requirement.