### PR TITLE
fix(process): collapse wine container processes into one group

### DIFF
--- a/deepin-system-monitor-main/process/process.cpp
+++ b/deepin-system-monitor-main/process/process.cpp
@@ -108,6 +108,11 @@ Process::~Process()
 {
 }
 
+void Process::detach()
+{
+    d.detach();
+}
+
 time_t Process::startTime() const
 {
     auto *monitor = ThreadManager::instance()->thread<SystemMonitorThread>(BaseThread::kSystemMonitorThread)->systemMonitorInstance();

--- a/deepin-system-monitor-main/process/process.h
+++ b/deepin-system-monitor-main/process/process.h
@@ -56,6 +56,8 @@ public:
     Process &operator=(const Process &rhs);
     ~Process();
 
+    void detach();
+
     bool isValid() const;
 
     pid_t pid() const;

--- a/deepin-system-monitor-main/process/process_set.cpp
+++ b/deepin-system-monitor-main/process/process_set.cpp
@@ -10,6 +10,7 @@
 // #include "settings.h"
 
 #include <QDebug>
+#include <QSet>
 
 #include <errno.h>
 
@@ -41,29 +42,130 @@ ProcessSet::ProcessSet(const ProcessSet &other)
     // m_settings = Settings::instance();
 }
 
-void ProcessSet::mergeSubProcNetIO(pid_t ppid, qreal &recvBps, qreal &sendBps)
+void ProcessSet::mergeSubProcResources(pid_t ppid, qreal &cpu,
+                                        qreal &recvBps, qreal &sendBps) const
 {
-    auto it = m_pidPtoCMapping.find(ppid);
-    while (it != m_pidPtoCMapping.end() && it.key() == ppid) {
-        mergeSubProcNetIO(it.value(), recvBps, sendBps);
-        ++it;
-    }
+    QList<pid_t> pending {ppid};
+    QSet<pid_t> visited;
+    while (!pending.isEmpty()) {
+        const pid_t pid = pending.takeLast();
+        if (visited.contains(pid))
+            continue;
+        visited.insert(pid);
 
-    const Process &proc = m_set[ppid];
-    recvBps += proc.recvBps();
-    sendBps += proc.sentBps();
+        const auto proc = m_set.constFind(pid);
+        if (proc == m_set.cend())
+            continue;
+        cpu += proc->cpu();
+        recvBps += proc->recvBps();
+        sendBps += proc->sentBps();
+
+        auto child = m_pidPtoCMapping.constFind(pid);
+        while (child != m_pidPtoCMapping.cend() && child.key() == pid) {
+            pending.append(child.value());
+            ++child;
+        }
+    }
 }
 
-void ProcessSet::mergeSubProcCpu(pid_t ppid, qreal &cpu)
+QMap<pid_t, QList<pid_t>> ProcessSet::collapseWineContainerGroups(WMWindowList *windowList,
+                                                                  uid_t euid)
 {
-    auto it = m_pidPtoCMapping.find(ppid);
-    while (it != m_pidPtoCMapping.end() && it.key() == ppid) {
-        mergeSubProcCpu(it.value(), cpu);
-        ++it;
+    using WineIdentity = QPair<QString, QString>;
+
+    const auto wineIdentity = [](const Process &proc, WineIdentity &identity) {
+        const QHash<QString, QString> environ = proc.environ();
+        const QString prefix = environ.value("WINEPREFIX").trimmed();
+        const QString package = environ.value("DEB_PACKAGE_NAME").trimmed();
+        if (prefix.isEmpty() || package.isEmpty())
+            return false;
+
+        identity = qMakePair(prefix, package);
+        return true;
+    };
+    const auto isWineContainerProcess = [](const Process &proc) {
+        const QString name = proc.name();
+        if (name == QStringLiteral("wineserver")
+                || name.startsWith(QStringLiteral("deepin-wine"))
+                || name.endsWith(QStringLiteral(".exe"), Qt::CaseInsensitive))
+            return true;
+
+        const QByteArrayList cmdline = proc.cmdline();
+        return !cmdline.isEmpty()
+                && QString::fromLocal8Bit(cmdline.first())
+                           .contains(".exe", Qt::CaseInsensitive);
+    };
+
+    QMap<WineIdentity, QList<pid_t>> membersByContainer;
+    for (auto it = m_set.cbegin(); it != m_set.cend(); ++it) {
+        if (it.value().uid() != euid)
+            continue;
+
+        WineIdentity identity;
+        if (wineIdentity(it.value(), identity) && isWineContainerProcess(it.value()))
+            membersByContainer[identity].append(it.key());
     }
 
-    const Process &proc = m_set[ppid];
-    cpu += proc.cpu();
+    QMap<pid_t, QList<pid_t>> groups;
+    for (auto it = membersByContainer.cbegin(); it != membersByContainer.cend(); ++it) {
+        // Appended in PID order while traversing m_set.
+        const QList<pid_t> &members = it.value();
+
+        QSet<pid_t> memberPids;
+        QList<pid_t> appCandidates;
+        int rootCount = 0;
+        for (pid_t pid : members) {
+            memberPids.insert(pid);
+            if (m_set.constFind(pid)->appType() == kFilterApps)
+                appCandidates.append(pid);
+        }
+        for (pid_t pid : members) {
+            if (!memberPids.contains(m_set.constFind(pid)->ppid()))
+                ++rootCount;
+        }
+
+        if (appCandidates.isEmpty() || (rootCount < 2 && appCandidates.size() < 2))
+            continue;
+
+        pid_t representativePid = -1;
+        int representativeScore = -1;
+        for (pid_t pid : appCandidates) {
+            int score = 0;
+            if (windowList->isGuiApp(pid))
+                score = 3;
+            else if (windowList->isDesktopEntryApp(pid))
+                score = 2;
+            else if (windowList->isTrayApp(pid))
+                score = 1;
+
+            if (score > representativeScore
+                    || (score == representativeScore
+                        && (representativePid < 0 || pid < representativePid))) {
+                representativePid = pid;
+                representativeScore = score;
+            }
+        }
+
+        groups.insert(representativePid, members);
+        // Reparent only the aggregation tree. Keep the real PPIDs for process
+        // details and ancestor checks. Native descendants stay on their branches.
+        for (pid_t pid : members) {
+            m_pidPtoCMapping.remove(m_set.constFind(pid)->ppid(), pid);
+            if (pid != representativePid)
+                m_pidPtoCMapping.insert(representativePid, pid);
+        }
+        for (pid_t pid : appCandidates) {
+            if (pid == representativePid)
+                continue;
+
+            Process &demoted = m_set.find(pid).value();
+            demoted.detach();
+            demoted.setAppType(kFilterCurrentUser);
+            windowList->removeDesktopEntryApp(pid);
+        }
+    }
+
+    return groups;
 }
 
 void ProcessSet::refresh()
@@ -103,7 +205,6 @@ void ProcessSet::scanProcess()
     if(m_prePid != m_curPid) {
         for (const pid_t &pid : m_prePid) {
             if(!m_curPid.contains(pid)){
-                m_prePid.removeAt(pid);  //remove disappear process pid
                 if(m_simpleSet.contains(pid))
                     m_simpleSet.remove(pid);
                 //for each pid,only one process reflected.So "removeOne()"func replied.
@@ -146,27 +247,42 @@ void ProcessSet::scanProcess()
         }
     }
 
-    std::function<bool(pid_t ppid)> anyRootIsGuiProc;
-    // find if any ancestor processes is gui application
-    anyRootIsGuiProc = [&](pid_t ppid) -> bool {
-        bool b;
-        b = wmwindowList->isGuiApp(ppid);
-        if (!b && m_pidCtoPMapping.contains(ppid))
-        {
-            b = anyRootIsGuiProc(m_pidCtoPMapping[ppid]);
+    const QMap<pid_t, QList<pid_t>> wineGroups =
+            collapseWineContainerGroups(wmwindowList, ProcessDB::instance()->processEuid());
+    for (auto it = wineGroups.cbegin(); it != wineGroups.cend(); ++it) {
+        if (!m_pidMyApps.contains(it.key()))
+            m_pidMyApps.append(it.key());
+    }
+
+    // Follow real parent links iteratively; a racy scan can contain cycles.
+    const auto anyRootIsGuiProc = [&](pid_t ppid) -> bool {
+        QSet<pid_t> visited;
+        while (!visited.contains(ppid)) {
+            visited.insert(ppid);
+            if (wmwindowList->isGuiApp(ppid))
+                return true;
+            const auto parent = m_pidCtoPMapping.constFind(ppid);
+            if (parent == m_pidCtoPMapping.cend())
+                break;
+            ppid = parent.value();
         }
-        return b;
+        return false;
     };
 
     for (const pid_t &pid : m_pidMyApps) {
+        auto proc = m_set.find(pid);
+        if (proc == m_set.end() || proc->appType() != kFilterApps)
+            continue;
+
         qreal recvBps = 0;
         qreal sendBps = 0;
-        mergeSubProcNetIO(pid, recvBps, sendBps);
-        m_set[pid].setNetIoBps(recvBps, sendBps);
-
         qreal ptotalCpu = 0.;
-        mergeSubProcCpu(pid, ptotalCpu);
-        m_set[pid].setCpu(ptotalCpu);
+        mergeSubProcResources(pid, ptotalCpu, recvBps, sendBps);
+        proc->setNetIoBps(recvBps, sendBps);
+        proc->setCpu(ptotalCpu);
+
+        if (wineGroups.contains(pid))
+            continue;
 
         if (!wmwindowList->isGuiApp(pid))
         {

--- a/deepin-system-monitor-main/process/process_set.h
+++ b/deepin-system-monitor-main/process/process_set.h
@@ -17,6 +17,10 @@ using namespace common::alloc;
 
 // class Settings;
 namespace core {
+namespace wm {
+class WMWindowList;
+}
+
 namespace process {
 
 enum FilterType { kFilterApps,
@@ -52,8 +56,10 @@ public:
 
 private:
     void scanProcess();
-    void mergeSubProcNetIO(pid_t ppid, qreal &recvBps, qreal &sendBps);
-    void mergeSubProcCpu(pid_t ppid, qreal &cpu);
+    void mergeSubProcResources(pid_t ppid, qreal &cpu,
+                               qreal &recvBps, qreal &sendBps) const;
+    QMap<pid_t, QList<pid_t>> collapseWineContainerGroups(
+            core::wm::WMWindowList *windowList, uid_t euid);
 
     class Iterator
     {
@@ -77,7 +83,8 @@ private:
     QMap<pid_t, std::shared_ptr<RecentProcStage>> m_recentProcStage {};
 
     QMap<pid_t, pid_t> m_pidCtoPMapping {}; // child to parent pid mapping
-    QMultiMap<pid_t, pid_t> m_pidPtoCMapping {}; // parent to child pid mapping
+    // Resource aggregation tree; Wine members can have a virtual parent here.
+    QMultiMap<pid_t, pid_t> m_pidPtoCMapping {};
     QList<pid_t> m_prePid;
     QList<pid_t> m_curPid;
     QList<pid_t> m_pidMyApps;

--- a/deepin-system-monitor-plugin-popup/process/process.cpp
+++ b/deepin-system-monitor-plugin-popup/process/process.cpp
@@ -108,6 +108,11 @@ Process::~Process()
 {
 }
 
+void Process::detach()
+{
+    d.detach();
+}
+
 time_t Process::startTime() const
 {
     auto *monitor = ThreadManager::instance()->thread<SystemMonitorThread>(BaseThread::kSystemMonitorThread)->systemMonitorInstance();

--- a/deepin-system-monitor-plugin-popup/process/process.h
+++ b/deepin-system-monitor-plugin-popup/process/process.h
@@ -56,6 +56,8 @@ public:
     Process &operator=(const Process &rhs);
     ~Process();
 
+    void detach();
+
     bool isValid() const;
 
     pid_t pid() const;

--- a/tests/deepin-system-monitor-main/process/ut_process_set.cpp
+++ b/tests/deepin-system-monitor-main/process/ut_process_set.cpp
@@ -6,6 +6,7 @@
 //self
 #include "process/process_set.h"
 #include "process/process_db.h"
+#include "process/private/process_p.h"
 #include "common/common.h"
 #include "wm/wm_window_list.h"
 
@@ -38,6 +39,55 @@ public:
     }
 
 protected:
+    // Exercise the full scan with a deterministic process snapshot.
+    QList<pid_t> scanProcesses(const QList<pid_t> &pids,
+                              const QList<pid_t> &guiPids = {})
+    {
+        ProcessDB db;
+        for (pid_t pid : guiPids)
+            db.windowList()->m_guiAppcache.emplace(pid, WMWindow(new wm_window_t()));
+        static ProcessDB *database;
+        static QList<pid_t> pending, simpleReads;
+        database = &db;
+        pending = pids;
+        simpleReads.clear();
+        Stub stub;
+        stub.set(&ProcessDB::instance, +[]() { return database; });
+        stub.set(ADDR(ProcessSet::Iterator, hasNext),
+                 +[](ProcessSet::Iterator *) { return !pending.isEmpty(); });
+        stub.set(ADDR(ProcessSet::Iterator, next),
+                 +[](ProcessSet::Iterator *) { return Process(pending.takeFirst()); });
+        stub.set(ADDR(Process, readProcessSimpleInfo), +[](Process *proc) {
+            simpleReads.append(proc->pid());
+            proc->d->valid = true;
+        });
+        stub.set(ADDR(Process, readProcessVariableInfo), +[](Process *proc) {
+            proc->d->valid = true;
+        });
+        m_tester->scanProcess();
+        return simpleReads;
+    }
+
+    Process addProcess(pid_t pid, pid_t ppid, const char *name,
+                       int type = kFilterApps,
+                       const QString &prefix = "/home/test/.deepinwine/example",
+                       const QString &package = "com.example.wine")
+    {
+        Process proc(pid);
+        proc.d->ppid = ppid;
+        proc.d->uid = geteuid();
+        proc.d->name = name;
+        proc.d->cmdline << name;
+        proc.d->environ.insert("WINEPREFIX", prefix);
+        proc.d->environ.insert("DEB_PACKAGE_NAME", package);
+        proc.setAppType(type);
+        m_tester->m_simpleSet.insert(pid, proc);
+        m_tester->m_set.insert(pid, proc);
+        m_tester->m_pidPtoCMapping.insert(ppid, pid);
+        m_tester->m_pidCtoPMapping.insert(pid, ppid);
+        return proc;
+    }
+
     ProcessSet *m_tester;
 
 };
@@ -47,21 +97,155 @@ TEST_F(UT_ProcessSet, initTest)
 
 }
 
-TEST_F(UT_ProcessSet, test_mergeSubProcNetIO_001)
+TEST_F(UT_ProcessSet, test_mergeSubProcResources_missingProcess)
 {
-    pid_t ppid = getppid();
-    qreal recvBps = 100;
-    qreal sendBps = 100;
-    m_tester->mergeSubProcNetIO(ppid,recvBps,sendBps);
-
+    qreal cpu = 0, recvBps = 0, sendBps = 0;
+    m_tester->mergeSubProcResources(101, cpu, recvBps, sendBps);
+    EXPECT_DOUBLE_EQ(cpu, 0);
+    EXPECT_DOUBLE_EQ(recvBps, 0);
+    EXPECT_DOUBLE_EQ(sendBps, 0);
+    EXPECT_TRUE(m_tester->m_set.isEmpty());
 }
 
-TEST_F(UT_ProcessSet, test_mergeSubProcCpu_001)
+TEST_F(UT_ProcessSet, test_mergeSubProcResources_countsEachPidOnce)
 {
-    pid_t ppid = getppid();
-    qreal cpu = 0;
-    m_tester->mergeSubProcCpu(ppid,cpu);
+    Process parent = addProcess(101, 1, "parent");
+    Process child = addProcess(102, 101, "child", kFilterCurrentUser);
+    parent.setCpu(1);
+    parent.setNetIoBps(2, 3);
+    child.setCpu(4);
+    child.setNetIoBps(5, 6);
+    m_tester->m_pidPtoCMapping.insert(101, 102);
+    m_tester->m_pidPtoCMapping.insert(102, 101);
 
+    qreal cpu = 0, recvBps = 0, sendBps = 0;
+    m_tester->mergeSubProcResources(101, cpu, recvBps, sendBps);
+    EXPECT_DOUBLE_EQ(cpu, 5);
+    EXPECT_DOUBLE_EQ(recvBps, 7);
+    EXPECT_DOUBLE_EQ(sendBps, 9);
+}
+
+TEST_F(UT_ProcessSet, test_collapseWineContainerGroups_001)
+{
+    WMWindowList windowList;
+    windowList.m_guiAppcache.emplace(102, WMWindow(new wm_window_t()));
+
+    addProcess(103, 1, "C:\\Program Files\\Example\\helper.exe");
+    addProcess(101, 1, "C:\\Program Files\\Example\\example.exe");
+    addProcess(102, 101, "C:\\windows\\system32\\services.exe");
+
+    const QMap<pid_t, QList<pid_t>> groups =
+            m_tester->collapseWineContainerGroups(&windowList, geteuid());
+
+    ASSERT_EQ(groups.size(), 1);
+    EXPECT_EQ(groups.value(102), QList<pid_t>({101, 102, 103}));
+    EXPECT_EQ(m_tester->m_set.value(102).appType(), kFilterApps);
+    EXPECT_EQ(m_tester->m_set.value(101).appType(), kFilterCurrentUser);
+    EXPECT_EQ(m_tester->m_simpleSet.value(101).appType(), kFilterApps);
+    EXPECT_EQ(m_tester->m_set.value(102).ppid(), 101);
+    EXPECT_EQ(m_tester->m_pidCtoPMapping.value(102), 101);
+    EXPECT_FALSE(m_tester->m_pidPtoCMapping.contains(101, 102));
+    EXPECT_TRUE(m_tester->m_pidPtoCMapping.contains(102, 101));
+}
+
+TEST_F(UT_ProcessSet, test_collapseWineContainerGroups_excludesNativeProcess)
+{
+    WMWindowList windowList;
+    windowList.m_guiAppcache.emplace(102, WMWindow(new wm_window_t()));
+
+    addProcess(101, 1, "C:\\Program Files\\Example\\example.exe");
+    addProcess(102, 1, "C:\\windows\\system32\\services.exe");
+    addProcess(104, 1, "wineserver");
+    Process native = addProcess(103, 1, "/usr/bin/dde-file-manager");
+    native.d->cmdline << "/tmp/setup.exe";
+
+    const QMap<pid_t, QList<pid_t>> groups =
+            m_tester->collapseWineContainerGroups(&windowList, geteuid());
+
+    ASSERT_EQ(groups.size(), 1);
+    EXPECT_EQ(groups.value(102), QList<pid_t>({101, 102, 104}));
+    EXPECT_EQ(m_tester->m_set.value(103).appType(), kFilterApps);
+}
+
+TEST_F(UT_ProcessSet, test_collapseWineContainerGroups_keepsHelperResourcesAndMemory)
+{
+    WMWindowList windowList;
+    Process parent = addProcess(100, 1, "native-launcher");
+    Process representative = addProcess(101, 100, "main.exe");
+    Process server = addProcess(102, 1, "wineserver", kFilterCurrentUser);
+    Process helper = addProcess(103, 102, "native-helper", kFilterCurrentUser);
+    parent.setCpu(1);
+    parent.setNetIoBps(1, 1);
+    representative.setCpu(2);
+    representative.setNetIoBps(2, 2);
+    representative.d->rss = 13;
+    representative.d->shm = 3;
+    server.setCpu(3);
+    server.setNetIoBps(3, 3);
+    helper.setCpu(4);
+    helper.setNetIoBps(4, 4);
+
+    const auto groups = m_tester->collapseWineContainerGroups(&windowList, geteuid());
+    ASSERT_EQ(groups.size(), 1);
+    ASSERT_TRUE(groups.contains(101));
+    qreal cpu = 0, recvBps = 0, sendBps = 0;
+    m_tester->mergeSubProcResources(101, cpu, recvBps, sendBps);
+    EXPECT_DOUBLE_EQ(cpu, 9);
+    EXPECT_DOUBLE_EQ(recvBps, 9);
+    EXPECT_DOUBLE_EQ(sendBps, 9);
+    // Apply the same setters as scanProcess: memory must stay per-PID.
+    representative.setCpu(cpu);
+    representative.setNetIoBps(recvBps, sendBps);
+    EXPECT_EQ(m_tester->getProcessById(101).memory(), 10U);
+    EXPECT_EQ(m_tester->m_simpleSet.value(101).memory(), 10U);
+    EXPECT_EQ(m_tester->getProcessById(101).sharememory(), 3U);
+
+    cpu = recvBps = sendBps = 0;
+    m_tester->mergeSubProcResources(100, cpu, recvBps, sendBps);
+    EXPECT_DOUBLE_EQ(cpu, 1);
+    EXPECT_DOUBLE_EQ(recvBps, 1);
+    EXPECT_DOUBLE_EQ(sendBps, 1);
+}
+
+TEST_F(UT_ProcessSet, test_collapseWineContainerGroups_isolatesContainersAndUsers)
+{
+    WMWindowList windowList;
+    addProcess(101, 1, "main.exe", kFilterApps, "/prefix/a", "package.a");
+    addProcess(102, 101, "helper.exe", kFilterApps, "/prefix/a", "package.a");
+    addProcess(201, 101, "main.exe", kFilterApps, "/prefix/b", "package.a");
+    addProcess(202, 201, "helper.exe", kFilterApps, "/prefix/b", "package.a");
+    addProcess(301, 1, "main.exe", kFilterApps, "/prefix/a", "package.b");
+    addProcess(302, 301, "helper.exe", kFilterApps, "/prefix/a", "package.b");
+    Process foreign = addProcess(401, 1, "other.exe", kFilterApps, "/prefix/a", "package.a");
+    foreign.d->uid = geteuid() + 1;
+    addProcess(501, 1, "no-prefix.exe", kFilterApps, "", "package.a");
+    addProcess(502, 1, "no-package.exe", kFilterApps, "/prefix/a", "");
+    for (auto it = m_tester->m_set.begin(); it != m_tester->m_set.end(); ++it)
+        it->setCpu(1);
+
+    const auto groups = m_tester->collapseWineContainerGroups(&windowList, geteuid());
+    ASSERT_EQ(groups.size(), 3);
+    EXPECT_EQ(groups.value(101), QList<pid_t>({101, 102}));
+    EXPECT_EQ(groups.value(201), QList<pid_t>({201, 202}));
+    EXPECT_EQ(groups.value(301), QList<pid_t>({301, 302}));
+    for (pid_t pid : {101, 201, 301}) {
+        qreal cpu = 0, recvBps = 0, sendBps = 0;
+        m_tester->mergeSubProcResources(pid, cpu, recvBps, sendBps);
+        EXPECT_DOUBLE_EQ(cpu, 2);
+    }
+    for (pid_t pid : {401, 501, 502})
+        EXPECT_EQ(m_tester->getProcessById(pid).appType(), kFilterApps);
+}
+
+TEST_F(UT_ProcessSet, test_collapseWineContainerGroups_leavesSingleTreeAlone)
+{
+    WMWindowList windowList;
+    addProcess(101, 1, "main.exe");
+    addProcess(102, 101, "helper.exe", kFilterCurrentUser);
+    const auto originalTree = m_tester->m_pidPtoCMapping;
+
+    EXPECT_TRUE(m_tester->collapseWineContainerGroups(&windowList, geteuid()).isEmpty());
+    EXPECT_EQ(m_tester->m_pidPtoCMapping, originalTree);
 }
 
 TEST_F(UT_ProcessSet, test_refresh_001)
@@ -75,6 +259,51 @@ TEST_F(UT_ProcessSet, test_scanProcess_001)
     m_tester->m_set.insert(proc->pid(),*proc);
     m_tester->scanProcess();
     delete proc;
+}
+
+TEST_F(UT_ProcessSet, test_scanProcess_removesExitedPidsWithoutReaddingLiveProcesses)
+{
+    for (pid_t pid = 10; pid < 25; ++pid) {
+        addProcess(pid, 1, "native-app");
+        m_tester->m_prePid.append(pid);
+        m_tester->m_pidMyApps.append(pid);
+    }
+    const QList<pid_t> livePids = m_tester->m_prePid.mid(3);
+    EXPECT_TRUE(scanProcesses(livePids).isEmpty());
+    EXPECT_EQ(m_tester->m_prePid, livePids);
+    EXPECT_EQ(m_tester->m_simpleSet.keys(), livePids);
+    EXPECT_EQ(m_tester->m_pidMyApps, livePids);
+    EXPECT_EQ(m_tester->getPIDList(), livePids);
+}
+
+TEST_F(UT_ProcessSet, test_scanProcess_parentCycleTerminates)
+{
+    for (bool selfParent : {false, true}) {
+        addProcess(101, 102, "native-app");
+        addProcess(102, selfParent ? 102 : 103, "helper", kFilterCurrentUser);
+        addProcess(103, 102, "helper", kFilterCurrentUser);
+        m_tester->m_prePid = {101, 102, 103};
+        m_tester->m_pidMyApps = {101};
+
+        scanProcesses({101, 102, 103});
+        EXPECT_EQ(m_tester->getProcessById(101).appType(), kFilterApps);
+    }
+}
+
+TEST_F(UT_ProcessSet, test_scanProcess_findsGuiAncestorAndKeepsShellException)
+{
+    addProcess(101, 102, "native-app");
+    addProcess(102, 103, "helper", kFilterCurrentUser);
+    addProcess(103, 1, "gui-app");
+    addProcess(104, 105, "native-app");
+    addProcess(105, 103, "/bin/bash", kFilterCurrentUser);
+    m_tester->m_prePid = {101, 102, 103, 104, 105};
+    m_tester->m_pidMyApps = {101, 103, 104};
+
+    scanProcesses({101, 102, 103, 104, 105}, {103});
+    EXPECT_EQ(m_tester->getProcessById(101).appType(), kFilterCurrentUser);
+    EXPECT_EQ(m_tester->getProcessById(103).appType(), kFilterApps);
+    EXPECT_EQ(m_tester->getProcessById(104).appType(), kFilterApps);
 }
 
 TEST_F(UT_ProcessSet, test_hasNext_001)


### PR DESCRIPTION
## Summary

同一 Wine 应用的多个进程会在“应用”列表中显示为多个条目。现在按当前用户、Wine 进程特征及相同的 `WINEPREFIX + DEB_PACKAGE_NAME` 合并显示，优先选择 GUI 进程作为代表。

- 仅重组资源统计使用的父子关系，统一遍历汇总 CPU 和网络用量，包含原生辅助子进程，并避免 Wine 容器重复计入启动器。
- 内存沿用每个 PID 的原始值；真实 PPID 和进程控制方式保持原有行为。
- 删除遍历中的 `m_prePid.removeAt(pid)`，祖先查找改用迭代与防环检查。
- 主程序与弹窗接口同步，补充分组隔离、辅助进程统计、单进程内存和进程扫描回归测试。

## Validation

- 10 个定向 GTest 用例通过，覆盖 Wine 分组、不同容器/用户隔离、辅助进程统计、内存保持原值、多个进程退出、父子关系成环和终端启动例外。
- `cmake --build obj-x86_64-linux-gnu --target deepin-system-monitor deepin-system-monitor-plugin-popup --parallel 4` 通过。
- `git diff --check` 通过。
- 尚未进行 Wine 实机界面回归。

## Log

Bug: https://pms.uniontech.com/bug-view-374247.html

Influence: Wine 应用合并显示，CPU 和网络计入辅助进程，内存保持单进程值。

## Summary by Sourcery

Group related Wine processes into one application entry while accurately aggregating resources and retaining stable process behavior.

Bug Fixes:
- Collapse related Wine application processes into a single application entry while preserving process-specific memory reporting.
- Include Wine and native helper descendants in aggregated CPU and network usage without double-counting launcher processes.

Enhancements:
- Isolate Wine groups by user, WINEPREFIX, and package identity, selecting the most appropriate GUI representative.
- Make process resource traversal resilient to missing processes and parent cycles while preserving real process relationships.

Tests:
- Add regression coverage for Wine grouping, container and user isolation, helper resource aggregation, per-process memory, exited processes, parent cycles, and GUI ancestor handling.